### PR TITLE
Update setup-python action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
           cache: 'pip'


### PR DESCRIPTION
There are some deprecation warnings:
https://github.com/openSUSE/qem-bot/actions/runs/3627993901

    Warning: The `set-output` command is deprecated and will be disabled soon. ...
    Warning: The `save-state` command is deprecated and will be disabled soon. ...