### PR TITLE
Revert simplify cleanup update code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Check style
         run: make checkstyle
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v2
         with:
           files: coverage.xml

--- a/openqabot/aggrsync.py
+++ b/openqabot/aggrsync.py
@@ -9,7 +9,7 @@ from .loader.config import read_products
 from .loader.qem import get_aggregate_settings_data
 from .syncres import SyncRes
 
-log = getLogger("bot.aggrsync")
+logger = getLogger("bot.aggrsync")
 
 
 class AggregateResultsSync(SyncRes):
@@ -26,7 +26,7 @@ class AggregateResultsSync(SyncRes):
             try:
                 update_setting += get_aggregate_settings_data(self.token, product)
             except EmptySettings as e:
-                log.info(e)
+                logger.info(e)
                 continue
 
         job_results = {}
@@ -53,6 +53,6 @@ class AggregateResultsSync(SyncRes):
         for r in results:
             self.post_result(r)
 
-        log.info("End of bot run")
+        logger.info("End of bot run")
 
         return 0

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -25,28 +25,7 @@ from .loader.qem import (
 )
 from .utils import retry3 as requests
 
-log = getLogger("bot.approver")
-
-
-def _handle_http_error(e: HTTPError, inc: IncReq) -> bool:
-    if e.code == 403:
-        log.info(
-            "Received '%s'. Request %s likely already approved, ignoring"
-            % (e.reason, inc.req)
-        )
-        return True
-    elif e.code == 404:
-        log.info(
-            "Received '%s'. Request %s removed or problem on OBS side, ignoring"
-            % (e.reason, inc.req)
-        )
-        return False
-    else:
-        log.error(
-            "Recived error %s, reason: '%s' for Request %s - problem on OBS side"
-            % (e.code, e.reason, inc.req)
-        )
-        return False
+logger = getLogger("bot.approver")
 
 
 class Approver:
@@ -58,7 +37,7 @@ class Approver:
         self.client = openQAInterface(args.openqa_instance)
 
     def __call__(self) -> int:
-        log.info("Start approving incidents in IBS")
+        logger.info("Start approving incidents in IBS")
         increqs = (
             get_single_incident(self.token, self.single_incident)
             if self.single_incident
@@ -66,51 +45,49 @@ class Approver:
         )
 
         overall_result = True
-        incidents_to_approve = [inc for inc in increqs if self._approvable(inc)]
+        incidents_to_approve = []
 
-        log.info("Incidents to approve:")
+        for inc in increqs:
+            try:
+                i_jobs = get_incident_settings(inc.inc, self.token, self.all_incidents)
+            except NoResultsError as e:
+                logger.info(e)
+                continue
+            try:
+                u_jobs = get_aggregate_settings(inc.inc, self.token)
+            except NoResultsError as e:
+                logger.info(e)
+
+                if any(i.withAggregate for i in i_jobs):
+                    logger.info("Aggregate missing for %s" % str(inc.inc))
+                    continue
+
+                u_jobs = []
+
+            if not self.get_incident_result(i_jobs, "api/jobs/incident/", inc.inc):
+                logger.info("Inc %s has failed job in incidents" % str(inc.inc))
+                continue
+
+            if any(i.withAggregate for i in i_jobs):
+                if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
+                    logger.info("Inc %s has failed job in aggregates" % str(inc.inc))
+                    continue
+
+            # everything is green --> approve inc
+            incidents_to_approve.append(inc)
+
+        logger.info("Incidents to approve:")
         for inc in incidents_to_approve:
-            log.info(OBS_MAINT_PRJ + ":%s:%s" % (str(inc.inc), str(inc.req)))
+            logger.info(OBS_MAINT_PRJ + ":%s:%s" % (str(inc.inc), str(inc.req)))
 
         if not self.dry:
             osc.conf.get_config(override_apiurl=OBS_URL)
             for inc in incidents_to_approve:
                 overall_result &= self.osc_approve(inc)
 
-        log.info("End of bot run")
+        logger.info("End of bot run")
 
         return 0 if overall_result else 1
-
-    def _approvable(self, inc: IncReq) -> bool:
-        try:
-            i_jobs = get_incident_settings(inc.inc, self.token, self.all_incidents)
-        except NoResultsError as e:
-            log.info(e)
-            return False
-        try:
-            u_jobs = get_aggregate_settings(inc.inc, self.token)
-        except NoResultsError as e:
-            log.info(e)
-
-            if any(i.withAggregate for i in i_jobs):
-                log.info("Aggregate missing for %s" % str(inc.inc))
-                return False
-
-            u_jobs = []
-
-        if not self.get_incident_result(i_jobs, "api/jobs/incident/", inc.inc):
-            log.info(
-                "Inc %s has at least one failed job in incident tests" % str(inc.inc)
-            )
-            return False
-
-        if any(i.withAggregate for i in i_jobs):
-            if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
-                log.info("Inc %s has failed job in aggregate tests" % str(inc.inc))
-                return False
-
-        # everything is green --> add incident to approve list
-        return True
 
     @lru_cache(maxsize=512)
     def is_job_marked_acceptable_for_incident(self, job: JobAggr, inc: int) -> bool:
@@ -135,16 +112,12 @@ class Approver:
             if ok_job:
                 continue
             if self.is_job_marked_acceptable_for_incident(job, inc):
-                log.info(
+                logger.info(
                     "Ignoring failed job %s for incident %s due to openQA comment"
                     % (job.job_id, inc)
                 )
                 res["status"] = "passed"
             else:
-                log.info(
-                    "Found failed, not-ignored job %s for incident %s"
-                    % (job.job_id, inc)
-                )
                 break
 
         if not results:
@@ -159,7 +132,7 @@ class Approver:
             try:
                 res = self.get_jobs(job, api, inc)
             except NoResultsError as e:
-                log.info(e)
+                logger.info(e)
                 continue
             if not res:
                 return False
@@ -172,7 +145,7 @@ class Approver:
         msg = (
             "Request accepted for '" + OBS_GROUP + "' based on data in " + QEM_DASHBOARD
         )
-        log.info(
+        logger.info(
             "Accepting review for "
             + OBS_MAINT_PRJ
             + ":%s:%s" % (str(inc.inc), str(inc.req))
@@ -187,9 +160,26 @@ class Approver:
                 message=msg,
             )
         except HTTPError as e:
-            return _handle_http_error(e, inc)
+            if e.code == 403:
+                logger.info(
+                    "Received '%s'. Request %s likely already approved, ignoring"
+                    % (e.reason, inc.req)
+                )
+                return True
+            elif e.code == 404:
+                logger.info(
+                    "Received '%s'. Request %s removed or problem on OBS side, ignoring"
+                    % (e.reason, inc.req)
+                )
+                return False
+            else:
+                logger.error(
+                    "Recived error %s, reason: '%s' for Request %s - problem on OBS side"
+                    % (e.code, e.reason, inc.req)
+                )
+                return False
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
             return False
 
         return True

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -106,10 +106,7 @@ class Approver:
 
         if any(i.withAggregate for i in i_jobs):
             if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
-                log.info(
-                    "Inc %s has at least one failed job in aggregate tests"
-                    % str(inc.inc)
-                )
+                log.info("Inc %s has failed job in aggregate tests" % str(inc.inc))
                 return False
 
         # everything is green --> add incident to approve list

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -16,7 +16,7 @@ from .openqa import openQAInterface
 from .osclib.comments import CommentAPI
 from .types.incident import Incident
 
-log = getLogger("bot.commenter")
+logger = getLogger("bot.commenter")
 
 
 class Commenter:
@@ -30,27 +30,27 @@ class Commenter:
 
     def __call__(self) -> int:
 
-        log.info("Start commenting incidents in IBS")
+        logger.info("Start commenting incidents in IBS")
 
         for inc in self.incidents:
             try:
                 i_jobs = get_incident_results(inc.id, self.token)
                 u_jobs = get_aggregate_results(inc.id, self.token)
             except ValueError as e:
-                log.debug(e)
+                logger.debug(e)
                 continue
             except NoResultsError as e:
-                log.debug(e)
+                logger.debug(e)
                 continue
 
             state = "none"
             if any(j["status"] in ["running"] for j in i_jobs + u_jobs):
-                log.info("%s needs to wait a bit longer" % inc)
+                logger.info("%s needs to wait a bit longer" % inc)
             else:
                 if any(
                     j["status"] not in ["passed", "softfailed"] for j in i_jobs + u_jobs
                 ):
-                    log.info("There is a failed job for %s" % inc)
+                    logger.info("There is a failed job for %s" % inc)
                     state = "failed"
                 else:
                     state = "passed"
@@ -62,11 +62,11 @@ class Commenter:
 
     def osc_comment(self, inc: Incident, msg: str, state: str) -> None:
         if inc.rr is None:
-            log.debug("Skipping comment -- no request defined")
+            logger.debug("Skipping comment -- no request defined")
             return
 
         if not msg:
-            log.debug("Skipping empty comment")
+            logger.debug("Skipping empty comment")
             return
 
         kw = {}
@@ -87,33 +87,33 @@ class Commenter:
         # To prevent spam, assume same state/result
         # and number of lines in message is a duplicate message
         if comment is not None and comment["comment"].count("\n") == msg.count("\n"):
-            log.debug("Previous comment is too similar")
+            logger.debug("Previous comment is too similar")
             return
 
         if comment is None:
-            log.debug("No comment with this state, looking without the state filter")
+            logger.debug("No comment with this state, looking without the state filter")
             comment, _ = self.commentapi.comment_find(comments, bot_name)
 
         if comment is None:
-            log.debug("No comment to replace found")
+            logger.debug("No comment to replace found")
         else:
             if not self.dry:
                 self.commentapi.delete(comment["id"])
             else:
-                log.info("Would delete comment %d" % int(comment["id"]))
+                logger.info("Would delete comment %d" % int(comment["id"]))
 
         if not self.dry:
             self.commentapi.add_comment(comment=msg, **kw)
         else:
-            log.info("Would write comment to request %s" % inc)
-            log.debug(pformat(msg))
+            logger.info("Would write comment to request %s" % inc)
+            logger.debug(pformat(msg))
 
     def summarize_message(self, jobs) -> str:
         groups = {}
         for job in jobs:
             if "job_group" not in job:
                 # workaround for experimets of some QAM devs
-                log.warning(f"group missing in {job['job_id']}")
+                logger.warning(f"group missing in {job['job_id']}")
                 continue
             gl = "{!s}@{!s}".format(
                 Commenter.emd(job["job_group"]), Commenter.emd(job["flavor"])

--- a/openqabot/incsyncres.py
+++ b/openqabot/incsyncres.py
@@ -9,7 +9,7 @@ from .loader.qem import get_active_incidents, get_incident_settings_data
 from .syncres import SyncRes
 from .types import Data
 
-log = getLogger("bot.incsyncres")
+logger = getLogger("bot.incsyncres")
 
 
 class IncResultsSync(SyncRes):
@@ -54,6 +54,6 @@ class IncResultsSync(SyncRes):
         for r in results:
             self.post_result(r)
 
-        log.info("End of bot run")
+        logger.info("End of bot run")
 
         return 0

--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -11,7 +11,7 @@ from ..types import Data
 from ..types.aggregate import Aggregate
 from ..types.incidents import Incidents
 
-log = getLogger("bot.loader.config")
+logger = getLogger("bot.loader.config")
 
 
 def load_metadata(
@@ -27,7 +27,7 @@ def load_metadata(
         try:
             data = loader.load(p)
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
             continue
 
         try:
@@ -37,7 +37,7 @@ def load_metadata(
             continue
 
         if "product" not in data:
-            log.debug("Skipping invalid config %s" % p)
+            logger.debug("Skipping invalid config %s" % p)
             continue
 
         if settings:
@@ -50,7 +50,9 @@ def load_metadata(
                     try:
                         ret.append(Aggregate(data["product"], settings, data[key]))
                     except NoTestIssues:
-                        log.warning("No 'test_issues' in %s config" % data["product"])
+                        logger.warning(
+                            "No 'test_issues' in %s config" % data["product"]
+                        )
                 else:
                     continue
     return ret
@@ -64,16 +66,16 @@ def read_products(path: Path) -> List[Data]:
         data = loader.load(p)
 
         if not data:
-            log.info("Skipping invalid config %s - empty config" % str(p))
+            logger.info("Skipping invalid config %s - empty config" % str(p))
             continue
         if not isinstance(data, dict):
-            log.info("Skipping invalid config %s - invalid format" % str(p))
+            logger.info("Skipping invalid config %s - invalid format" % str(p))
             continue
 
         try:
             flavor = data["aggregate"]["FLAVOR"]
         except KeyError:
-            log.info("Config %s does not have aggregate" % str(p))
+            logger.info("Config %s does not have aggregate" % str(p))
             continue
 
         try:
@@ -81,7 +83,7 @@ def read_products(path: Path) -> List[Data]:
             version = data["settings"]["VERSION"]
             product = data["product"]
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
             continue
 
         for arch in data["aggregate"]["archs"]:
@@ -96,7 +98,7 @@ def get_onearch(path: Path) -> Set[str]:
     try:
         data = loader.load(path)
     except Exception as e:
-        log.exception(e)
+        logger.exception(e)
         return set()
 
     return set(data)

--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -12,7 +12,7 @@ from requests.exceptions import RetryError
 from ..errors import NoRepoFoundError
 from ..utils import retry5 as requests
 
-log = getLogger("bot.loader.repohash")
+logger = getLogger("bot.loader.repohash")
 
 
 def get_max_revision(
@@ -41,14 +41,14 @@ def get_max_revision(
             HTTPError,
             RetryError,
         ):  # for now, use logger.exception to determine possible exceptions in this code :D
-            log.info("%s not found -- skip incident" % url)
+            logger.info("%s not found -- skip incident" % url)
             raise NoRepoFoundError
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
             raise e
 
         if cs is None:
-            log.error("%s's revision is None" % url)
+            logger.error("%s's revision is None" % url)
             raise NoRepoFoundError
 
         rev = int(str(cs.text))

--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -12,7 +12,7 @@ from .. import SMELT
 from ..utils import walk
 from ..utils import retry10 as requests
 
-log = getLogger("bot.loader.smelt")
+logger = getLogger("bot.loader.smelt")
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -121,7 +121,7 @@ def get_json(query: str, host: str = SMELT) -> dict:
     try:
         return requests.get(host, params={"query": query}, verify=False).json()
     except Exception as e:
-        log.exception(e)
+        logger.exception(e)
         raise e
 
 
@@ -139,7 +139,7 @@ def get_active_incidents() -> Set[int]:
         try:
             validate(instance=ndata, schema=ACTIVE_INC_SCHEMA)
         except ValidationError as e:
-            log.exception("Invalid data from SMELT received")
+            logger.exception("Invalid data from SMELT received")
             return []
         incidents = ndata["data"]["incidents"]
         active.update(x["node"]["incidentId"] for x in incidents["edges"])
@@ -147,7 +147,7 @@ def get_active_incidents() -> Set[int]:
         if has_next:
             cursor = incidents["pageInfo"]["endCursor"]
 
-    log.info("Loaded %s active incidents" % len(active))
+    logger.info("Loaded %s active incidents" % len(active))
 
     return active
 
@@ -155,17 +155,17 @@ def get_active_incidents() -> Set[int]:
 def get_incident(incident: int):
     query = INCIDENT % {"incident": incident}
 
-    log.info("Getting info about incident %s from SMELT" % incident)
+    logger.info("Getting info about incident %s from SMELT" % incident)
     inc_result = get_json(query)
     try:
         validate(instance=inc_result, schema=INCIDENT_SCHEMA)
         inc_result = walk(inc_result["data"]["incidents"]["edges"][0]["node"])
     except ValidationError as e:
-        log.exception("Invalid data from SMELT for incident %s" % incident)
+        logger.exception("Invalid data from SMELT for incident %s" % incident)
         return None
     except Exception as e:
-        log.error("Unknown error for incident %s" % incident)
-        log.exception(e)
+        logger.error("Unknown error for incident %s" % incident)
+        logger.exception(e)
         return None
 
     return inc_result

--- a/openqabot/main.py
+++ b/openqabot/main.py
@@ -7,19 +7,19 @@ from .args import get_parser
 
 
 def create_logger() -> logging.Logger:
-    log = logging.getLogger("bot")
+    logger = logging.getLogger("bot")
     handler = logging.StreamHandler()
     formatter = logging.Formatter(
         fmt="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
     handler.setFormatter(formatter)
-    log.addHandler(handler)
-    log.setLevel(logging.INFO)
-    return log
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
 
 
 def main() -> None:
-    log = create_logger()
+    logger = create_logger()
     parser = get_parser()
 
     if len(sys.argv) < 1:
@@ -29,15 +29,15 @@ def main() -> None:
     cfg = parser.parse_args(sys.argv[1:])
 
     if not cfg.configs.exists() and not cfg.configs.is_dir():
-        log.error(f"Path {cfg.configs} is not a valid directory with config files")
+        logger.error(f"Path {cfg.configs} is not a valid directory with config files")
         sys.exit(1)
 
     if not hasattr(cfg, "func"):
-        log.error("Command is required")
+        logger.error("Command is required")
         parser.print_help()
         sys.exit(1)
 
     if cfg.debug:
-        log.setLevel(logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
 
     sys.exit(cfg.func(cfg))

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -12,7 +12,7 @@ from . import DEVELOPMENT_PARENT_GROUP_ID, OPENQA_URL
 from .errors import PostOpenQAError
 from .types import Data
 
-log = logging.getLogger("bot.openqa")
+logger = logging.getLogger("bot.openqa")
 
 
 class openQAInterface:
@@ -26,7 +26,7 @@ class openQAInterface:
         return self.url.netloc == OPENQA_URL
 
     def post_job(self, settings) -> None:
-        log.info(
+        logger.info(
             "openqa-cli api --host %s -X post isos %s"
             % (
                 self.url.geturl(),
@@ -38,16 +38,16 @@ class openQAInterface:
                 "POST", "isos", data=settings, retries=self.retries
             )
         except RequestError as e:
-            log.error("openQA returned %s" % e.args[-1])
-            log.error("Post failed with {}".format(pformat(settings)))
+            logger.error("openQA returned %s" % e.args[-1])
+            logger.error("Post failed with {}".format(pformat(settings)))
             raise PostOpenQAError
         except Exception as e:
-            log.exception(e)
-            log.error("Post failed with {}".format(pformat(settings)))
+            logger.exception(e)
+            logger.error("Post failed with {}".format(pformat(settings)))
             raise PostOpenQAError
 
     def get_jobs(self, data: Data):
-        log.info("Getting openQA tests results for %s" % pformat(data))
+        logger.info("Getting openQA tests results for %s" % pformat(data))
         param = {}
         param["scope"] = "relevant"
         param["latest"] = "1"
@@ -61,7 +61,7 @@ class openQAInterface:
         try:
             ret = self.openqa.openqa_request("GET", "jobs", param)["jobs"]
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
             raise e
         return ret
 
@@ -76,7 +76,7 @@ class openQAInterface:
         except Exception as e:
             (method, url, status_code) = e.args
             if status_code != 404:
-                log.exception(e)
+                logger.exception(e)
         return ret
 
     @lru_cache(maxsize=256)
@@ -86,7 +86,7 @@ class openQAInterface:
         try:
             ret = self.openqa.openqa_request("GET", f"job_groups/{groupid}")
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
             raise e
 
         # return True as safe option if ret = None

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -11,17 +11,17 @@ from .loader.qem import get_incidents
 from .openqa import openQAInterface
 from .utils import retry3 as requests
 
-log = getLogger("bot.openqabot")
+logger = getLogger("bot.openqabot")
 
 
 class OpenQABot:
     def __init__(self, args: Namespace) -> None:
-        log.info("Bot schedule starts now")
+        logger.info("Bot schedule starts now")
         self.dry = args.dry
         self.ignore_onetime = args.ignore_onetime
         self.token = {"Authorization": "Token " + args.token}
         self.incidents = get_incidents(self.token)
-        log.info("%s incidents loaded from qem dashboard" % len(self.incidents))
+        logger.info("%s incidents loaded from qem dashboard" % len(self.incidents))
 
         extrasettings = get_onearch(args.singlearch)
 
@@ -34,7 +34,7 @@ class OpenQABot:
 
     def post_qem(self, data, api) -> None:
         if not self.openqa:
-            log.warning(
+            logger.warning(
                 "No valid openQA configuration specified: '%s' not posted to dashboard"
                 % data
             )
@@ -43,40 +43,40 @@ class OpenQABot:
         url = QEM_DASHBOARD + api
         try:
             res = requests.put(url, headers=self.token, json=data)
-            log.info(
+            logger.info(
                 "Put to dashboard result %s, database id: %s"
                 % (res.status_code, res.json().get("id", "No id?"))
             )
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
             raise e
 
     def post_openqa(self, data) -> None:
         self.openqa.post_job(data)
 
     def __call__(self):
-        log.info("Starting bot mainloop")
+        logger.info("Starting bot mainloop")
         post = []
         for worker in self.workers:
             post += worker(self.incidents, self.token, self.ci, self.ignore_onetime)
 
         if self.dry:
-            log.info("Would trigger %s products in openQA" % len(post))
+            logger.info("Would trigger %s products in openQA" % len(post))
             for job in post:
-                log.info(job)
+                logger.info(job)
 
         else:
-            log.info("Triggering %s products in openQA" % len(post))
+            logger.info("Triggering %s products in openQA" % len(post))
             for job in post:
-                log.info("Triggering %s" % str(job))
+                logger.info("Triggering %s" % str(job))
                 try:
                     self.post_openqa(job["openqa"])
                 except PostOpenQAError:
-                    log.info("POST failed, not updating dashboard")
+                    logger.info("POST failed, not updating dashboard")
                     pass
                 else:
                     self.post_qem(job["qem"], job["api"])
 
-        log.info("End of bot run")
+        logger.info("End of bot run")
 
         return 0

--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -8,7 +8,7 @@ import bs4
 
 from .utils import retry5 as requests
 
-log = logging.getLogger("bot.openqabot.pc_helper")
+logger = logging.getLogger("bot.openqabot.pc_helper")
 
 
 def fetch_matching_link(url, regex):
@@ -21,7 +21,7 @@ def fetch_matching_link(url, regex):
         req = requests.get(url + "/?C=M;O=A")
         text = req.text
     except BaseException as err:
-        log.error("error fetching '%s': %s" % (url, err))
+        logger.error("error fetching '%s': %s" % (url, err))
         return None
     getpage_soup = bs4.BeautifulSoup(text, "html.parser")
     # Returns lazy iterator, so
@@ -59,7 +59,7 @@ def apply_publiccloud_regex(settings):
         )
         return settings
     except BaseException as e:
-        log.warning(f"PUBLIC_CLOUD_IMAGE_REGEX handling failed: {e}")
+        logger.warning(f"PUBLIC_CLOUD_IMAGE_REGEX handling failed: {e}")
         settings["PUBLIC_CLOUD_IMAGE_LOCATION"] = None
         return settings
 
@@ -73,7 +73,7 @@ def apply_pc_tools_image(settings):
             del settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
         return settings
     except BaseException as e:
-        log.warning(f"PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed: {e}")
+        logger.warning(f"PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed: {e}")
         return settings
 
 
@@ -120,7 +120,7 @@ def apply_publiccloud_pint_image(settings):
             del settings["PUBLIC_CLOUD_PINT_FIELD"]
         return settings
     except BaseException as e:
-        log.warning(
+        logger.warning(
             f"PUBLIC_CLOUD_PINT_QUERY handling failed for {settings['PUBLIC_CLOUD_PINT_NAME']}: {e}"
         )
         settings["PUBLIC_CLOUD_IMAGE_ID"] = None

--- a/openqabot/smeltsync.py
+++ b/openqabot/smeltsync.py
@@ -44,11 +44,11 @@ class SMELTSync:
 
     @staticmethod
     def _is_inreview(rr_number) -> bool:
-        return bool(rr_number["reviewSet"]) and rr_number["status"]["name"] == "review"
+        return rr_number["reviewSet"] and rr_number["status"]["name"] == "review"
 
     @staticmethod
     def _is_revoked(rr_number) -> bool:
-        return bool(rr_number["reviewSet"]) and rr_number["status"]["name"] == "revoked"
+        return rr_number["reviewSet"] and rr_number["status"]["name"] == "revoked"
 
     @staticmethod
     def _is_accepted(rr_number) -> bool:
@@ -63,7 +63,7 @@ class SMELTSync:
             return False
         rr = (r for r in rr_number["reviewSet"] if r["assignedByGroup"])
         review = [r for r in rr if r["assignedByGroup"]["name"] == "qam-openqa"]
-        return bool(review) and review[0]["status"]["name"] in ("review", "new")
+        return review and review[0]["status"]["name"] in ("review", "new")
 
     @classmethod
     def _create_record(cls, inc):

--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -11,7 +11,7 @@ from .openqa import openQAInterface
 from .types import Data
 from .utils import normalize_results
 
-log = getLogger("bot.syncres")
+logger = getLogger("bot.syncres")
 
 
 class SyncRes:
@@ -58,11 +58,11 @@ class SyncRes:
             return False
 
         if data["clone_id"]:
-            log.info("Job '%s' already has a clone, ignoring" % data["clone_id"])
+            logger.info("Job '%s' already has a clone, ignoring" % data["clone_id"])
             return False
 
         if self._is_in_devel_group(data):
-            log.info(
+            logger.info(
                 "Ignoring job '%s' in development group '%s'"
                 % (data["id"], data["group"])
             )
@@ -71,13 +71,13 @@ class SyncRes:
         return True
 
     def post_result(self, result):
-        log.debug(
+        logger.debug(
             "Posting results of %s job %s with status %s"
             % (self.operation, result["job_id"], result["status"])
         )
-        log.debug("Full post data: %s" % pformat(result))
+        logger.debug("Full post data: %s" % pformat(result))
 
         if not self.dry and self.client:
             post_job(self.token, result)
         else:
-            log.info("Dry run -- data in dashboard untouched")
+            logger.info("Dry run -- data in dashboard untouched")

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -20,7 +20,7 @@ from .baseconf import BaseConf
 from .incident import Incident
 
 
-log = getLogger("bot.types.aggregate")
+logger = getLogger("bot.types.aggregate")
 
 
 class Aggregate(BaseConf):
@@ -47,159 +47,19 @@ class Aggregate(BaseConf):
         return f"<Aggregate product: {self.product}>"
 
     @staticmethod
-    def get_buildnr(repohash: str, old_repohash: str, build: str) -> str:
+    def get_buildnr(repohash: str, old_repohash: str, cur_build: str) -> str:
         today = date.today().strftime("%Y%m%d")
         build = today
 
-        if build.startswith(today) and repohash == old_repohash:
+        if cur_build.startswith(today) and repohash == old_repohash:
             raise SameBuildExists
 
-        counter = int(build.split("-")[-1]) + 1 if build.startswith(today) else 1
+        if cur_build.startswith(today):
+            counter = int(cur_build.split("-")[-1]) + 1
+        else:
+            counter = 1
+
         return f"{build}-{counter}"
-
-    def handle_arch(
-        self,
-        incidents: List[Incident],
-        token: Dict[str, str],
-        ci_url: Optional[str],
-        ignore_onetime: bool = False,
-    ) -> Dict[str, Any]:
-        full_post: Dict["str", Any] = {}
-        full_post["openqa"] = {}
-        full_post["qem"] = {}
-        full_post["qem"]["incidents"] = []
-        full_post["qem"]["settings"] = {}
-        full_post["api"] = "api/update_settings"
-        if ci_url:
-            full_post["openqa"]["__CI_JOB_URL"] = ci_url
-
-        test_incidents = defaultdict(list)
-        test_repos = defaultdict(list)
-
-        # Temporary workaround for applying the correct architecture on jobs, which use a helper VM
-        issues_arch = self.settings.get("TEST_ISSUES_ARCH", arch)
-
-        # only testing queue and not livepatch
-        valid_incidents = [i for i in incidents if not any((i.livepatch, i.staging))]
-        for issue, template in self.test_issues.items():
-            for inc in valid_incidents:
-                if (
-                    Repos(template.product, template.version, issues_arch)
-                    in inc.channels
-                ):
-                    test_incidents[issue].append(inc)
-
-        for issue, incs in test_incidents.items():
-            tmpl = issue.replace("ISSUES", "REPOS")
-            for inc in incs:
-                if self.test_issues[issue].product.startswith("openSUSE"):
-                    test_repos[tmpl].append(
-                        f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}/"
-                    )
-                else:
-                    test_repos[tmpl].append(
-                        f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}_{issues_arch}/"
-                    )
-
-        full_post["openqa"]["REPOHASH"] = merge_repohash(
-            sorted(
-                set(str(inc) for inc in chain.from_iterable(test_incidents.values()))
-            )
-        )
-
-        try:
-            old_jobs = requests.get(
-                QEM_DASHBOARD + "api/update_settings",
-                params={"product": self.product, "arch": arch},
-                headers=token,
-            ).json()
-        except Exception as e:
-            log.exception(e)
-            old_jobs = None
-
-        old_repohash = old_jobs[0].get("repohash", "") if old_jobs else ""
-        old_build = old_jobs[0].get("build", "") if old_jobs else ""
-
-        try:
-            full_post["openqa"]["BUILD"] = self.get_buildnr(
-                full_post["openqa"]["REPOHASH"], old_repohash, old_build
-            )
-        except SameBuildExists:
-            log.info(
-                "For %s aggreagate on %s there is existing build" % (self.product, arch)
-            )
-            return {}
-
-        if not ignore_onetime and (
-            self.onetime and full_post["openqa"]["BUILD"].split("-")[-1] != "1"
-        ):
-            return {}
-
-        settings = self.settings.copy()
-
-        # if set, we use this query to detect latest public cloud tools image which used for running
-        # all public cloud related tests in openQA
-        if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
-            query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
-            settings = apply_pc_tools_image(settings)
-            if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
-                log.error(
-                    f"Failed to query latest publiccloud tools image using {query}"
-                )
-                return {}
-
-        # parse Public-Cloud image REGEX if present
-        if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
-            settings = apply_publiccloud_regex(settings)
-            if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                log.error(
-                    f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
-                )
-                return {}
-        # parse Public-Cloud pint query if present
-        if "PUBLIC_CLOUD_PINT_QUERY" in settings:
-            settings = apply_publiccloud_pint_image(settings)
-            if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
-                log.error(
-                    f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
-                )
-                return {}
-
-        full_post["openqa"].update(settings)
-        full_post["openqa"]["FLAVOR"] = self.flavor
-        full_post["openqa"]["ARCH"] = arch
-        full_post["openqa"]["_OBSOLETE"] = 1
-
-        for template, issues in test_incidents.items():
-            full_post["openqa"][template] = ",".join(str(x) for x in issues)
-        for template, issues in test_repos.items():
-            full_post["openqa"][template] = ",".join(issues)
-        for issues in test_incidents.values():
-            full_post["qem"]["incidents"] += issues
-
-        full_post["qem"]["incidents"] = [
-            str(inc) for inc in set(full_post["qem"]["incidents"])
-        ]
-
-        if not full_post["qem"]["incidents"]:
-            return {}
-
-        full_post["openqa"]["__DASHBOARD_INCIDENTS_URL"] = ",".join(
-            f"https://dashboard.qam.suse.de/incident/{inc}"
-            for inc in set(full_post["qem"]["incidents"])
-        )
-        full_post["openqa"]["__SMELT_INCIDENTS_URL"] = ",".join(
-            f"https://smelt.suse.de/incident/{inc}"
-            for inc in set(full_post["qem"]["incidents"])
-        )
-
-        full_post["qem"]["settings"] = full_post["openqa"]
-        full_post["qem"]["repohash"] = full_post["openqa"]["REPOHASH"]
-        full_post["qem"]["build"] = full_post["openqa"]["BUILD"]
-        full_post["qem"]["arch"] = full_post["openqa"]["ARCH"]
-        full_post["qem"]["product"] = self.product
-
-        return full_post
 
     def __call__(
         self,
@@ -208,6 +68,150 @@ class Aggregate(BaseConf):
         ci_url: Optional[str],
         ignore_onetime: bool = False,
     ) -> List[Dict[str, Any]]:
-        return [
-            handle_arch(incidents, token, ci_url, ignore_onetime) for arch in self.archs
-        ]
+        ret = []
+
+        for arch in self.archs:
+            full_post: Dict["str", Any] = {}
+            full_post["openqa"] = {}
+            full_post["qem"] = {}
+            full_post["qem"]["incidents"] = []
+            full_post["qem"]["settings"] = {}
+            full_post["api"] = "api/update_settings"
+            if ci_url:
+                full_post["openqa"]["__CI_JOB_URL"] = ci_url
+
+            test_incidents = defaultdict(list)
+            test_repos = defaultdict(list)
+
+            # Temporary workaround for applying the correct architecture on jobs, which use a helper VM
+            issues_arch = self.settings.get("TEST_ISSUES_ARCH", arch)
+
+            # only testing queue and not livepatch
+            valid_incidents = [
+                i for i in incidents if not any((i.livepatch, i.staging))
+            ]
+            for issue, template in self.test_issues.items():
+                for inc in valid_incidents:
+                    if (
+                        Repos(template.product, template.version, issues_arch)
+                        in inc.channels
+                    ):
+                        test_incidents[issue].append(inc)
+
+            for issue, incs in test_incidents.items():
+                tmpl = issue.replace("ISSUES", "REPOS")
+                for inc in incs:
+                    if self.test_issues[issue].product.startswith("openSUSE"):
+                        test_repos[tmpl].append(
+                            f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}/"
+                        )
+                    else:
+                        test_repos[tmpl].append(
+                            f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}_{issues_arch}/"
+                        )
+
+            full_post["openqa"]["REPOHASH"] = merge_repohash(
+                sorted(
+                    set(
+                        str(inc) for inc in chain.from_iterable(test_incidents.values())
+                    )
+                )
+            )
+
+            try:
+                old_jobs = requests.get(
+                    QEM_DASHBOARD + "api/update_settings",
+                    params={"product": self.product, "arch": arch},
+                    headers=token,
+                ).json()
+            except Exception as e:
+                logger.exception(e)
+                old_jobs = None
+
+            old_repohash = old_jobs[0].get("repohash", "") if old_jobs else ""
+            old_build = old_jobs[0].get("build", "") if old_jobs else ""
+
+            try:
+                full_post["openqa"]["BUILD"] = self.get_buildnr(
+                    full_post["openqa"]["REPOHASH"], old_repohash, old_build
+                )
+            except SameBuildExists:
+                logger.info(
+                    "For %s aggreagate on %s there is existing build"
+                    % (self.product, arch)
+                )
+                continue
+
+            if not ignore_onetime and (
+                self.onetime and full_post["openqa"]["BUILD"].split("-")[-1] != "1"
+            ):
+                continue
+
+            settings = self.settings.copy()
+
+            # if set, we use this query to detect latest public cloud tools image which used for running
+            # all public cloud related tests in openQA
+            if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
+                query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
+                settings = apply_pc_tools_image(settings)
+                if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
+                    logger.error(
+                        f"Failed to query latest publiccloud tools image using {query}"
+                    )
+                    continue
+
+            # parse Public-Cloud image REGEX if present
+            if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
+                settings = apply_publiccloud_regex(settings)
+                if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
+                    logger.error(
+                        f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
+                    )
+                    continue
+            # parse Public-Cloud pint query if present
+            if "PUBLIC_CLOUD_PINT_QUERY" in settings:
+                settings = apply_publiccloud_pint_image(settings)
+                if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
+                    logger.error(
+                        f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
+                    )
+                    continue
+
+            full_post["openqa"].update(settings)
+            full_post["openqa"]["FLAVOR"] = self.flavor
+            full_post["openqa"]["ARCH"] = arch
+            full_post["openqa"]["_OBSOLETE"] = 1
+
+            for template, issues in test_incidents.items():
+                full_post["openqa"][template] = ",".join(str(x) for x in issues)
+            for template, issues in test_repos.items():
+                full_post["openqa"][template] = ",".join(issues)
+            for issues in test_incidents.values():
+                full_post["qem"]["incidents"] += issues
+
+            full_post["qem"]["incidents"] = [
+                str(inc) for inc in set(full_post["qem"]["incidents"])
+            ]
+
+            if not full_post["qem"]["incidents"]:
+                continue
+
+            full_post["openqa"]["__DASHBOARD_INCIDENTS_URL"] = ",".join(
+                f"https://dashboard.qam.suse.de/incident/{inc}"
+                for inc in set(full_post["qem"]["incidents"])
+            )
+            full_post["openqa"]["__SMELT_INCIDENTS_URL"] = ",".join(
+                f"https://smelt.suse.de/incident/{inc}"
+                for inc in set(full_post["qem"]["incidents"])
+            )
+
+            full_post["qem"]["settings"] = full_post["openqa"]
+            full_post["qem"]["repohash"] = full_post["openqa"]["REPOHASH"]
+            full_post["qem"]["build"] = full_post["openqa"]["BUILD"]
+            full_post["qem"]["arch"] = full_post["openqa"]["ARCH"]
+            full_post["qem"]["product"] = self.product
+
+            # add to ret
+            ret.append(full_post)
+
+        return ret

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -209,6 +209,5 @@ class Aggregate(BaseConf):
         ignore_onetime: bool = False,
     ) -> List[Dict[str, Any]]:
         return [
-            self.handle_arch(incidents, token, ci_url, ignore_onetime)
-            for arch in self.archs
+            handle_arch(incidents, token, ci_url, ignore_onetime) for arch in self.archs
         ]

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -8,7 +8,7 @@ from . import ArchVer, Repos
 from ..errors import EmptyChannels, EmptyPackagesError, NoRepoFoundError
 from ..loader.repohash import get_max_revision
 
-log = getLogger("bot.types.incident")
+logger = getLogger("bot.types.incident")
 version_pattern = re.compile(r"(\d+(?:[.-](?:SP)?\d+)?)")
 
 

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -14,7 +14,7 @@ from ..utils import retry3 as requests
 from .baseconf import BaseConf
 from .incident import Incident
 
-log = getLogger("bot.types.incidents")
+logger = getLogger("bot.types.incidents")
 
 
 class Incidents(BaseConf):
@@ -59,7 +59,7 @@ class Incidents(BaseConf):
                 headers=token,
             ).json()
         except Exception as e:
-            log.exception(e)
+            logger.exception(e)
 
         if not jobs:
             return False
@@ -132,7 +132,7 @@ class Incidents(BaseConf):
                             ArchVer(arch, self.settings["VERSION"])
                         ]
                     except KeyError:
-                        log.debug(
+                        logger.debug(
                             "Incident %s does not have %s arch in %s"
                             % (inc.id, arch, self.settings["VERSION"])
                         )
@@ -148,7 +148,7 @@ class Incidents(BaseConf):
                             channels_set.add(f_channel)
 
                     if not issue_dict:
-                        log.debug(
+                        logger.debug(
                             "No channels in %s for %s on %s" % (inc.id, flavor, arch)
                         )
                         continue
@@ -160,7 +160,7 @@ class Incidents(BaseConf):
                     if not ignore_onetime and self._is_scheduled_job(
                         token, inc, arch, self.settings["VERSION"], flavor
                     ):
-                        log.info(
+                        logger.info(
                             "not scheduling: Flavor: %s, version: %s incident: %s , arch: %s  - exists in openQA "
                             % (flavor, self.settings["VERSION"], inc.id, arch)
                         )
@@ -181,7 +181,7 @@ class Incidents(BaseConf):
                                 ]
                             )
                         ):
-                            log.warning(
+                            logger.warning(
                                 "Kernel incident %s doesn't have product repository"
                                 % str(inc)
                             )
@@ -207,10 +207,10 @@ class Incidents(BaseConf):
 
                         if pos and not pos.isdisjoint(full_post["openqa"].keys()):
                             full_post["qem"]["withAggregate"] = False
-                            log.info("Aggregate not needed for incident %s" % inc.id)
+                            logger.info("Aggregate not needed for incident %s" % inc.id)
                         if neg and neg.isdisjoint(full_post["openqa"].keys()):
                             full_post["qem"]["withAggregate"] = False
-                            log.info("Aggregate not needed for incident %s" % inc.id)
+                            logger.info("Aggregate not needed for incident %s" % inc.id)
                         if not (neg and pos):
                             full_post["qem"]["withAggregate"] = False
 
@@ -252,7 +252,7 @@ class Incidents(BaseConf):
                         query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
                         settings = apply_pc_tools_image(settings)
                         if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
-                            log.error(
+                            logger.error(
                                 f"Failed to query latest publiccloud tools image using {query}"
                             )
                             continue
@@ -261,7 +261,7 @@ class Incidents(BaseConf):
                     if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
                         settings = apply_publiccloud_regex(settings)
                         if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                            log.error(
+                            logger.error(
                                 f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
                             )
                             continue
@@ -269,7 +269,7 @@ class Incidents(BaseConf):
                     if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                         settings = apply_publiccloud_pint_image(settings)
                         if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
-                            log.error(
+                            logger.error(
                                 f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
                             )
                             continue

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -23,14 +23,6 @@ _namespace = namedtuple(
 openqa_instance_url = urlparse("http://instance.qa")
 
 
-def add_two_passed_response():
-    responses.add(
-        responses.GET,
-        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
-        json=[{"status": "passed"}, {"status": "passed"}],
-    )
-
-
 @pytest.fixture(scope="function")
 def fake_openqa_comment_api():
     responses.add(
@@ -42,18 +34,17 @@ def fake_openqa_comment_api():
 
 
 @pytest.fixture(scope="function")
-def fake_two_passed_jobs():
-    add_two_passed_response()
-
-
-@pytest.fixture(scope="function")
 def fake_responses_for_unblocking_incidents_via_openqa_comments(request):
     responses.add(
         responses.GET,
         "http://dashboard.qam.suse.de/api/jobs/update/20005",
         json=[{"status": "passed"}, {"status": "failed"}, {"status": "passed"}],
     )
-    add_two_passed_response()
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
     responses.add(
         responses.GET,
         url="http://instance.qa/api/v1/jobs/20005/comments",
@@ -67,7 +58,10 @@ def fake_qem(monkeypatch, request):
         return [IncReq(1, 100), IncReq(2, 200), IncReq(3, 300), IncReq(4, 400)]
 
     def f_inc_single_approver(token: Dict[str, str], id: int) -> List[IncReq]:
-        return [IncReq(1, 100) if id == 1 else IncReq(4, 400)]
+        if id == 1:
+            return [IncReq(1, 100)]
+        else:
+            return [IncReq(4, 400)]
 
     # inc 1 needs aggregates
     # inc 2 needs aggregates
@@ -118,22 +112,24 @@ def f_osconf(monkeypatch):
     monkeypatch.setattr(osc.conf, "get_config", fake)
 
 
-def approver(incident=None):
-    args = _namespace(True, "123", False, openqa_instance_url, incident)
-    approver = Approver(args)
-    approver.client.retries = 0
-    return approver()
-
-
 @responses.activate
 @pytest.mark.xfail(reason="Bug in responses")
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-def test_no_jobs(fake_qem, fake_two_passed_jobs, caplog):
+def test_no_jobs(fake_qem, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json={},
+    )
+    args = _namespace(True, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
     approver()
+
     assert len(caplog.records) == 42
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has at least one failed job in incident tests" in messages
+    assert "Inc 4 has failed job in incidents" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:4:400" not in messages
@@ -175,19 +171,25 @@ def test_single_incident(fake_qem, caplog):
         re.compile(r"http://dashboard.qam.suse.de/api/jobs/update/1000.*"),
         json=[{"status": "passed"}, {"status": "failed"}, {"status": "failed"}],
     )
-    approver(incident=1)
-    assert len(caplog.records) == 5
+    args = _namespace(True, "123", False, openqa_instance_url, 1)
+
+    approver = Approver(args)
+    approver()
+    assert len(caplog.records) == 4
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has at least one failed job in incident tests" in messages
+    assert "Inc 1 has failed job in incidents" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:1:100" not in messages
 
     caplog.clear()
-    approver(incident=4)
+
+    args = _namespace(True, "123", False, openqa_instance_url, 4)
+    approver = Approver(args)
+    approver()
     assert len(caplog.records) == 4
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has at least one failed job in incident tests" not in messages
+    assert "Inc 4 has failed job in incidents" not in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -195,9 +197,19 @@ def test_single_incident(fake_qem, caplog):
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-def test_all_passed(fake_qem, fake_two_passed_jobs, caplog):
+def test_all_passed(fake_qem, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(True, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+
     assert approver() == 0
+
     assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:1:100" in messages
@@ -210,8 +222,17 @@ def test_all_passed(fake_qem, fake_two_passed_jobs, caplog):
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("aggr")], indirect=True)
-def test_inc_passed_aggr_without_results(fake_qem, fake_two_passed_jobs, caplog):
+def test_inc_passed_aggr_without_results(fake_qem, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(True, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+
     assert approver() == 0
     assert len(caplog.records) == 11
     messages = [x[-1] for x in caplog.record_tuples]
@@ -226,8 +247,17 @@ def test_inc_passed_aggr_without_results(fake_qem, fake_two_passed_jobs, caplog)
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("inc")], indirect=True)
-def test_inc_without_results(fake_qem, fake_two_passed_jobs, caplog):
+def test_inc_without_results(fake_qem, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(True, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+
     assert approver() == 0
     assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
@@ -239,14 +269,23 @@ def test_inc_without_results(fake_qem, fake_two_passed_jobs, caplog):
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-def test_403_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypatch):
+def test_403_response(fake_qem, f_osconf, caplog, monkeypatch):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*args, **kwds):
         raise HTTPError("Fake OBS", 403, "Not allowed", "sd", None)
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 0
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(False, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+    assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -269,14 +308,23 @@ def test_403_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-def test_404_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypatch):
+def test_404_response(fake_qem, f_osconf, caplog, monkeypatch):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*args, **kwds):
         raise HTTPError("Fake OBS", 404, "Not allowed", "sd", None)
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 1
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(False, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+    assert approver() == 1
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -299,14 +347,23 @@ def test_404_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-def test_500_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypatch):
+def test_500_response(fake_qem, f_osconf, caplog, monkeypatch):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*args, **kwds):
         raise HTTPError("Fake OBS", 500, "Not allowed", "sd", None)
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 1
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(False, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+    assert approver() == 1
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -329,16 +386,23 @@ def test_500_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-def test_osc_unknown_exception(
-    fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypatch
-):
+def test_osc_unknown_exception(fake_qem, f_osconf, caplog, monkeypatch):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*args, **kwds):
         raise Exception("Fake OBS exception")
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 1
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(False, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+    assert approver() == 1
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -361,14 +425,23 @@ def test_osc_unknown_exception(
 
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-def test_osc_all_pass(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypatch):
+def test_osc_all_pass(fake_qem, f_osconf, caplog, monkeypatch):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*args, **kwds):
         pass
 
     monkeypatch.setattr(osc.core, "change_review_state", f_osc_core)
-    assert Approver(_namespace(False, "123", False, openqa_instance_url, None))() == 0
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(False, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+    assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert messages == [
         "Start approving incidents in IBS",
@@ -385,31 +458,32 @@ def test_osc_all_pass(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
     ]
 
 
-@pytest.fixture(scope="function")
-def fake_incident_1_failed_2_passed(request):
-    responses.add(
-        responses.GET,
-        "http://dashboard.qam.suse.de/api/jobs/incident/%s" % request.param,
-        json=[{"status": "passed"}, {"status": "failed"}, {"status": "passed"}],
-    )
-    add_two_passed_response()
-
-
 @responses.activate
 @pytest.mark.parametrize("fake_qem", [("NoResultsError isn't raised")], indirect=True)
-@pytest.mark.parametrize("fake_incident_1_failed_2_passed", [1005], indirect=True)
-def test_one_incident_failed(
-    fake_qem,
-    fake_incident_1_failed_2_passed,
-    fake_two_passed_jobs,
-    fake_openqa_comment_api,
-    caplog,
-):
+def test_one_incident_failed(fake_qem, fake_openqa_comment_api, caplog):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
+
+    responses.add(
+        responses.GET,
+        "http://dashboard.qam.suse.de/api/jobs/incident/1005",
+        json=[{"status": "passed"}, {"status": "failed"}, {"status": "passed"}],
+    )
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(True, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+    approver.client.retries = 0
+
     assert approver() == 0
-    assert len(caplog.records) == 8
+
+    assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has at least one failed job in incident tests" in messages
+    assert "Inc 1 has failed job in incidents" in messages
     assert "SUSE:Maintenance:2:200" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -427,11 +501,22 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
         "http://dashboard.qam.suse.de/api/jobs/update/20005",
         json=[{"status": "passed"}, {"status": "failed"}, {"status": "passed"}],
     )
-    add_two_passed_response()
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://dashboard.qam.suse.de/api/jobs/.*/.*"),
+        json=[{"status": "passed"}, {"status": "passed"}],
+    )
+    args = _namespace(True, "123", False, openqa_instance_url, None)
+
+    approver = Approver(args)
+    approver.client.retries = 0
+
     assert approver() == 0
-    assert len(caplog.records) == 8
+
+    assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 2 has failed job in aggregate tests" in messages
+    assert "Inc 2 has failed job in aggregates" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -451,6 +536,8 @@ def test_approval_unblocked_via_openqa_comment(
     caplog,
 ):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
+    approver = Approver(_namespace(True, "123", False, openqa_instance_url, None))
+    approver.client.retries = 0
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:2:200" in messages
@@ -469,6 +556,8 @@ def test_approval_still_blocked_if_openqa_comment_not_relevant(
     caplog,
 ):
     caplog.set_level(logging.DEBUG, logger="bot.approver")
+    approver = Approver(_namespace(True, "123", False, openqa_instance_url, None))
+    approver.client.retries = 0
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:2:200" not in messages

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -431,7 +431,7 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
     assert approver() == 0
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 2 has at least one failed job in aggregate tests" in messages
+    assert "Inc 2 has failed job in aggregate tests" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,6 @@
 import pytest
 import responses
-
-has_registries = False
-try:
-    from responses import registries
-
-    has_registries = True
-except ImportError as e:
-    import logging
-
-    logging.info(str(e) + ": Likely older python version")
-
+from responses import registries
 from openqabot.utils import walk, normalize_results, retry3
 
 
@@ -89,14 +79,12 @@ def test_walk(data, result):
     assert result == ret
 
 
-if has_registries:
+@responses.activate(registry=registries.OrderedRegistry)
+def test_retry3():
+    rsp1 = responses.add(responses.GET, "http://host.some", status=503)
+    rsp2 = responses.add(responses.GET, "http://host.some", status=503)
+    rsp3 = responses.add(responses.GET, "http://host.some", status=200)
 
-    @responses.activate(registry=registries.OrderedRegistry)
-    def test_retry3():
-        rsp1 = responses.add(responses.GET, "http://host.some", status=503)
-        rsp2 = responses.add(responses.GET, "http://host.some", status=503)
-        rsp3 = responses.add(responses.GET, "http://host.some", status=200)
-
-        req = retry3.get("http://host.some")
-        assert req.status_code == 200
-        assert rsp3.call_count == 1
+    req = retry3.get("http://host.some")
+    assert req.status_code == 200
+    assert rsp3.call_count == 1


### PR DESCRIPTION
This reverts #84, #87, #88 and #89. Apparently there's still a regression and instead of fixing it up more I'm proposing to go back and add test coverage first.

See: https://progress.opensuse.org/issues/120939