### PR TITLE
Log failed jobs

### DIFF
--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -129,7 +129,7 @@ def test_no_jobs(fake_qem, caplog):
 
     assert len(caplog.records) == 42
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has failed job in incidents" in messages
+    assert "Inc 4 has failed job in incidents ()" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:4:400" not in messages
@@ -177,7 +177,7 @@ def test_single_incident(fake_qem, caplog):
     approver()
     assert len(caplog.records) == 4
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has failed job in incidents" in messages
+    assert "Inc 1 has failed job in incidents (1000)" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:1:100" not in messages
@@ -189,7 +189,7 @@ def test_single_incident(fake_qem, caplog):
     approver()
     assert len(caplog.records) == 4
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has failed job in incidents" not in messages
+    assert "Inc 4 has failed job in incidents (1000)" not in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -483,7 +483,7 @@ def test_one_incident_failed(fake_qem, fake_openqa_comment_api, caplog):
 
     assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has failed job in incidents" in messages
+    assert "Inc 1 has failed job in incidents (1005)" in messages
     assert "SUSE:Maintenance:2:200" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -516,7 +516,7 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
 
     assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 2 has failed job in aggregates" in messages
+    assert "Inc 2 has failed job in aggregates (20005)" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages


### PR DESCRIPTION
Previously we were looking into pipelines and were wondering if we could improve the "Inc x has failed jobs" message by adding the list of failed jobs.

Note that if the list is empty, then there were jobs which were simply not found anymore in openQA.

Related issue: https://progress.opensuse.org/issues/114415

This was a low hanging fruit as I would have touched that code anyway to save the list of failed jobs one level up.