### PR TITLE
Add backoff_factor to __retry and set some reasonable values

### DIFF
--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -9,7 +9,7 @@ import urllib3.exceptions
 
 from .. import SMELT
 from ..utils import walk
-from ..utils import retry20 as requests
+from ..utils import retry10 as requests
 
 logger = getLogger("bot.loader.smelt")
 

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -1,11 +1,11 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
 from copy import deepcopy
+from typing import Optional
 
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from typing import Optional
 
 
 def walk(inc):
@@ -48,12 +48,12 @@ def normalize_results(result: str) -> str:
     return "failed"
 
 
-def __retry(retries: Optional[int]) -> Session:
+def __retry(retries: Optional[int], backoff_factor: float) -> Session:
 
     adapter = HTTPAdapter(
         max_retries=Retry(
             retries,
-            backoff_factor=5,
+            backoff_factor=backoff_factor,
             status_forcelist=frozenset({404, 403, 413, 429, 503}),
         )
     )
@@ -64,7 +64,7 @@ def __retry(retries: Optional[int]) -> Session:
     return http
 
 
-no_retry = __retry(None)
-retry3 = __retry(3)
-retry5 = __retry(5)
-retry20 = __retry(20)
+no_retry = __retry(None, 0)
+retry3 = __retry(3, 2)
+retry5 = __retry(5, 1)
+retry10 = __retry(10, 0.1)


### PR DESCRIPTION
Original __retry used backoff_factor 5 wich with high retry value
caused too big time between retries.

For 20 retries with backoff_factor 5:
[5, 15, 35, 75, 155, 315, 635, 1275, 2555, 5115, 10235, 20475, 40955,
81915, 163835, 327675, 655355, 1310715, 2621435, 5242875]

so this limit max retries to 10 with reasonable backoff_factor