### PR TITLE
Revert "Avoid retrying comment fetching"

### DIFF
--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -70,7 +70,7 @@ class openQAInterface:
         ret = []
         try:
             ret = self.openqa.openqa_request(
-                "GET", "jobs/%s/comments" % job_id, retries=0
+                "GET", "jobs/%s/comments" % job_id, retries=self.retries
             )
             ret = list(map(lambda c: {"text": c.get("text", "")}, ret))
         except Exception as e:


### PR DESCRIPTION
This reverts commit f41b07078c1b9854eccb458bb94317724e2fd4c3.

We should be able to use retry again as openQA-python-client will not retry for 404 anymore.

References:
* https://progress.opensuse.org/issues/107923#note-35
* https://github.com/os-autoinst/openQA-python-client/pull/34