### PR TITLE
Avoid logging 404 errors when getting comments during approval

### DIFF
--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -74,7 +74,9 @@ class openQAInterface:
             )
             ret = list(map(lambda c: {"text": c.get("text", "")}, ret))
         except Exception as e:
-            logger.exception(e)
+            (method, url, status_code) = e.args
+            if status_code != 404:
+                logger.exception(e)
         return ret
 
     @lru_cache(maxsize=256)

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -481,7 +481,7 @@ def test_one_incident_failed(fake_qem, fake_openqa_comment_api, caplog):
 
     assert approver() == 0
 
-    assert len(caplog.records) == 8
+    assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has failed job in incidents" in messages
     assert "SUSE:Maintenance:2:200" in messages
@@ -514,7 +514,7 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
 
     assert approver() == 0
 
-    assert len(caplog.records) == 8
+    assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 2 has failed job in aggregates" in messages
     assert "SUSE:Maintenance:1:100" in messages


### PR DESCRIPTION
It seems quite common that the job IDs don't exist anymore and there's no need to clutter logs with according errors.

See https://progress.opensuse.org/issues/107923#note-22