### PR TITLE
Fix "AttributeError: 'Incident' object has no attribute 'azure'"

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -166,7 +166,7 @@ class Incidents(BaseConf):
                         )
                         continue
 
-                    if "Kernel" in flavor and not inc.livepatch and not inc.azure:
+                    if "Kernel" in flavor and not inc.livepatch:
                         if set(issue_dict.keys()).isdisjoint(
                             set(
                                 [

--- a/tests/fixtures/config/05_normal.yml
+++ b/tests/fixtures/config/05_normal.yml
@@ -36,6 +36,6 @@ incidents:
       packages:
         - kernel-source
         - kernel-livepatch
-        - kernel-azure  
+        - kernel-azure
 empty_key:
   - empty


### PR DESCRIPTION
d836f9d removed most code for handling azure but missed this one spot
which now causes a problem:

```
AttributeError: 'Incident' object has no attribute 'azure'
```