### PR TITLE
Avoid retrying comment fetching

### DIFF
--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -70,7 +70,7 @@ class openQAInterface:
         ret = []
         try:
             ret = self.openqa.openqa_request(
-                "GET", "jobs/%s/comments" % job_id, retries=self.retries
+                "GET", "jobs/%s/comments" % job_id, retries=0
             )
             ret = list(map(lambda c: {"text": c.get("text", "")}, ret))
         except Exception as e:


### PR DESCRIPTION
Apparently the retry is also done for 404 responses (see https://progress.opensuse.org/issues/107923#note-15), so let's just disable it completely for now.