### PR TITLE
Reduce verbose line "Post results …" to debug level

### DIFF
--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -69,7 +69,7 @@ class SyncRes:
         return True
 
     def post_result(self, result):
-        logger.info(
+        logger.debug(
             "Posting results of %s job %s with status %s"
             % (self.operation, result["job_id"], result["status"])
         )


### PR DESCRIPTION
A "sync aggregates" job like
https://gitlab.suse.de/qa-maintenance/bot-ng/-/jobs/1009892
has multiple thousands of lines with content
"Post results of aggregate job …" so I consider the "debug" log level
more fitting.