### PR TITLE
Move Manager-Server workaround from repohash to Incident itself

### DIFF
--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -24,13 +24,6 @@ def get_max_revision(
     url_base = f"http://download.suse.de/ibs/{project.replace(':',':/')}"
 
     for repo in repos:
-        # workaround for manager server 4.1
-        if (
-            arch == "aarch64"
-            and repo[0] == "SLE-Module-SUSE-Manager-Server"
-            and repo[1] == "4.1"
-        ):
-            continue
 
         # don't use openSUSE-SLE
         if repo[0] == "openSUSE-SLE":

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -43,6 +43,17 @@ class Incident:
                 )
             )
         ]
+
+        # remove Manager-Server on aarch64 from channels
+        self.channels = [
+            chan
+            for chan in self.channels
+            if (
+                chan.product != "SLE-Module-SUSE-Manager-Server"
+                and chan.arch != "aarch64"
+            )
+        ]
+
         if not self.channels:
             raise EmptyChannels(self.project)
 


### PR DESCRIPTION
In original place can leads to invalid skip of incident