### PR TITLE
Fix status badge

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-![https://github.com/openSUSE/qem-bot/actions](https://github.com/openSUSE/qem-bot/actions/workflows/ci/badge.svg)
+[![ci](https://github.com/openSUSE/qem-bot/actions/workflows/ci.yml/badge.svg)](https://github.com/openSUSE/qem-bot/actions/workflows/ci.yml)
 # bot-ng
 
 tool for schedule maintenance jobs + sync SMELT/OpenQA to QEM-Dashboard


### PR DESCRIPTION
Sorry about that. I previously hand-crafted the badge
URL when instead I should have used
the "Create status badge" button within github actions.