### PR TITLE
Revert "Enhance JobAggr to also have openQA job id and use it"

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -119,7 +119,7 @@ class Approver:
     def is_job_marked_acceptable_for_incident(self, job: JobAggr, inc: int) -> bool:
         regex = re.compile(r"\@review\:acceptable_for\:incident_%s\:(.+)" % inc)
         try:
-            for comment in self.client.get_job_comments(job.openqa_id):
+            for comment in self.client.get_job_comments(job.job_id):
                 if regex.match(comment["text"]):
                     return True
         except RequestError:
@@ -140,18 +140,18 @@ class Approver:
             if self.is_job_marked_acceptable_for_incident(job, inc):
                 log.info(
                     "Ignoring failed job %s for incident %s due to openQA comment"
-                    % (job.openqa_id, inc)
+                    % (job.job_id, inc)
                 )
                 res["status"] = "passed"
             else:
                 log.info(
                     "Found failed, not-ignored job %s for incident %s"
-                    % (job.openqa_id, inc)
+                    % (job.job_id, inc)
                 )
                 break
 
         if not results:
-            raise NoResultsError("Job %s not found " % str(job.openqa_id))
+            raise NoResultsError("Job %s not found " % str(job.job_id))
 
         return all(r["status"] == "passed" for r in results)
 

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -29,7 +29,6 @@ class IncReq(NamedTuple):
 
 class JobAggr(NamedTuple):
     job_id: int
-    openqa_id: int
     aggregate: bool
     withAggregate: bool
 
@@ -92,7 +91,7 @@ def get_incident_settings(
             rrid = rrid[-1]
             settings = [s for s in settings if s["settings"].get("RRID", rrid) == rrid]
 
-    return [JobAggr(i["id"], i["job_id"], False, i["withAggregate"]) for i in settings]
+    return [JobAggr(i["id"], False, i["withAggregate"]) for i in settings]
 
 
 def get_incident_settings_data(token: Dict[str, str], number: int) -> Sequence[Data]:
@@ -159,11 +158,7 @@ def get_aggregate_settings(inc: int, token: Dict[str, str]) -> List[JobAggr]:
     # use all data from day (some jobs have set onetime=True)
     # which causes need to use data from both runs
     last_build = settings[0]["build"][:-2]
-    return [
-        JobAggr(i["id"], i["job_id"], True, False)
-        for i in settings
-        if last_build in i["build"]
-    ]
+    return [JobAggr(i["id"], True, False) for i in settings if last_build in i["build"]]
 
 
 def get_aggregate_settings_data(token: Dict[str, str], data: Data):

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -56,7 +56,7 @@ def fake_responses_for_unblocking_incidents_via_openqa_comments(request):
     add_two_passed_response()
     responses.add(
         responses.GET,
-        url="http://instance.qa/api/v1/jobs/120005/comments",
+        url="http://instance.qa/api/v1/jobs/20005/comments",
         json=[{"text": "@review:acceptable_for:incident_%s:foo" % request.param}],
     )
 
@@ -78,16 +78,16 @@ def fake_qem(monkeypatch, request):
         if "inc" in request.param:
             raise NoResultsError("No results for settings")
         results = {
-            1: [JobAggr(i, 100000 + i, False, True) for i in range(1000, 1010)],
-            2: [JobAggr(i, 100000 + i, False, True) for i in range(2000, 2010)],
+            1: [JobAggr(i, False, True) for i in range(1000, 1010)],
+            2: [JobAggr(i, False, True) for i in range(2000, 2010)],
             3: [
-                JobAggr(3000, 103000, False, False),
-                JobAggr(3001, 103001, False, False),
-                JobAggr(3002, 103002, False, True),
-                JobAggr(3002, 103002, False, False),
-                JobAggr(3003, 103003, False, True),
+                JobAggr(3000, False, False),
+                JobAggr(3001, False, False),
+                JobAggr(3002, False, True),
+                JobAggr(3002, False, False),
+                JobAggr(3003, False, True),
             ],
-            4: [JobAggr(i, 100000 + i, False, False) for i in range(4000, 4010)],
+            4: [JobAggr(i, False, False) for i in range(4000, 4010)],
         }
         return results.get(inc, None)
 
@@ -96,9 +96,9 @@ def fake_qem(monkeypatch, request):
             raise NoResultsError("No results for settings")
         results = {
             4: [],
-            1: [JobAggr(i, 100000 + i, True, False) for i in range(10000, 10010)],
-            2: [JobAggr(i, 100000 + i, True, False) for i in range(20000, 20010)],
-            3: [JobAggr(i, 100000 + i, True, False) for i in range(30000, 30010)],
+            1: [JobAggr(i, True, False) for i in range(10000, 10010)],
+            2: [JobAggr(i, True, False) for i in range(20000, 20010)],
+            3: [JobAggr(i, True, False) for i in range(30000, 30010)],
         }
         return results.get(inc, None)
 
@@ -179,7 +179,6 @@ def test_single_incident(fake_qem, caplog):
     assert len(caplog.records) == 5
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
-    assert "Found failed, not-ignored job 101000 for incident 1" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "SUSE:Maintenance:1:100" not in messages
@@ -411,7 +410,6 @@ def test_one_incident_failed(
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
-    assert "Found failed, not-ignored job 101005 for incident 1" in messages
     assert "SUSE:Maintenance:2:200" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -434,7 +432,6 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 2 has at least one failed job in aggregate tests" in messages
-    assert "Found failed, not-ignored job 120005 for incident 2" in messages
     assert "SUSE:Maintenance:1:100" in messages
     assert "SUSE:Maintenance:3:300" in messages
     assert "SUSE:Maintenance:4:400" in messages
@@ -457,7 +454,7 @@ def test_approval_unblocked_via_openqa_comment(
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert "SUSE:Maintenance:2:200" in messages
-    assert "Ignoring failed job 120005 for incident 2 due to openQA comment" in messages
+    assert "Ignoring failed job 20005 for incident 2 due to openQA comment" in messages
 
 
 @responses.activate


### PR DESCRIPTION
Reverts openSUSE/qem-bot#105 due to issues like

```
++ ./qem-bot/bot-ng.py -c /etc/openqabot --token [MASKED] inc-approve
++ tee bot_inc-approve_0.log
2023-01-02 09:04:41 INFO     Start approving incidents in IBS
Traceback (most recent call last):
  File "./qem-bot/bot-ng.py", line 7, in <module>
    main()
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/main.py", line 43, in main
    sys.exit(cfg.func(cfg))
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/args.py", line 49, in do_approve
    return approve()
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/approver.py", line 69, in __call__
    incidents_to_approve = [inc for inc in increqs if self._approvable(inc)]
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/approver.py", line 69, in <listcomp>
    incidents_to_approve = [inc for inc in increqs if self._approvable(inc)]
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/approver.py", line 86, in _approvable
    i_jobs = get_incident_settings(inc.inc, self.token, self.all_incidents)
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/loader/qem.py", line 95, in get_incident_settings
    return [JobAggr(i["id"], i["job_id"], False, i["withAggregate"]) for i in settings]
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/loader/qem.py", line 95, in <listcomp>
    return [JobAggr(i["id"], i["job_id"], False, i["withAggregate"]) for i in settings]
KeyError: 'job_id'
```

See https://gitlab.suse.de/qa-maintenance/bot-ng/-/jobs/1319382