### PR TITLE
Simplify, cleanup, update code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Check style
         run: make checkstyle
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: coverage.xml

--- a/openqabot/aggrsync.py
+++ b/openqabot/aggrsync.py
@@ -9,7 +9,7 @@ from .loader.config import read_products
 from .loader.qem import get_aggregate_settings_data
 from .syncres import SyncRes
 
-logger = getLogger("bot.aggrsync")
+log = getLogger("bot.aggrsync")
 
 
 class AggregateResultsSync(SyncRes):
@@ -26,7 +26,7 @@ class AggregateResultsSync(SyncRes):
             try:
                 update_setting += get_aggregate_settings_data(self.token, product)
             except EmptySettings as e:
-                logger.info(e)
+                log.info(e)
                 continue
 
         job_results = {}
@@ -53,6 +53,6 @@ class AggregateResultsSync(SyncRes):
         for r in results:
             self.post_result(r)
 
-        logger.info("End of bot run")
+        log.info("End of bot run")
 
         return 0

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -45,41 +45,7 @@ class Approver:
         )
 
         overall_result = True
-        incidents_to_approve = []
-
-        for inc in increqs:
-            try:
-                i_jobs = get_incident_settings(inc.inc, self.token, self.all_incidents)
-            except NoResultsError as e:
-                logger.info(e)
-                continue
-            try:
-                u_jobs = get_aggregate_settings(inc.inc, self.token)
-            except NoResultsError as e:
-                logger.info(e)
-
-                if any(i.withAggregate for i in i_jobs):
-                    logger.info("Aggregate missing for %s" % str(inc.inc))
-                    continue
-
-                u_jobs = []
-
-            if not self.get_incident_result(i_jobs, "api/jobs/incident/", inc.inc):
-                logger.info(
-                    "Inc %s has at least one failed job in incident tests"
-                    % str(inc.inc)
-                )
-                continue
-
-            if any(i.withAggregate for i in i_jobs):
-                if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
-                    logger.info(
-                        "Inc %s has failed job in aggregate tests" % str(inc.inc)
-                    )
-                    continue
-
-            # everything is green --> approve inc
-            incidents_to_approve.append(inc)
+        incidents_to_approve = [inc for inc in increqs if self._approvable(inc)]
 
         logger.info("Incidents to approve:")
         for inc in incidents_to_approve:
@@ -93,6 +59,37 @@ class Approver:
         logger.info("End of bot run")
 
         return 0 if overall_result else 1
+
+    def _approvable(self, inc: IncReq) -> bool:
+        try:
+            i_jobs = get_incident_settings(inc.inc, self.token, self.all_incidents)
+        except NoResultsError as e:
+            logger.info(e)
+            return False
+        try:
+            u_jobs = get_aggregate_settings(inc.inc, self.token)
+        except NoResultsError as e:
+            logger.info(e)
+
+            if any(i.withAggregate for i in i_jobs):
+                logger.info("Aggregate missing for %s" % str(inc.inc))
+                return False
+
+            u_jobs = []
+
+        if not self.get_incident_result(i_jobs, "api/jobs/incident/", inc.inc):
+            logger.info(
+                "Inc %s has at least one failed job in incident tests" % str(inc.inc)
+            )
+            return False
+
+        if any(i.withAggregate for i in i_jobs):
+            if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
+                logger.info("Inc %s has failed job in aggregate tests" % str(inc.inc))
+                return False
+
+        # everything is green --> add incident to approve list
+        return True
 
     @lru_cache(maxsize=512)
     def is_job_marked_acceptable_for_incident(self, job: JobAggr, inc: int) -> bool:

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -65,12 +65,17 @@ class Approver:
                 u_jobs = []
 
             if not self.get_incident_result(i_jobs, "api/jobs/incident/", inc.inc):
-                logger.info("Inc %s has failed job in incidents" % str(inc.inc))
+                logger.info(
+                    "Inc %s has at least one failed job in incident tests"
+                    % str(inc.inc)
+                )
                 continue
 
             if any(i.withAggregate for i in i_jobs):
                 if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
-                    logger.info("Inc %s has failed job in aggregates" % str(inc.inc))
+                    logger.info(
+                        "Inc %s has failed job in aggregate tests" % str(inc.inc)
+                    )
                     continue
 
             # everything is green --> approve inc
@@ -118,6 +123,10 @@ class Approver:
                 )
                 res["status"] = "passed"
             else:
+                logger.info(
+                    "Found failed, not-ignored job %s for incident %s"
+                    % (job.job_id, inc)
+                )
                 break
 
         if not results:

--- a/openqabot/incsyncres.py
+++ b/openqabot/incsyncres.py
@@ -9,7 +9,7 @@ from .loader.qem import get_active_incidents, get_incident_settings_data
 from .syncres import SyncRes
 from .types import Data
 
-logger = getLogger("bot.incsyncres")
+log = getLogger("bot.incsyncres")
 
 
 class IncResultsSync(SyncRes):
@@ -54,6 +54,6 @@ class IncResultsSync(SyncRes):
         for r in results:
             self.post_result(r)
 
-        logger.info("End of bot run")
+        log.info("End of bot run")
 
         return 0

--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -11,7 +11,7 @@ from ..types import Data
 from ..types.aggregate import Aggregate
 from ..types.incidents import Incidents
 
-logger = getLogger("bot.loader.config")
+log = getLogger("bot.loader.config")
 
 
 def load_metadata(
@@ -27,7 +27,7 @@ def load_metadata(
         try:
             data = loader.load(p)
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             continue
 
         try:
@@ -37,7 +37,7 @@ def load_metadata(
             continue
 
         if "product" not in data:
-            logger.debug("Skipping invalid config %s" % p)
+            log.debug("Skipping invalid config %s" % p)
             continue
 
         if settings:
@@ -50,9 +50,7 @@ def load_metadata(
                     try:
                         ret.append(Aggregate(data["product"], settings, data[key]))
                     except NoTestIssues:
-                        logger.warning(
-                            "No 'test_issues' in %s config" % data["product"]
-                        )
+                        log.warning("No 'test_issues' in %s config" % data["product"])
                 else:
                     continue
     return ret
@@ -66,16 +64,16 @@ def read_products(path: Path) -> List[Data]:
         data = loader.load(p)
 
         if not data:
-            logger.info("Skipping invalid config %s - empty config" % str(p))
+            log.info("Skipping invalid config %s - empty config" % str(p))
             continue
         if not isinstance(data, dict):
-            logger.info("Skipping invalid config %s - invalid format" % str(p))
+            log.info("Skipping invalid config %s - invalid format" % str(p))
             continue
 
         try:
             flavor = data["aggregate"]["FLAVOR"]
         except KeyError:
-            logger.info("Config %s does not have aggregate" % str(p))
+            log.info("Config %s does not have aggregate" % str(p))
             continue
 
         try:
@@ -83,7 +81,7 @@ def read_products(path: Path) -> List[Data]:
             version = data["settings"]["VERSION"]
             product = data["product"]
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             continue
 
         for arch in data["aggregate"]["archs"]:
@@ -98,7 +96,7 @@ def get_onearch(path: Path) -> Set[str]:
     try:
         data = loader.load(path)
     except Exception as e:
-        logger.exception(e)
+        log.exception(e)
         return set()
 
     return set(data)

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -19,7 +19,7 @@ from ..types import Data
 from ..types.incident import Incident
 from ..utils import retry5 as requests
 
-logger = getLogger("bot.loader.qem")
+log = getLogger("bot.loader.qem")
 
 
 class IncReq(NamedTuple):
@@ -41,15 +41,15 @@ def get_incidents(token: Dict[str, str]) -> List[Incident]:
         try:
             xs.append(Incident(i))
         except NoRepoFoundError as e:
-            logger.info(
+            log.info(
                 "Project %s can't calculate repohash %s .. skipping" % (i["project"], e)
             )
         except EmptyChannels as e:
-            logger.info(
+            log.info(
                 "Project %s has empty channels - check incident in SMELT" % i["project"]
             )
         except EmptyPackagesError as e:
-            logger.info(
+            log.info(
                 "Project %s has empty packages - check incident in SMELT" % i["project"]
             )
 
@@ -60,7 +60,7 @@ def get_active_incidents(token: Dict[str, str]) -> Sequence[int]:
     try:
         data = requests.get(QEM_DASHBOARD + "api/incidents", headers=token).json()
     except Exception as e:
-        logger.exception(e)
+        log.exception(e)
         raise e
     return list(set([i["number"] for i in data]))
 
@@ -96,11 +96,11 @@ def get_incident_settings(
 
 def get_incident_settings_data(token: Dict[str, str], number: int) -> Sequence[Data]:
     url = QEM_DASHBOARD + "api/incident_settings/" + f"{number}"
-    logger.info("Getting settings for %s" % number)
+    log.info("Getting settings for %s" % number)
     try:
         data = requests.get(url, headers=token).json()
     except Exception as e:
-        logger.exception(e)
+        log.exception(e)
         raise e
 
     if "error" in data:
@@ -138,7 +138,7 @@ def get_incident_results(inc: int, token: Dict[str, str]):
             ).json()
             ret += data
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             raise e
         if "error" in data:
             raise ValueError(data["error"])
@@ -170,7 +170,7 @@ def get_aggregate_settings_data(token: Dict[str, str], data: Data):
     try:
         settings = requests.get(url, headers=token).json()
     except Exception as e:
-        logger.exception(e)
+        log.exception(e)
         raise e
 
     ret = []
@@ -179,7 +179,7 @@ def get_aggregate_settings_data(token: Dict[str, str], data: Data):
             f"Product: {data.product} on arch: {data.arch} does not have any settings"
         )
 
-    logger.debug("Getting id for %s" % pformat(data))
+    log.debug("Getting id for %s" % pformat(data))
 
     # use last three schedule
     for s in settings[:3]:
@@ -212,7 +212,7 @@ def get_aggregate_results(inc: int, token: Dict[str, str]):
                 QEM_DASHBOARD + "api/jobs/update/" + f"{job.job_id}", headers=token
             ).json()
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             raise e
         if "error" in data:
             raise ValueError(data["error"])
@@ -231,13 +231,13 @@ def update_incidents(token: Dict[str, str], data, **kwargs) -> int:
         try:
             ret = req.patch(QEM_DASHBOARD + "api/incidents", headers=token, json=data)
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             return 1
         else:
             if ret.status_code == 200:
-                logger.info("Smelt Incidents updated")
+                log.info("Smelt Incidents updated")
             else:
-                logger.error(
+                log.error(
                     "Smelt Incidents were not synced to dashboard: error %s"
                     % ret.status_code
                 )
@@ -250,7 +250,7 @@ def post_job(token: Dict[str, str], data) -> None:
     try:
         result = requests.put(QEM_DASHBOARD + "api/jobs", headers=token, json=data)
         if result.status_code != 200:
-            logger.error(result.text)
+            log.error(result.text)
 
     except Exception as e:
-        logger.exception(e)
+        log.exception(e)

--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -12,7 +12,7 @@ from requests.exceptions import RetryError
 from ..errors import NoRepoFoundError
 from ..utils import retry5 as requests
 
-logger = getLogger("bot.loader.repohash")
+log = getLogger("bot.loader.repohash")
 
 
 def get_max_revision(
@@ -41,14 +41,14 @@ def get_max_revision(
             HTTPError,
             RetryError,
         ):  # for now, use logger.exception to determine possible exceptions in this code :D
-            logger.info("%s not found -- skip incident" % url)
+            log.info("%s not found -- skip incident" % url)
             raise NoRepoFoundError
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             raise e
 
         if cs is None:
-            logger.error("%s's revision is None" % url)
+            log.error("%s's revision is None" % url)
             raise NoRepoFoundError
 
         rev = int(str(cs.text))

--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -12,7 +12,7 @@ from .. import SMELT
 from ..utils import walk
 from ..utils import retry10 as requests
 
-logger = getLogger("bot.loader.smelt")
+log = getLogger("bot.loader.smelt")
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -121,7 +121,7 @@ def get_json(query: str, host: str = SMELT) -> dict:
     try:
         return requests.get(host, params={"query": query}, verify=False).json()
     except Exception as e:
-        logger.exception(e)
+        log.exception(e)
         raise e
 
 
@@ -139,7 +139,7 @@ def get_active_incidents() -> Set[int]:
         try:
             validate(instance=ndata, schema=ACTIVE_INC_SCHEMA)
         except ValidationError as e:
-            logger.exception("Invalid data from SMELT received")
+            log.exception("Invalid data from SMELT received")
             return []
         incidents = ndata["data"]["incidents"]
         active.update(x["node"]["incidentId"] for x in incidents["edges"])
@@ -147,7 +147,7 @@ def get_active_incidents() -> Set[int]:
         if has_next:
             cursor = incidents["pageInfo"]["endCursor"]
 
-    logger.info("Loaded %s active incidents" % len(active))
+    log.info("Loaded %s active incidents" % len(active))
 
     return active
 
@@ -155,17 +155,17 @@ def get_active_incidents() -> Set[int]:
 def get_incident(incident: int):
     query = INCIDENT % {"incident": incident}
 
-    logger.info("Getting info about incident %s from SMELT" % incident)
+    log.info("Getting info about incident %s from SMELT" % incident)
     inc_result = get_json(query)
     try:
         validate(instance=inc_result, schema=INCIDENT_SCHEMA)
         inc_result = walk(inc_result["data"]["incidents"]["edges"][0]["node"])
     except ValidationError as e:
-        logger.exception("Invalid data from SMELT for incident %s" % incident)
+        log.exception("Invalid data from SMELT for incident %s" % incident)
         return None
     except Exception as e:
-        logger.error("Unknown error for incident %s" % incident)
-        logger.exception(e)
+        log.error("Unknown error for incident %s" % incident)
+        log.exception(e)
         return None
 
     return inc_result

--- a/openqabot/main.py
+++ b/openqabot/main.py
@@ -7,19 +7,19 @@ from .args import get_parser
 
 
 def create_logger() -> logging.Logger:
-    logger = logging.getLogger("bot")
+    log = logging.getLogger("bot")
     handler = logging.StreamHandler()
     formatter = logging.Formatter(
         fmt="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-    return logger
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+    return log
 
 
 def main() -> None:
-    logger = create_logger()
+    log = create_logger()
     parser = get_parser()
 
     if len(sys.argv) < 1:
@@ -29,15 +29,15 @@ def main() -> None:
     cfg = parser.parse_args(sys.argv[1:])
 
     if not cfg.configs.exists() and not cfg.configs.is_dir():
-        logger.error(f"Path {cfg.configs} is not a valid directory with config files")
+        log.error(f"Path {cfg.configs} is not a valid directory with config files")
         sys.exit(1)
 
     if not hasattr(cfg, "func"):
-        logger.error("Command is required")
+        log.error("Command is required")
         parser.print_help()
         sys.exit(1)
 
     if cfg.debug:
-        logger.setLevel(logging.DEBUG)
+        log.setLevel(logging.DEBUG)
 
     sys.exit(cfg.func(cfg))

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -12,7 +12,7 @@ from . import DEVELOPMENT_PARENT_GROUP_ID, OPENQA_URL
 from .errors import PostOpenQAError
 from .types import Data
 
-logger = logging.getLogger("bot.openqa")
+log = logging.getLogger("bot.openqa")
 
 
 class openQAInterface:
@@ -26,7 +26,7 @@ class openQAInterface:
         return self.url.netloc == OPENQA_URL
 
     def post_job(self, settings) -> None:
-        logger.info(
+        log.info(
             "openqa-cli api --host %s -X post isos %s"
             % (
                 self.url.geturl(),
@@ -38,16 +38,16 @@ class openQAInterface:
                 "POST", "isos", data=settings, retries=self.retries
             )
         except RequestError as e:
-            logger.error("openQA returned %s" % e.args[-1])
-            logger.error("Post failed with {}".format(pformat(settings)))
+            log.error("openQA returned %s" % e.args[-1])
+            log.error("Post failed with {}".format(pformat(settings)))
             raise PostOpenQAError
         except Exception as e:
-            logger.exception(e)
-            logger.error("Post failed with {}".format(pformat(settings)))
+            log.exception(e)
+            log.error("Post failed with {}".format(pformat(settings)))
             raise PostOpenQAError
 
     def get_jobs(self, data: Data):
-        logger.info("Getting openQA tests results for %s" % pformat(data))
+        log.info("Getting openQA tests results for %s" % pformat(data))
         param = {}
         param["scope"] = "relevant"
         param["latest"] = "1"
@@ -61,7 +61,7 @@ class openQAInterface:
         try:
             ret = self.openqa.openqa_request("GET", "jobs", param)["jobs"]
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             raise e
         return ret
 
@@ -76,7 +76,7 @@ class openQAInterface:
         except Exception as e:
             (method, url, status_code) = e.args
             if status_code != 404:
-                logger.exception(e)
+                log.exception(e)
         return ret
 
     @lru_cache(maxsize=256)
@@ -86,7 +86,7 @@ class openQAInterface:
         try:
             ret = self.openqa.openqa_request("GET", f"job_groups/{groupid}")
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
             raise e
 
         # return True as safe option if ret = None

--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -8,7 +8,7 @@ import bs4
 
 from .utils import retry5 as requests
 
-logger = logging.getLogger("bot.openqabot.pc_helper")
+log = logging.getLogger("bot.openqabot.pc_helper")
 
 
 def fetch_matching_link(url, regex):
@@ -21,7 +21,7 @@ def fetch_matching_link(url, regex):
         req = requests.get(url + "/?C=M;O=A")
         text = req.text
     except BaseException as err:
-        logger.error("error fetching '%s': %s" % (url, err))
+        log.error("error fetching '%s': %s" % (url, err))
         return None
     getpage_soup = bs4.BeautifulSoup(text, "html.parser")
     # Returns lazy iterator, so
@@ -59,7 +59,7 @@ def apply_publiccloud_regex(settings):
         )
         return settings
     except BaseException as e:
-        logger.warning(f"PUBLIC_CLOUD_IMAGE_REGEX handling failed: {e}")
+        log.warning(f"PUBLIC_CLOUD_IMAGE_REGEX handling failed: {e}")
         settings["PUBLIC_CLOUD_IMAGE_LOCATION"] = None
         return settings
 
@@ -73,7 +73,7 @@ def apply_pc_tools_image(settings):
             del settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
         return settings
     except BaseException as e:
-        logger.warning(f"PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed: {e}")
+        log.warning(f"PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed: {e}")
         return settings
 
 
@@ -120,7 +120,7 @@ def apply_publiccloud_pint_image(settings):
             del settings["PUBLIC_CLOUD_PINT_FIELD"]
         return settings
     except BaseException as e:
-        logger.warning(
+        log.warning(
             f"PUBLIC_CLOUD_PINT_QUERY handling failed for {settings['PUBLIC_CLOUD_PINT_NAME']}: {e}"
         )
         settings["PUBLIC_CLOUD_IMAGE_ID"] = None

--- a/openqabot/smeltsync.py
+++ b/openqabot/smeltsync.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 from .loader.qem import update_incidents
 from .loader.smelt import get_active_incidents, get_incidents
 
-logger = getLogger("bot.smeltsync")
+log = getLogger("bot.smeltsync")
 
 
 class SMELTSync:
@@ -20,16 +20,16 @@ class SMELTSync:
         self.retry = args.retry
 
     def __call__(self) -> int:
-        logger.info("Start syncing incidents from smelt to dashboard")
+        log.info("Start syncing incidents from smelt to dashboard")
 
         data = self._create_list(self.incidents)
-        logger.info("Updating info about %s incidents" % str(len(data)))
-        logger.info("Data: %s" % pformat(data))
+        log.info("Updating info about %s incidents" % str(len(data)))
+        log.info("Data: %s" % pformat(data))
 
         if not self.dry:
             ret = update_incidents(self.token, data, retry=self.retry)
         else:
-            logger.info("Dry run, nothing synced")
+            log.info("Dry run, nothing synced")
             ret = 0
 
         return ret

--- a/openqabot/smeltsync.py
+++ b/openqabot/smeltsync.py
@@ -38,51 +38,32 @@ class SMELTSync:
     def _review_rrequest(requestSet):
         if not requestSet:
             return None
-        else:
-            rr = sorted(requestSet, key=itemgetter("requestId"), reverse=True)[0]
-            if rr["status"]["name"] in ("new", "review", "accepted", "revoked"):
-                return rr
-            else:
-                return None
+        rr = sorted(requestSet, key=itemgetter("requestId"), reverse=True)[0]
+        valid = ("new", "review", "accepted", "revoked")
+        return rr if rr["status"]["name"] in valid else None
 
     @staticmethod
     def _is_inreview(rr_number) -> bool:
-        if rr_number["reviewSet"]:
-            if rr_number["status"]["name"] == "review":
-                return True
-            else:
-                return False
-        else:
-            return False
+        return rr_number["reviewSet"] and rr_number["status"]["name"] == "review"
 
     @staticmethod
     def _is_revoked(rr_number) -> bool:
-        if rr_number["reviewSet"]:
-            if rr_number["status"]["name"] == "revoked":
-                return True
-            else:
-                return False
-        else:
-            return False
+        return rr_number["reviewSet"] and rr_number["status"]["name"] == "revoked"
 
     @staticmethod
     def _is_accepted(rr_number) -> bool:
-        if (
+        return (
             rr_number["status"]["name"] == "accepted"
             or rr_number["status"]["name"] == "new"
-        ):
-            return True
-        else:
-            return False
+        )
 
     @staticmethod
     def _has_qam_review(rr_number) -> bool:
-        if rr_number["reviewSet"]:
-            rr = (r for r in rr_number["reviewSet"] if r["assignedByGroup"])
-            review = [r for r in rr if r["assignedByGroup"]["name"] == "qam-openqa"]
-            if review and review[0]["status"]["name"] in ("review", "new"):
-                return True
-        return False
+        if not rr_number["reviewSet"]:
+            return False
+        rr = (r for r in rr_number["reviewSet"] if r["assignedByGroup"])
+        review = [r for r in rr if r["assignedByGroup"]["name"] == "qam-openqa"]
+        return review and review[0]["status"]["name"] in ("review", "new")
 
     @classmethod
     def _create_record(cls, inc):

--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -11,7 +11,7 @@ from .openqa import openQAInterface
 from .types import Data
 from .utils import normalize_results
 
-logger = getLogger("bot.syncres")
+log = getLogger("bot.syncres")
 
 
 class SyncRes:
@@ -58,11 +58,11 @@ class SyncRes:
             return False
 
         if data["clone_id"]:
-            logger.info("Job '%s' already has a clone, ignoring" % data["clone_id"])
+            log.info("Job '%s' already has a clone, ignoring" % data["clone_id"])
             return False
 
         if self._is_in_devel_group(data):
-            logger.info(
+            log.info(
                 "Ignoring job '%s' in development group '%s'"
                 % (data["id"], data["group"])
             )
@@ -71,13 +71,13 @@ class SyncRes:
         return True
 
     def post_result(self, result):
-        logger.debug(
+        log.debug(
             "Posting results of %s job %s with status %s"
             % (self.operation, result["job_id"], result["status"])
         )
-        logger.debug("Full post data: %s" % pformat(result))
+        log.debug("Full post data: %s" % pformat(result))
 
         if not self.dry and self.client:
             post_job(self.token, result)
         else:
-            logger.info("Dry run -- data in dashboard untouched")
+            log.info("Dry run -- data in dashboard untouched")

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -20,7 +20,7 @@ from .baseconf import BaseConf
 from .incident import Incident
 
 
-logger = getLogger("bot.types.aggregate")
+log = getLogger("bot.types.aggregate")
 
 
 class Aggregate(BaseConf):
@@ -125,7 +125,7 @@ class Aggregate(BaseConf):
                     headers=token,
                 ).json()
             except Exception as e:
-                logger.exception(e)
+                log.exception(e)
                 old_jobs = None
 
             old_repohash = old_jobs[0].get("repohash", "") if old_jobs else ""
@@ -136,7 +136,7 @@ class Aggregate(BaseConf):
                     full_post["openqa"]["REPOHASH"], old_repohash, old_build
                 )
             except SameBuildExists:
-                logger.info(
+                log.info(
                     "For %s aggreagate on %s there is existing build"
                     % (self.product, arch)
                 )
@@ -155,7 +155,7 @@ class Aggregate(BaseConf):
                 query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
                 settings = apply_pc_tools_image(settings)
                 if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
-                    logger.error(
+                    log.error(
                         f"Failed to query latest publiccloud tools image using {query}"
                     )
                     continue
@@ -164,7 +164,7 @@ class Aggregate(BaseConf):
             if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
                 settings = apply_publiccloud_regex(settings)
                 if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                    logger.error(
+                    log.error(
                         f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
                     )
                     continue
@@ -172,7 +172,7 @@ class Aggregate(BaseConf):
             if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                 settings = apply_publiccloud_pint_image(settings)
                 if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
-                    logger.error(
+                    log.error(
                         f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
                     )
                     continue

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -57,6 +57,150 @@ class Aggregate(BaseConf):
         counter = int(build.split("-")[-1]) + 1 if build.startswith(today) else 1
         return f"{build}-{counter}"
 
+    def handle_arch(
+        self,
+        incidents: List[Incident],
+        token: Dict[str, str],
+        ci_url: Optional[str],
+        ignore_onetime: bool = False,
+    ) -> Dict[str, Any]:
+        full_post: Dict["str", Any] = {}
+        full_post["openqa"] = {}
+        full_post["qem"] = {}
+        full_post["qem"]["incidents"] = []
+        full_post["qem"]["settings"] = {}
+        full_post["api"] = "api/update_settings"
+        if ci_url:
+            full_post["openqa"]["__CI_JOB_URL"] = ci_url
+
+        test_incidents = defaultdict(list)
+        test_repos = defaultdict(list)
+
+        # Temporary workaround for applying the correct architecture on jobs, which use a helper VM
+        issues_arch = self.settings.get("TEST_ISSUES_ARCH", arch)
+
+        # only testing queue and not livepatch
+        valid_incidents = [i for i in incidents if not any((i.livepatch, i.staging))]
+        for issue, template in self.test_issues.items():
+            for inc in valid_incidents:
+                if (
+                    Repos(template.product, template.version, issues_arch)
+                    in inc.channels
+                ):
+                    test_incidents[issue].append(inc)
+
+        for issue, incs in test_incidents.items():
+            tmpl = issue.replace("ISSUES", "REPOS")
+            for inc in incs:
+                if self.test_issues[issue].product.startswith("openSUSE"):
+                    test_repos[tmpl].append(
+                        f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}/"
+                    )
+                else:
+                    test_repos[tmpl].append(
+                        f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}_{issues_arch}/"
+                    )
+
+        full_post["openqa"]["REPOHASH"] = merge_repohash(
+            sorted(
+                set(str(inc) for inc in chain.from_iterable(test_incidents.values()))
+            )
+        )
+
+        try:
+            old_jobs = requests.get(
+                QEM_DASHBOARD + "api/update_settings",
+                params={"product": self.product, "arch": arch},
+                headers=token,
+            ).json()
+        except Exception as e:
+            log.exception(e)
+            old_jobs = None
+
+        old_repohash = old_jobs[0].get("repohash", "") if old_jobs else ""
+        old_build = old_jobs[0].get("build", "") if old_jobs else ""
+
+        try:
+            full_post["openqa"]["BUILD"] = self.get_buildnr(
+                full_post["openqa"]["REPOHASH"], old_repohash, old_build
+            )
+        except SameBuildExists:
+            log.info(
+                "For %s aggreagate on %s there is existing build" % (self.product, arch)
+            )
+            return {}
+
+        if not ignore_onetime and (
+            self.onetime and full_post["openqa"]["BUILD"].split("-")[-1] != "1"
+        ):
+            return {}
+
+        settings = self.settings.copy()
+
+        # if set, we use this query to detect latest public cloud tools image which used for running
+        # all public cloud related tests in openQA
+        if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
+            query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
+            settings = apply_pc_tools_image(settings)
+            if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
+                log.error(
+                    f"Failed to query latest publiccloud tools image using {query}"
+                )
+                return {}
+
+        # parse Public-Cloud image REGEX if present
+        if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
+            settings = apply_publiccloud_regex(settings)
+            if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
+                log.error(
+                    f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
+                )
+                return {}
+        # parse Public-Cloud pint query if present
+        if "PUBLIC_CLOUD_PINT_QUERY" in settings:
+            settings = apply_publiccloud_pint_image(settings)
+            if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
+                log.error(
+                    f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
+                )
+                return {}
+
+        full_post["openqa"].update(settings)
+        full_post["openqa"]["FLAVOR"] = self.flavor
+        full_post["openqa"]["ARCH"] = arch
+        full_post["openqa"]["_OBSOLETE"] = 1
+
+        for template, issues in test_incidents.items():
+            full_post["openqa"][template] = ",".join(str(x) for x in issues)
+        for template, issues in test_repos.items():
+            full_post["openqa"][template] = ",".join(issues)
+        for issues in test_incidents.values():
+            full_post["qem"]["incidents"] += issues
+
+        full_post["qem"]["incidents"] = [
+            str(inc) for inc in set(full_post["qem"]["incidents"])
+        ]
+
+        if not full_post["qem"]["incidents"]:
+            return {}
+
+        full_post["openqa"]["__DASHBOARD_INCIDENTS_URL"] = ",".join(
+            f"https://dashboard.qam.suse.de/incident/{inc}"
+            for inc in set(full_post["qem"]["incidents"])
+        )
+        full_post["openqa"]["__SMELT_INCIDENTS_URL"] = ",".join(
+            f"https://smelt.suse.de/incident/{inc}"
+            for inc in set(full_post["qem"]["incidents"])
+        )
+
+        full_post["qem"]["settings"] = full_post["openqa"]
+        full_post["qem"]["repohash"] = full_post["openqa"]["REPOHASH"]
+        full_post["qem"]["build"] = full_post["openqa"]["BUILD"]
+        full_post["qem"]["arch"] = full_post["openqa"]["ARCH"]
+        full_post["qem"]["product"] = self.product
+
+        return full_post
+
     def __call__(
         self,
         incidents: List[Incident],
@@ -64,150 +208,6 @@ class Aggregate(BaseConf):
         ci_url: Optional[str],
         ignore_onetime: bool = False,
     ) -> List[Dict[str, Any]]:
-        ret = []
-
-        for arch in self.archs:
-            full_post: Dict["str", Any] = {}
-            full_post["openqa"] = {}
-            full_post["qem"] = {}
-            full_post["qem"]["incidents"] = []
-            full_post["qem"]["settings"] = {}
-            full_post["api"] = "api/update_settings"
-            if ci_url:
-                full_post["openqa"]["__CI_JOB_URL"] = ci_url
-
-            test_incidents = defaultdict(list)
-            test_repos = defaultdict(list)
-
-            # Temporary workaround for applying the correct architecture on jobs, which use a helper VM
-            issues_arch = self.settings.get("TEST_ISSUES_ARCH", arch)
-
-            # only testing queue and not livepatch
-            valid_incidents = [
-                i for i in incidents if not any((i.livepatch, i.staging))
-            ]
-            for issue, template in self.test_issues.items():
-                for inc in valid_incidents:
-                    if (
-                        Repos(template.product, template.version, issues_arch)
-                        in inc.channels
-                    ):
-                        test_incidents[issue].append(inc)
-
-            for issue, incs in test_incidents.items():
-                tmpl = issue.replace("ISSUES", "REPOS")
-                for inc in incs:
-                    if self.test_issues[issue].product.startswith("openSUSE"):
-                        test_repos[tmpl].append(
-                            f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}/"
-                        )
-                    else:
-                        test_repos[tmpl].append(
-                            f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}_{issues_arch}/"
-                        )
-
-            full_post["openqa"]["REPOHASH"] = merge_repohash(
-                sorted(
-                    set(
-                        str(inc) for inc in chain.from_iterable(test_incidents.values())
-                    )
-                )
-            )
-
-            try:
-                old_jobs = requests.get(
-                    QEM_DASHBOARD + "api/update_settings",
-                    params={"product": self.product, "arch": arch},
-                    headers=token,
-                ).json()
-            except Exception as e:
-                log.exception(e)
-                old_jobs = None
-
-            old_repohash = old_jobs[0].get("repohash", "") if old_jobs else ""
-            old_build = old_jobs[0].get("build", "") if old_jobs else ""
-
-            try:
-                full_post["openqa"]["BUILD"] = self.get_buildnr(
-                    full_post["openqa"]["REPOHASH"], old_repohash, old_build
-                )
-            except SameBuildExists:
-                log.info(
-                    "For %s aggreagate on %s there is existing build"
-                    % (self.product, arch)
-                )
-                continue
-
-            if not ignore_onetime and (
-                self.onetime and full_post["openqa"]["BUILD"].split("-")[-1] != "1"
-            ):
-                continue
-
-            settings = self.settings.copy()
-
-            # if set, we use this query to detect latest public cloud tools image which used for running
-            # all public cloud related tests in openQA
-            if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
-                query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
-                settings = apply_pc_tools_image(settings)
-                if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
-                    log.error(
-                        f"Failed to query latest publiccloud tools image using {query}"
-                    )
-                    continue
-
-            # parse Public-Cloud image REGEX if present
-            if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
-                settings = apply_publiccloud_regex(settings)
-                if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                    log.error(
-                        f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
-                    )
-                    continue
-            # parse Public-Cloud pint query if present
-            if "PUBLIC_CLOUD_PINT_QUERY" in settings:
-                settings = apply_publiccloud_pint_image(settings)
-                if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
-                    log.error(
-                        f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
-                    )
-                    continue
-
-            full_post["openqa"].update(settings)
-            full_post["openqa"]["FLAVOR"] = self.flavor
-            full_post["openqa"]["ARCH"] = arch
-            full_post["openqa"]["_OBSOLETE"] = 1
-
-            for template, issues in test_incidents.items():
-                full_post["openqa"][template] = ",".join(str(x) for x in issues)
-            for template, issues in test_repos.items():
-                full_post["openqa"][template] = ",".join(issues)
-            for issues in test_incidents.values():
-                full_post["qem"]["incidents"] += issues
-
-            full_post["qem"]["incidents"] = [
-                str(inc) for inc in set(full_post["qem"]["incidents"])
-            ]
-
-            if not full_post["qem"]["incidents"]:
-                continue
-
-            full_post["openqa"]["__DASHBOARD_INCIDENTS_URL"] = ",".join(
-                f"https://dashboard.qam.suse.de/incident/{inc}"
-                for inc in set(full_post["qem"]["incidents"])
-            )
-            full_post["openqa"]["__SMELT_INCIDENTS_URL"] = ",".join(
-                f"https://smelt.suse.de/incident/{inc}"
-                for inc in set(full_post["qem"]["incidents"])
-            )
-
-            full_post["qem"]["settings"] = full_post["openqa"]
-            full_post["qem"]["repohash"] = full_post["openqa"]["REPOHASH"]
-            full_post["qem"]["build"] = full_post["openqa"]["BUILD"]
-            full_post["qem"]["arch"] = full_post["openqa"]["ARCH"]
-            full_post["qem"]["product"] = self.product
-
-            # add to ret
-            ret.append(full_post)
-
-        return ret
+        return [
+            handle_arch(incidents, token, ci_url, ignore_onetime) for arch in self.archs
+        ]

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -47,18 +47,14 @@ class Aggregate(BaseConf):
         return f"<Aggregate product: {self.product}>"
 
     @staticmethod
-    def get_buildnr(repohash: str, old_repohash: str, cur_build: str) -> str:
+    def get_buildnr(repohash: str, old_repohash: str, build: str) -> str:
         today = date.today().strftime("%Y%m%d")
         build = today
 
-        if cur_build.startswith(today) and repohash == old_repohash:
+        if build.startswith(today) and repohash == old_repohash:
             raise SameBuildExists
 
-        if cur_build.startswith(today):
-            counter = int(cur_build.split("-")[-1]) + 1
-        else:
-            counter = 1
-
+        counter = int(build.split("-")[-1]) + 1 if build.startswith(today) else 1
         return f"{build}-{counter}"
 
     def __call__(

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -8,7 +8,7 @@ from . import ArchVer, Repos
 from ..errors import EmptyChannels, EmptyPackagesError, NoRepoFoundError
 from ..loader.repohash import get_max_revision
 
-logger = getLogger("bot.types.incident")
+log = getLogger("bot.types.incident")
 version_pattern = re.compile(r"(\d+(?:[.-](?:SP)?\d+)?)")
 
 

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -14,7 +14,7 @@ from ..utils import retry3 as requests
 from .baseconf import BaseConf
 from .incident import Incident
 
-logger = getLogger("bot.types.incidents")
+log = getLogger("bot.types.incidents")
 
 
 class Incidents(BaseConf):
@@ -59,7 +59,7 @@ class Incidents(BaseConf):
                 headers=token,
             ).json()
         except Exception as e:
-            logger.exception(e)
+            log.exception(e)
 
         if not jobs:
             return False
@@ -132,7 +132,7 @@ class Incidents(BaseConf):
                             ArchVer(arch, self.settings["VERSION"])
                         ]
                     except KeyError:
-                        logger.debug(
+                        log.debug(
                             "Incident %s does not have %s arch in %s"
                             % (inc.id, arch, self.settings["VERSION"])
                         )
@@ -148,7 +148,7 @@ class Incidents(BaseConf):
                             channels_set.add(f_channel)
 
                     if not issue_dict:
-                        logger.debug(
+                        log.debug(
                             "No channels in %s for %s on %s" % (inc.id, flavor, arch)
                         )
                         continue
@@ -160,7 +160,7 @@ class Incidents(BaseConf):
                     if not ignore_onetime and self._is_scheduled_job(
                         token, inc, arch, self.settings["VERSION"], flavor
                     ):
-                        logger.info(
+                        log.info(
                             "not scheduling: Flavor: %s, version: %s incident: %s , arch: %s  - exists in openQA "
                             % (flavor, self.settings["VERSION"], inc.id, arch)
                         )
@@ -181,7 +181,7 @@ class Incidents(BaseConf):
                                 ]
                             )
                         ):
-                            logger.warning(
+                            log.warning(
                                 "Kernel incident %s doesn't have product repository"
                                 % str(inc)
                             )
@@ -207,10 +207,10 @@ class Incidents(BaseConf):
 
                         if pos and not pos.isdisjoint(full_post["openqa"].keys()):
                             full_post["qem"]["withAggregate"] = False
-                            logger.info("Aggregate not needed for incident %s" % inc.id)
+                            log.info("Aggregate not needed for incident %s" % inc.id)
                         if neg and neg.isdisjoint(full_post["openqa"].keys()):
                             full_post["qem"]["withAggregate"] = False
-                            logger.info("Aggregate not needed for incident %s" % inc.id)
+                            log.info("Aggregate not needed for incident %s" % inc.id)
                         if not (neg and pos):
                             full_post["qem"]["withAggregate"] = False
 
@@ -252,7 +252,7 @@ class Incidents(BaseConf):
                         query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
                         settings = apply_pc_tools_image(settings)
                         if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
-                            logger.error(
+                            log.error(
                                 f"Failed to query latest publiccloud tools image using {query}"
                             )
                             continue
@@ -261,7 +261,7 @@ class Incidents(BaseConf):
                     if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
                         settings = apply_publiccloud_regex(settings)
                         if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                            logger.error(
+                            log.error(
                                 f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
                             )
                             continue
@@ -269,7 +269,7 @@ class Incidents(BaseConf):
                     if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                         settings = apply_publiccloud_pint_image(settings)
                         if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
-                            logger.error(
+                            log.error(
                                 f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
                             )
                             continue

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -198,7 +198,6 @@ def test_single_incident(fake_qem, caplog):
 def test_all_passed(fake_qem, fake_two_passed_jobs, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
-
     assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:1:100" in messages
@@ -247,10 +246,7 @@ def test_403_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
         raise HTTPError("Fake OBS", 403, "Not allowed", "sd", None)
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    args = _namespace(False, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-    assert approver() == 0
+    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -280,10 +276,7 @@ def test_404_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
         raise HTTPError("Fake OBS", 404, "Not allowed", "sd", None)
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    args = _namespace(False, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-    assert approver() == 1
+    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 1
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -313,10 +306,7 @@ def test_500_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
         raise HTTPError("Fake OBS", 500, "Not allowed", "sd", None)
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    args = _namespace(False, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-    assert approver() == 1
+    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 1
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -348,10 +338,7 @@ def test_osc_unknown_exception(
         raise Exception("Fake OBS exception")
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    args = _namespace(False, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-    assert approver() == 1
+    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 1
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -381,10 +368,7 @@ def test_osc_all_pass(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
         pass
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    args = _namespace(False, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-    assert approver() == 0
+    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -58,10 +58,7 @@ def fake_qem(monkeypatch, request):
         return [IncReq(1, 100), IncReq(2, 200), IncReq(3, 300), IncReq(4, 400)]
 
     def f_inc_single_approver(token: Dict[str, str], id: int) -> List[IncReq]:
-        if id == 1:
-            return [IncReq(1, 100)]
-        else:
-            return [IncReq(4, 400)]
+        return [IncReq(1, 100) if id == 1 else IncReq(4, 400)]
 
     # inc 1 needs aggregates
     # inc 2 needs aggregates

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -129,7 +129,7 @@ def test_no_jobs(fake_qem, caplog):
 
     assert len(caplog.records) == 42
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has failed job in incidents" in messages
+    assert "Inc 4 has at least one failed job in incident tests" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:4:400" not in messages
@@ -175,9 +175,9 @@ def test_single_incident(fake_qem, caplog):
 
     approver = Approver(args)
     approver()
-    assert len(caplog.records) == 4
+    assert len(caplog.records) == 5
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has failed job in incidents" in messages
+    assert "Inc 1 has at least one failed job in incident tests" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:1:100" not in messages
@@ -189,7 +189,7 @@ def test_single_incident(fake_qem, caplog):
     approver()
     assert len(caplog.records) == 4
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has failed job in incidents" not in messages
+    assert "Inc 4 has at least one failed job in incident tests" not in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -481,9 +481,9 @@ def test_one_incident_failed(fake_qem, fake_openqa_comment_api, caplog):
 
     assert approver() == 0
 
-    assert len(caplog.records) == 7
+    assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has failed job in incidents" in messages
+    assert "Inc 1 has at least one failed job in incident tests" in messages
     assert "SUSE:Maintenance:2:200" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -514,9 +514,9 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
 
     assert approver() == 0
 
-    assert len(caplog.records) == 7
+    assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 2 has failed job in aggregates" in messages
+    assert "Inc 2 has failed job in aggregate tests" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -118,16 +118,19 @@ def f_osconf(monkeypatch):
     monkeypatch.setattr(osc.conf, "get_config", fake)
 
 
+def approver(incident=None):
+    args = _namespace(True, "123", False, openqa_instance_url, incident)
+    approver = Approver(args)
+    approver.client.retries = 0
+    return approver()
+
+
 @responses.activate
 @pytest.mark.xfail(reason="Bug in responses")
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
 def test_no_jobs(fake_qem, fake_two_passed_jobs, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
-    args = _namespace(True, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
     approver()
-
     assert len(caplog.records) == 42
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 4 has at least one failed job in incident tests" in messages
@@ -172,10 +175,7 @@ def test_single_incident(fake_qem, caplog):
         re.compile(r"http://dashboard.qam.suse.de/api/jobs/update/1000.*"),
         json=[{"status": "passed"}, {"status": "failed"}, {"status": "failed"}],
     )
-    args = _namespace(True, "123", False, openqa_instance_url, 1)
-
-    approver = Approver(args)
-    approver()
+    approver(incident=1)
     assert len(caplog.records) == 5
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
@@ -184,10 +184,7 @@ def test_single_incident(fake_qem, caplog):
     assert "SUSE:Maintenance:1:100" not in messages
 
     caplog.clear()
-
-    args = _namespace(True, "123", False, openqa_instance_url, 4)
-    approver = Approver(args)
-    approver()
+    approver(incident=4)
     assert len(caplog.records) == 4
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 4 has at least one failed job in incident tests" not in messages
@@ -200,10 +197,6 @@ def test_single_incident(fake_qem, caplog):
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
 def test_all_passed(fake_qem, fake_two_passed_jobs, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
-    args = _namespace(True, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-
     assert approver() == 0
 
     assert len(caplog.records) == 7
@@ -220,10 +213,6 @@ def test_all_passed(fake_qem, fake_two_passed_jobs, caplog):
 @pytest.mark.parametrize("fake_qem", [("aggr")], indirect=True)
 def test_inc_passed_aggr_without_results(fake_qem, fake_two_passed_jobs, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
-    args = _namespace(True, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-
     assert approver() == 0
     assert len(caplog.records) == 11
     messages = [x[-1] for x in caplog.record_tuples]
@@ -240,10 +229,6 @@ def test_inc_passed_aggr_without_results(fake_qem, fake_two_passed_jobs, caplog)
 @pytest.mark.parametrize("fake_qem", [("inc")], indirect=True)
 def test_inc_without_results(fake_qem, fake_two_passed_jobs, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
-    args = _namespace(True, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-
     assert approver() == 0
     assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
@@ -437,11 +422,7 @@ def test_one_incident_failed(
     caplog,
 ):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
-    approver = Approver(args)
-    approver.client.retries = 0
-
     assert approver() == 0
-
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
@@ -463,13 +444,7 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
         json=[{"status": "passed"}, {"status": "failed"}, {"status": "passed"}],
     )
     add_two_passed_response()
-    args = _namespace(True, "123", False, openqa_instance_url, None)
-
-    approver = Approver(args)
-    approver.client.retries = 0
-
     assert approver() == 0
-
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 2 has failed job in aggregate tests" in messages
@@ -492,8 +467,6 @@ def test_approval_unblocked_via_openqa_comment(
     caplog,
 ):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
-    approver = Approver(_namespace(True, "123", False, openqa_instance_url, None))
-    approver.client.retries = 0
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:2:200" in messages
@@ -512,8 +485,6 @@ def test_approval_still_blocked_if_openqa_comment_not_relevant(
     caplog,
 ):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
-    approver = Approver(_namespace(True, "123", False, openqa_instance_url, None))
-    approver.client.retries = 0
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:2:200" not in messages

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,16 @@
 import pytest
 import responses
-from responses import registries
+
+has_registries = False
+try:
+    from responses import registries
+
+    has_registries = True
+except ImportError as e:
+    import logging
+
+    logging.info(str(e) + ": Likely older python version")
+
 from openqabot.utils import walk, normalize_results, retry3
 
 
@@ -79,12 +89,14 @@ def test_walk(data, result):
     assert result == ret
 
 
-@responses.activate(registry=registries.OrderedRegistry)
-def test_retry3():
-    rsp1 = responses.add(responses.GET, "http://host.some", status=503)
-    rsp2 = responses.add(responses.GET, "http://host.some", status=503)
-    rsp3 = responses.add(responses.GET, "http://host.some", status=200)
+if has_registries:
 
-    req = retry3.get("http://host.some")
-    assert req.status_code == 200
-    assert rsp3.call_count == 1
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_retry3():
+        rsp1 = responses.add(responses.GET, "http://host.some", status=503)
+        rsp2 = responses.add(responses.GET, "http://host.some", status=503)
+        rsp3 = responses.add(responses.GET, "http://host.some", status=200)
+
+        req = retry3.get("http://host.some")
+        assert req.status_code == 200
+        assert rsp3.call_count == 1


### PR DESCRIPTION
* Simplify loader/qem
* Simplify smeltsync
* Extract 'handle_arch' method in types/aggregates
* Simplify counter assignment in aggregates
* tests: Simplify test_repohash
* tests: Simplify remaining approver generators
* tests: Extract 'approver' helper in test_approve
* tests: Extract "two_passed_responses" helper
* Simplify tests
* tests: Skip 'responses' test if not available on older python
* Use updated codecov uploader v3
* approver: Extract _handle_http_error function
* Squeeze some whitespace in code with shorter 'log'
* approver: Extract approvable method
* Add and change log messages in case of approval-blocking tests