### PR TITLE
Switch kernel-azure QEMU VMs to virtio GPU

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -124,6 +124,8 @@ class Incidents(BaseConf):
 
                     if inc.azure:
                         full_post["openqa"]["AZURE"] = "1"
+                        if flavor == "Server-DVD-Incidents-Kernel":
+                            full_post["openqa"]["QEMUVGA"] = "virtio"
 
                     full_post["openqa"]["BUILD"] = f":{inc.id}:{inc.packages[0]}"
 


### PR DESCRIPTION
HyperV (virtio) GPU is the video device that will be used by kernel-azure in production environment. Switch to it in QEMU tests.