### PR TITLE
Fix the latest publiccloud tools image

### DIFF
--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -59,7 +59,7 @@ def get_latest_tools_image(query):
     build_results = request_get(query).json()["build_results"]
     for build in build_results:
         if build["failed"] == 0:
-            return build["build"]
+            return "publiccloud_tools_{}.qcow2".format(build["build"])
     return None
 
 


### PR DESCRIPTION
Fix the return value of get_latest_tools_image to return the image name
of the latest tools image, instead of just the number for it.

This is a fix for a regression introduced in https://github.com/openSUSE/qem-bot/pull/2 and pointed out in https://github.com/openSUSE/qem-bot/pull/2/files#r812648838