### PR TITLE
Remove special settings for kernel-azure

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -121,11 +121,6 @@ class Incidents(BaseConf):
                         else:
                             full_post["openqa"]["KGRAFT"] = "1"
 
-                    if inc.azure:
-                        full_post["openqa"]["AZURE"] = "1"
-                        if flavor == "Server-DVD-Incidents-Kernel":
-                            full_post["openqa"]["QEMUVGA"] = "virtio"
-
                     full_post["openqa"]["BUILD"] = f":{inc.id}:{inc.packages[0]}"
 
                     if inc.rrid:


### PR DESCRIPTION
These settings are now defined in OpenQA medium. The bot does not need to add anything extra.