### PR TITLE
Enhance JobAggr to also have openQA job id and use it

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -119,7 +119,7 @@ class Approver:
     def is_job_marked_acceptable_for_incident(self, job: JobAggr, inc: int) -> bool:
         regex = re.compile(r"\@review\:acceptable_for\:incident_%s\:(.+)" % inc)
         try:
-            for comment in self.client.get_job_comments(job.job_id):
+            for comment in self.client.get_job_comments(job.openqa_id):
                 if regex.match(comment["text"]):
                     return True
         except RequestError:
@@ -140,18 +140,18 @@ class Approver:
             if self.is_job_marked_acceptable_for_incident(job, inc):
                 log.info(
                     "Ignoring failed job %s for incident %s due to openQA comment"
-                    % (job.job_id, inc)
+                    % (job.openqa_id, inc)
                 )
                 res["status"] = "passed"
             else:
                 log.info(
                     "Found failed, not-ignored job %s for incident %s"
-                    % (job.job_id, inc)
+                    % (job.openqa_id, inc)
                 )
                 break
 
         if not results:
-            raise NoResultsError("Job %s not found " % str(job.job_id))
+            raise NoResultsError("Job %s not found " % str(job.openqa_id))
 
         return all(r["status"] == "passed" for r in results)
 

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -29,6 +29,7 @@ class IncReq(NamedTuple):
 
 class JobAggr(NamedTuple):
     job_id: int
+    openqa_id: int
     aggregate: bool
     withAggregate: bool
 
@@ -91,7 +92,7 @@ def get_incident_settings(
             rrid = rrid[-1]
             settings = [s for s in settings if s["settings"].get("RRID", rrid) == rrid]
 
-    return [JobAggr(i["id"], False, i["withAggregate"]) for i in settings]
+    return [JobAggr(i["id"], i["job_id"], False, i["withAggregate"]) for i in settings]
 
 
 def get_incident_settings_data(token: Dict[str, str], number: int) -> Sequence[Data]:
@@ -158,7 +159,11 @@ def get_aggregate_settings(inc: int, token: Dict[str, str]) -> List[JobAggr]:
     # use all data from day (some jobs have set onetime=True)
     # which causes need to use data from both runs
     last_build = settings[0]["build"][:-2]
-    return [JobAggr(i["id"], True, False) for i in settings if last_build in i["build"]]
+    return [
+        JobAggr(i["id"], i["job_id"], True, False)
+        for i in settings
+        if last_build in i["build"]
+    ]
 
 
 def get_aggregate_settings_data(token: Dict[str, str], data: Data):

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -56,7 +56,7 @@ def fake_responses_for_unblocking_incidents_via_openqa_comments(request):
     add_two_passed_response()
     responses.add(
         responses.GET,
-        url="http://instance.qa/api/v1/jobs/20005/comments",
+        url="http://instance.qa/api/v1/jobs/120005/comments",
         json=[{"text": "@review:acceptable_for:incident_%s:foo" % request.param}],
     )
 
@@ -78,16 +78,16 @@ def fake_qem(monkeypatch, request):
         if "inc" in request.param:
             raise NoResultsError("No results for settings")
         results = {
-            1: [JobAggr(i, False, True) for i in range(1000, 1010)],
-            2: [JobAggr(i, False, True) for i in range(2000, 2010)],
+            1: [JobAggr(i, 100000 + i, False, True) for i in range(1000, 1010)],
+            2: [JobAggr(i, 100000 + i, False, True) for i in range(2000, 2010)],
             3: [
-                JobAggr(3000, False, False),
-                JobAggr(3001, False, False),
-                JobAggr(3002, False, True),
-                JobAggr(3002, False, False),
-                JobAggr(3003, False, True),
+                JobAggr(3000, 103000, False, False),
+                JobAggr(3001, 103001, False, False),
+                JobAggr(3002, 103002, False, True),
+                JobAggr(3002, 103002, False, False),
+                JobAggr(3003, 103003, False, True),
             ],
-            4: [JobAggr(i, False, False) for i in range(4000, 4010)],
+            4: [JobAggr(i, 100000 + i, False, False) for i in range(4000, 4010)],
         }
         return results.get(inc, None)
 
@@ -96,9 +96,9 @@ def fake_qem(monkeypatch, request):
             raise NoResultsError("No results for settings")
         results = {
             4: [],
-            1: [JobAggr(i, True, False) for i in range(10000, 10010)],
-            2: [JobAggr(i, True, False) for i in range(20000, 20010)],
-            3: [JobAggr(i, True, False) for i in range(30000, 30010)],
+            1: [JobAggr(i, 100000 + i, True, False) for i in range(10000, 10010)],
+            2: [JobAggr(i, 100000 + i, True, False) for i in range(20000, 20010)],
+            3: [JobAggr(i, 100000 + i, True, False) for i in range(30000, 30010)],
         }
         return results.get(inc, None)
 
@@ -179,7 +179,7 @@ def test_single_incident(fake_qem, caplog):
     assert len(caplog.records) == 5
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
-    assert "Found failed, not-ignored job 1000 for incident 1" in messages
+    assert "Found failed, not-ignored job 101000 for incident 1" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:1:100" not in messages
@@ -411,7 +411,7 @@ def test_one_incident_failed(
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
-    assert "Found failed, not-ignored job 1005 for incident 1" in messages
+    assert "Found failed, not-ignored job 101005 for incident 1" in messages
     assert "SUSE:Maintenance:2:200" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -434,7 +434,7 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 2 has at least one failed job in aggregate tests" in messages
-    assert "Found failed, not-ignored job 20005 for incident 2" in messages
+    assert "Found failed, not-ignored job 120005 for incident 2" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -457,7 +457,7 @@ def test_approval_unblocked_via_openqa_comment(
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:2:200" in messages
-    assert "Ignoring failed job 20005 for incident 2 due to openQA comment" in messages
+    assert "Ignoring failed job 120005 for incident 2 due to openQA comment" in messages
 
 
 @responses.activate

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -179,6 +179,7 @@ def test_single_incident(fake_qem, caplog):
     assert len(caplog.records) == 5
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
+    assert "Found failed, not-ignored job 1000 for incident 1" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:1:100" not in messages
@@ -410,6 +411,7 @@ def test_one_incident_failed(
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
+    assert "Found failed, not-ignored job 1005 for incident 1" in messages
     assert "SUSE:Maintenance:2:200" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -432,6 +434,7 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 2 has at least one failed job in aggregate tests" in messages
+    assert "Found failed, not-ignored job 20005 for incident 2" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages


### PR DESCRIPTION
Use openQA job id instead of dashboard openqa_jobs.id where applicable. This will also fix unblocking incidents with openQA comment.

Reference: https://progress.opensuse.org/issues/122308