### PR TITLE
Clarify 'at least one failed' message for aggregate tests

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -106,7 +106,10 @@ class Approver:
 
         if any(i.withAggregate for i in i_jobs):
             if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
-                log.info("Inc %s has failed job in aggregate tests" % str(inc.inc))
+                log.info(
+                    "Inc %s has at least one failed job in aggregate tests"
+                    % str(inc.inc)
+                )
                 return False
 
         # everything is green --> add incident to approve list

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -431,7 +431,7 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
     assert approver() == 0
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 2 has failed job in aggregate tests" in messages
+    assert "Inc 2 has at least one failed job in aggregate tests" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages


### PR DESCRIPTION
Same as for incidents we should clarify the log message for aggregate
test results as well.