### PR TITLE
Revert obsolete "Skip approving incidents with 15-SP4 jobs"

### DIFF
--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -78,11 +78,6 @@ def get_incident_settings(
     if not settings:
         raise NoResultsError("Inc %s does not have any job_settings" % str(inc))
 
-    # temporary workaround, remove wheen jobs are fixed
-    for s in settings:
-        if s["settings"]["VERSION"] == "15-SP4":
-            raise NoResultsError("In %s has 15-SP4 schedule" % str(inc))
-
     if not all_incidents:
         rrids = [i["settings"].get("RRID", None) for i in settings]
         rrid = sorted([r for r in rrids if r])


### PR DESCRIPTION
This reverts commit 624200907d3daa50d9bc5f4168b689336c3d940a as we now
have proper 15-SP4 tests in place.

Related progress issue: https://progress.opensuse.org/issues/112124