### PR TITLE
README: Add testing instructions referencing Makefile

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,14 +132,21 @@ requests for consideration or create an issue with a code change proposal.
 
 ### Local testing
 
-There are currently no automatic tests available. The most simple way for at
-least syntax correctness checks is to just call `./bot-ng.py --help` to show
-the help text if the source can be correctly parsed. The next recommended way
-for testing is to call `bot-ng.py` with the `--dry` command line parameter in
-different modes. This might need additional data, e.g. "metadata" from
-https://gitlab.suse.de/qa-maintenance/metadata/ . For example with cloning
-this metadata as well as specifying a fake token value that is enough for
-testing:
+There are currently only limited automatic tests available. Call
+
+```
+make test
+```
+
+to execute all tests.
+
+Another simple way for at least syntax correctness checks is to just call
+`./bot-ng.py --help` to show the help text if the source can be correctly
+parsed. The next recommended way for testing is to call `bot-ng.py` with the
+`--dry` command line parameter in different modes. This might need additional
+data, e.g. "metadata" from https://gitlab.suse.de/qa-maintenance/metadata/ .
+For example with cloning this metadata as well as specifying a fake token
+value that is enough for testing:
 
 ```
 git clone --depth 1 gitlab@gitlab.suse.de:qa-maintenance/metadata.git

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,4 @@
+![https://github.com/openSUSE/qem-bot/actions](https://github.com/openSUSE/qem-bot/actions/workflows/ci/badge.svg)
 # bot-ng
 
 tool for schedule maintenance jobs + sync SMELT/OpenQA to QEM-Dashboard


### PR DESCRIPTION
The Makefile is providing the simple convenient entry path because many people know how to call "make" or "make test" regardless of the programming language specific ecosystem. Also we can easily extend the Makefile but the instructions stay the same :)