### PR TITLE
Add simple schema validation for SMELT responses

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ openqa-client
 ruamel.yaml
 beautifulsoup4
 black
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ openqa-client
 requests
 ruamel.yaml
 beautifulsoup4
+jsonschema


### PR DESCRIPTION
Use simple JSON schema to validate responses from SMELT. For now, only
the attributes used in iterations are required. Any error during
validation will be explained.

Reference: https://progress.opensuse.org/issues/115733