### PR TITLE
Handle correctly new product 'openSUSE-Leap-Micro'

### DIFF
--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -24,9 +24,8 @@ def get_max_revision(
     url_base = f"http://download.suse.de/ibs/{project.replace(':',':/')}"
 
     for repo in repos:
-
-        # don't use openSUSE-SLE
-        if repo[0] == "openSUSE-SLE":
+        # openSUSE and SLE incidents have different handling of architecture
+        if repo[0].startswith("openSUSE"):
             url = f"{url_base}/SUSE_Updates_{repo[0]}_{repo[1]}/repodata/repomd.xml"
         else:
             url = f"{url_base}/SUSE_Updates_{repo[0]}_{repo[1]}_{arch}/repodata/repomd.xml"

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -23,9 +23,13 @@ class Incident:
         self.channels = [
             Repos(p, v, a)
             for p, v, a in (
-                r.split(":")[2:]
-                for r in incident["channels"]
-                if r.startswith("SUSE:Updates") and "openSUSE-SLE" not in r
+                val
+                for val in (
+                    r.split(":")[2:]
+                    for r in incident["channels"]
+                    if r.startswith("SUSE:Updates")
+                )
+                if len(val) == 3
             )
             if p != "SLE-Module-Development-Tools-OBS"
         ]
@@ -35,12 +39,14 @@ class Incident:
         self.channels += [
             Repos(p, v, "x86_64")
             for p, v in (
-                r.split(":")[2:]
-                for r in (
-                    i
-                    for i in incident["channels"]
-                    if i.startswith("SUSE:Updates") and "openSUSE-SLE" in i
+                val
+                for val in (
+                    r.split(":")[2:]
+                    for r in (
+                        i for i in incident["channels"] if i.startswith("SUSE:Updates")
+                    )
                 )
+                if len(val) == 2
             )
         ]
 


### PR DESCRIPTION
This product has same incident structure as 'openSUSE-SLE' incidents

New nested generator is more universal --> in future changes affects
only loader/qem.py code

https://progress.opensuse.org/issues/112430