### PR TITLE
Stop filtering groups by special keywords

### DIFF
--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -54,14 +54,6 @@ class SyncRes:
             logger.info("Clone job %s" % data["clone_id"])
             return False
 
-        if "Devel" in data["group"] or "Test" in data["group"]:
-            logger.info("Devel job %s in group %s" % (data["id"], data["group"]))
-            return False
-
-        if "Timo" in data["group"]:
-            logger.info("Devel job %s in group %s" % (data["id"], data["group"]))
-            return False
-
         if self.client.is_devel_group(data["group_id"]):
             logger.info("Devel job %s in group %s" % (data["id"], data["group"]))
             return False


### PR DESCRIPTION
We should rely on the development parent group.

Related: https://progress.opensuse.org/issues/111506