### PR TITLE
Introduce TEST_ISSUES_ARCH setting

### DIFF
--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -83,6 +83,10 @@ class Aggregate(BaseConf):
             test_incidents = defaultdict(list)
             test_repos = defaultdict(list)
 
+            # Temporary workaround for applying the correct architecture on jobs, which use a helper VM
+            if "TEST_ISSUES_ARCH" in self.settings:
+                arch = self.settings["TEST_ISSUES_ARCH"]
+
             # only testing queue and not livepatch
             valid_incidents = [
                 i for i in incidents if not any((i.livepatch, i.staging))


### PR DESCRIPTION
Introduce the `TEST_ISSUES_ARCH` setting to allow changing of the
architecture for the computation of the TEST_ISSUES as a temporary
workaround.

Related tickets: https://progress.opensuse.org/issues/115652, https://progress.opensuse.org/issues/111710