### PR TITLE
Improve logs from Approver

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -43,7 +43,7 @@ def _handle_http_error(e: HTTPError, inc: IncReq) -> bool:
         return False
     else:
         log.error(
-            "Recived error %s, reason: '%s' for Request %s - problem on OBS side"
+            "Received error %s, reason: '%s' for Request %s - problem on OBS side"
             % (e.code, e.reason, inc.req)
         )
         return False

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -70,7 +70,7 @@ class Approver:
 
         log.info("Incidents to approve:")
         for inc in incidents_to_approve:
-            log.info(OBS_MAINT_PRJ + ":%s:%s" % (str(inc.inc), str(inc.req)))
+            log.info("* %s:%s:%s" % (OBS_MAINT_PRJ, str(inc.inc), str(inc.req)))
 
         if not self.dry:
             osc.conf.get_config(override_apiurl=OBS_URL)

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -140,14 +140,14 @@ class Approver:
                 continue
             if self.is_job_marked_acceptable_for_incident(res["job_id"], inc):
                 log.info(
-                    "Ignoring failed job %s for incident %s due to openQA comment"
-                    % (res["job_id"], inc)
+                    "Ignoring failed job %s/t%s for incident %s due to openQA comment"
+                    % (str(self.client.url.geturl()), res["job_id"], inc)
                 )
                 res["status"] = "passed"
             else:
                 log.info(
-                    "Found failed, not-ignored job %s for incident %s"
-                    % (res["job_id"], inc)
+                    "Found failed, not-ignored job %s/t%s for incident %s"
+                    % (str(self.client.url.geturl()), res["job_id"], inc)
                 )
                 break
 

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -66,7 +66,7 @@ class openQAInterface:
         return ret
 
     @lru_cache(maxsize=512)
-    def get_job_comments(self, job_id: int):
+    def get_job_comments(self, job_id: int) -> list[str]:
         ret = []
         try:
             ret = self.openqa.openqa_request(
@@ -75,7 +75,9 @@ class openQAInterface:
             ret = list(map(lambda c: {"text": c.get("text", "")}, ret))
         except Exception as e:
             (method, url, status_code) = e.args
-            if status_code != 404:
+            if status_code == 404:
+                log.info("Job %s not found in openQA" % job_id)
+            else:
                 log.exception(e)
         return ret
 

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -193,7 +193,10 @@ def test_single_incident(fake_qem, caplog):
         "SUSE:Maintenance:1:100 has at least one failed job in incident tests"
         in messages
     )
-    assert "Found failed, not-ignored job 100001 for incident 1" in messages
+    assert (
+        "Found failed, not-ignored job http://instance.qa/t100001 for incident 1"
+        in messages
+    )
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "* SUSE:Maintenance:1:100" not in messages
@@ -435,7 +438,10 @@ def test_one_incident_failed(
         "SUSE:Maintenance:1:100 has at least one failed job in incident tests"
         in messages
     )
-    assert "Found failed, not-ignored job 100001 for incident 1" in messages
+    assert (
+        "Found failed, not-ignored job http://instance.qa/t100001 for incident 1"
+        in messages
+    )
     assert "* SUSE:Maintenance:2:200" in messages
     assert "* SUSE:Maintenance:3:300" in messages
     assert "* SUSE:Maintenance:4:400" in messages
@@ -465,7 +471,10 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
         "SUSE:Maintenance:2:200 has at least one failed job in aggregate tests"
         in messages
     )
-    assert "Found failed, not-ignored job 100001 for incident 2" in messages
+    assert (
+        "Found failed, not-ignored job http://instance.qa/t100001 for incident 2"
+        in messages
+    )
     assert "* SUSE:Maintenance:1:100" in messages
     assert "* SUSE:Maintenance:3:300" in messages
     assert "* SUSE:Maintenance:4:400" in messages
@@ -488,7 +497,10 @@ def test_approval_unblocked_via_openqa_comment(
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
     assert "* SUSE:Maintenance:2:200" in messages
-    assert "Ignoring failed job 100002 for incident 2 due to openQA comment" in messages
+    assert (
+        "Ignoring failed job http://instance.qa/t100002 for incident 2 due to openQA comment"
+        in messages
+    )
 
 
 @responses.activate

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -73,8 +73,8 @@ def fake_qem(monkeypatch, request):
     def f_inc_single_approver(token: Dict[str, str], id: int) -> List[IncReq]:
         return [IncReq(1, 100) if id == 1 else IncReq(4, 400)]
 
-    # inc 1 needs aggregates
-    # inc 2 needs aggregates
+    # Inc 1 needs aggregates
+    # Inc 2 needs aggregates
     # Inc 3 part needs aggregates
     # Inc 4 dont need aggregates
 

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -137,7 +137,10 @@ def test_no_jobs(fake_qem, fake_two_passed_jobs, caplog):
     approver()
     assert len(caplog.records) == 42
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has at least one failed job in incident tests" in messages
+    assert (
+        "SUSE:Maintenance:4:400 has at least one failed job in incident tests"
+        in messages
+    )
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "* SUSE:Maintenance:4:400" not in messages
@@ -186,7 +189,10 @@ def test_single_incident(fake_qem, caplog):
     approver(incident=1)
     assert len(caplog.records) == 5
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has at least one failed job in incident tests" in messages
+    assert (
+        "SUSE:Maintenance:1:100 has at least one failed job in incident tests"
+        in messages
+    )
     assert "Found failed, not-ignored job 100001 for incident 1" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
@@ -196,7 +202,10 @@ def test_single_incident(fake_qem, caplog):
     approver(incident=4)
     assert len(caplog.records) == 4
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 4 has at least one failed job in incident tests" not in messages
+    assert (
+        "SUSE:Maintenance:4:400 has at least one failed job in incident tests"
+        not in messages
+    )
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
     assert "* SUSE:Maintenance:4:400" in messages
@@ -225,9 +234,9 @@ def test_inc_passed_aggr_without_results(fake_qem, fake_two_passed_jobs, caplog)
     assert len(caplog.records) == 11
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Start approving incidents in IBS" in messages
-    assert "Aggregate missing for 1" in messages
-    assert "Aggregate missing for 2" in messages
-    assert "Aggregate missing for 3" in messages
+    assert "Aggregate missing for SUSE:Maintenance:1:100" in messages
+    assert "Aggregate missing for SUSE:Maintenance:2:200" in messages
+    assert "Aggregate missing for SUSE:Maintenance:3:300" in messages
     assert "Incidents to approve:" in messages
     assert "* SUSE:Maintenance:4:400" in messages
     assert "End of bot run" in messages
@@ -422,7 +431,10 @@ def test_one_incident_failed(
     assert approver() == 0
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 1 has at least one failed job in incident tests" in messages
+    assert (
+        "SUSE:Maintenance:1:100 has at least one failed job in incident tests"
+        in messages
+    )
     assert "Found failed, not-ignored job 100001 for incident 1" in messages
     assert "* SUSE:Maintenance:2:200" in messages
     assert "* SUSE:Maintenance:3:300" in messages
@@ -449,7 +461,10 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
     assert approver() == 0
     assert len(caplog.records) == 8
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "Inc 2 has at least one failed job in aggregate tests" in messages
+    assert (
+        "SUSE:Maintenance:2:200 has at least one failed job in aggregate tests"
+        in messages
+    )
     assert "Found failed, not-ignored job 100001 for incident 2" in messages
     assert "* SUSE:Maintenance:1:100" in messages
     assert "* SUSE:Maintenance:3:300" in messages

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -140,7 +140,7 @@ def test_no_jobs(fake_qem, fake_two_passed_jobs, caplog):
     assert "Inc 4 has at least one failed job in incident tests" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
-    assert "SUSE:Maintenance:4:400" not in messages
+    assert "* SUSE:Maintenance:4:400" not in messages
 
 
 @responses.activate
@@ -190,7 +190,7 @@ def test_single_incident(fake_qem, caplog):
     assert "Found failed, not-ignored job 100001 for incident 1" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
-    assert "SUSE:Maintenance:1:100" not in messages
+    assert "* SUSE:Maintenance:1:100" not in messages
 
     caplog.clear()
     approver(incident=4)
@@ -199,7 +199,7 @@ def test_single_incident(fake_qem, caplog):
     assert "Inc 4 has at least one failed job in incident tests" not in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
-    assert "SUSE:Maintenance:4:400" in messages
+    assert "* SUSE:Maintenance:4:400" in messages
 
 
 @responses.activate
@@ -209,10 +209,10 @@ def test_all_passed(fake_qem, fake_two_passed_jobs, caplog):
     assert approver() == 0
     assert len(caplog.records) == 7
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "SUSE:Maintenance:1:100" in messages
-    assert "SUSE:Maintenance:2:200" in messages
-    assert "SUSE:Maintenance:3:300" in messages
-    assert "SUSE:Maintenance:4:400" in messages
+    assert "* SUSE:Maintenance:1:100" in messages
+    assert "* SUSE:Maintenance:2:200" in messages
+    assert "* SUSE:Maintenance:3:300" in messages
+    assert "* SUSE:Maintenance:4:400" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
 
@@ -229,7 +229,7 @@ def test_inc_passed_aggr_without_results(fake_qem, fake_two_passed_jobs, caplog)
     assert "Aggregate missing for 2" in messages
     assert "Aggregate missing for 3" in messages
     assert "Incidents to approve:" in messages
-    assert "SUSE:Maintenance:4:400" in messages
+    assert "* SUSE:Maintenance:4:400" in messages
     assert "End of bot run" in messages
 
 
@@ -242,7 +242,7 @@ def test_inc_without_results(fake_qem, fake_two_passed_jobs, caplog):
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Start approving incidents in IBS" in messages
     assert "Incidents to approve:" in messages
-    assert "SUSE:Maintenance" not in messages
+    assert "* SUSE:Maintenance" not in messages
     assert "End of bot run" in messages
 
 
@@ -260,10 +260,10 @@ def test_403_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
     assert messages == [
         "Start approving incidents in IBS",
         "Incidents to approve:",
-        "SUSE:Maintenance:1:100",
-        "SUSE:Maintenance:2:200",
-        "SUSE:Maintenance:3:300",
-        "SUSE:Maintenance:4:400",
+        "* SUSE:Maintenance:1:100",
+        "* SUSE:Maintenance:2:200",
+        "* SUSE:Maintenance:3:300",
+        "* SUSE:Maintenance:4:400",
         "Accepting review for SUSE:Maintenance:1:100",
         "Received 'Not allowed'. Request 100 likely already approved, ignoring",
         "Accepting review for SUSE:Maintenance:2:200",
@@ -290,10 +290,10 @@ def test_404_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
     assert messages == [
         "Start approving incidents in IBS",
         "Incidents to approve:",
-        "SUSE:Maintenance:1:100",
-        "SUSE:Maintenance:2:200",
-        "SUSE:Maintenance:3:300",
-        "SUSE:Maintenance:4:400",
+        "* SUSE:Maintenance:1:100",
+        "* SUSE:Maintenance:2:200",
+        "* SUSE:Maintenance:3:300",
+        "* SUSE:Maintenance:4:400",
         "Accepting review for SUSE:Maintenance:1:100",
         "Received 'Not allowed'. Request 100 removed or problem on OBS side, ignoring",
         "Accepting review for SUSE:Maintenance:2:200",
@@ -320,18 +320,18 @@ def test_500_response(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
     assert messages == [
         "Start approving incidents in IBS",
         "Incidents to approve:",
-        "SUSE:Maintenance:1:100",
-        "SUSE:Maintenance:2:200",
-        "SUSE:Maintenance:3:300",
-        "SUSE:Maintenance:4:400",
+        "* SUSE:Maintenance:1:100",
+        "* SUSE:Maintenance:2:200",
+        "* SUSE:Maintenance:3:300",
+        "* SUSE:Maintenance:4:400",
         "Accepting review for SUSE:Maintenance:1:100",
-        "Recived error 500, reason: 'Not allowed' for Request 100 - problem on OBS side",
+        "Received error 500, reason: 'Not allowed' for Request 100 - problem on OBS side",
         "Accepting review for SUSE:Maintenance:2:200",
-        "Recived error 500, reason: 'Not allowed' for Request 200 - problem on OBS side",
+        "Received error 500, reason: 'Not allowed' for Request 200 - problem on OBS side",
         "Accepting review for SUSE:Maintenance:3:300",
-        "Recived error 500, reason: 'Not allowed' for Request 300 - problem on OBS side",
+        "Received error 500, reason: 'Not allowed' for Request 300 - problem on OBS side",
         "Accepting review for SUSE:Maintenance:4:400",
-        "Recived error 500, reason: 'Not allowed' for Request 400 - problem on OBS side",
+        "Received error 500, reason: 'Not allowed' for Request 400 - problem on OBS side",
         "End of bot run",
     ]
 
@@ -352,10 +352,10 @@ def test_osc_unknown_exception(
     assert messages == [
         "Start approving incidents in IBS",
         "Incidents to approve:",
-        "SUSE:Maintenance:1:100",
-        "SUSE:Maintenance:2:200",
-        "SUSE:Maintenance:3:300",
-        "SUSE:Maintenance:4:400",
+        "* SUSE:Maintenance:1:100",
+        "* SUSE:Maintenance:2:200",
+        "* SUSE:Maintenance:3:300",
+        "* SUSE:Maintenance:4:400",
         "Accepting review for SUSE:Maintenance:1:100",
         "Fake OBS exception",
         "Accepting review for SUSE:Maintenance:2:200",
@@ -382,10 +382,10 @@ def test_osc_all_pass(fake_qem, fake_two_passed_jobs, f_osconf, caplog, monkeypa
     assert messages == [
         "Start approving incidents in IBS",
         "Incidents to approve:",
-        "SUSE:Maintenance:1:100",
-        "SUSE:Maintenance:2:200",
-        "SUSE:Maintenance:3:300",
-        "SUSE:Maintenance:4:400",
+        "* SUSE:Maintenance:1:100",
+        "* SUSE:Maintenance:2:200",
+        "* SUSE:Maintenance:3:300",
+        "* SUSE:Maintenance:4:400",
         "Accepting review for SUSE:Maintenance:1:100",
         "Accepting review for SUSE:Maintenance:2:200",
         "Accepting review for SUSE:Maintenance:3:300",
@@ -424,9 +424,9 @@ def test_one_incident_failed(
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 1 has at least one failed job in incident tests" in messages
     assert "Found failed, not-ignored job 100001 for incident 1" in messages
-    assert "SUSE:Maintenance:2:200" in messages
-    assert "SUSE:Maintenance:3:300" in messages
-    assert "SUSE:Maintenance:4:400" in messages
+    assert "* SUSE:Maintenance:2:200" in messages
+    assert "* SUSE:Maintenance:3:300" in messages
+    assert "* SUSE:Maintenance:4:400" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
 
@@ -451,9 +451,9 @@ def test_one_aggr_failed(fake_qem, fake_openqa_comment_api, caplog):
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Inc 2 has at least one failed job in aggregate tests" in messages
     assert "Found failed, not-ignored job 100001 for incident 2" in messages
-    assert "SUSE:Maintenance:1:100" in messages
-    assert "SUSE:Maintenance:3:300" in messages
-    assert "SUSE:Maintenance:4:400" in messages
+    assert "* SUSE:Maintenance:1:100" in messages
+    assert "* SUSE:Maintenance:3:300" in messages
+    assert "* SUSE:Maintenance:4:400" in messages
     assert "Incidents to approve:" in messages
     assert "End of bot run" in messages
 
@@ -472,7 +472,7 @@ def test_approval_unblocked_via_openqa_comment(
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "SUSE:Maintenance:2:200" in messages
+    assert "* SUSE:Maintenance:2:200" in messages
     assert "Ignoring failed job 100002 for incident 2 due to openQA comment" in messages
 
 
@@ -490,4 +490,4 @@ def test_approval_still_blocked_if_openqa_comment_not_relevant(
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
-    assert "SUSE:Maintenance:2:200" not in messages
+    assert "* SUSE:Maintenance:2:200" not in messages


### PR DESCRIPTION
* Log nonexistent openQA jobs
* Show links to failed openQA jobs
* Use both the incident and release request numbers in approval context
* Show incident numbers in all messages related to openQA tests
* Output a (markdown) list when listing incidents to approve
* Fix typo in log message
