### PR TITLE
pc_helper: Add tests and cleanup unused code

### DIFF
--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -31,17 +31,20 @@ def fetch_matching_link(url, regex):
     raise ValueError("No matching links found")
 
 
-# Gets the latest image from the given URL/regex
-# image is of the format 'URL/regex'
 def get_latest_pc_image(image):
+    """
+    Gets the latest image from the given URL/regex image is of the format 'URL/regex'
+    """
     basepath, _, regex = image.rpartition("/")
     return fetch_matching_link(basepath, re.compile(regex))
 
 
 def get_latest_tools_image(query):
-    # 'publiccloud_tools_<BUILD NUM>.qcow2' is generic name for image used by Public Cloud tests to run
-    # in openQA. query suppose to look like this "https://openqa.suse.de/group_overview/276.json" to get
-    # value for <BUILD NUM>
+    """
+    'publiccloud_tools_<BUILD NUM>.qcow2' is a generic name for an image used by Public Cloud tests to run
+    in openQA. A query is supposed to look like this "https://openqa.suse.de/group_overview/276.json" to get
+    a value for <BUILD NUM>
+    """
 
     ## Get the first not-failing item
     build_results = requests.get(query).json()["build_results"]
@@ -51,8 +54,10 @@ def get_latest_tools_image(query):
     return None
 
 
-# Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
 def apply_publiccloud_regex(settings):
+    """
+    Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
+    """
     try:
         settings["PUBLIC_CLOUD_IMAGE_LOCATION"] = get_latest_pc_image(
             settings["PUBLIC_CLOUD_IMAGE_REGEX"]
@@ -65,6 +70,10 @@ def apply_publiccloud_regex(settings):
 
 
 def apply_pc_tools_image(settings):
+    """
+    Use PUBLIC_CLOUD_TOOLS_IMAGE_QUERY to get latest tools image and set it into
+    PUBLIC_CLOUD_TOOLS_IMAGE_BASE
+    """
     try:
         if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
             settings["PUBLIC_CLOUD_TOOLS_IMAGE_BASE"] = get_latest_tools_image(
@@ -77,14 +86,18 @@ def apply_pc_tools_image(settings):
         return settings
 
 
-# Perform a pint query. Sucessive queries are cached
 @lru_cache(maxsize=None)
 def pint_query(query):
+    """
+    Perform a pint query. Sucessive queries are cached
+    """
     return requests.get(query).json()
 
 
-# Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
 def apply_publiccloud_pint_image(settings):
+    """
+    Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
+    """
     try:
         images = pint_query(settings["PUBLIC_CLOUD_PINT_QUERY"])["images"]
         region = (

--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -4,39 +4,9 @@ from functools import lru_cache
 import logging
 import re
 
-import bs4
-
 from .utils import retry5 as requests
 
 log = logging.getLogger("bot.openqabot.pc_helper")
-
-
-def fetch_matching_link(url, regex):
-    """
-    Apply odering by modification date (ascending) and return the first link that matches the given regex
-    """
-    try:
-        # Note: ?C=M;O=A - C - compare , M - modify time , O - order , A - asc
-        # So, the first link matching the regex is the most recent one
-        req = requests.get(url + "/?C=M;O=A")
-        text = req.text
-    except BaseException as err:
-        log.error("error fetching '%s': %s" % (url, err))
-        return None
-    getpage_soup = bs4.BeautifulSoup(text, "html.parser")
-    # Returns lazy iterator, so
-    links = getpage_soup.findAll("a", href=regex)
-    if links:
-        return f"{url}/{links[0].get('href')}"
-    raise ValueError("No matching links found")
-
-
-def get_latest_pc_image(image):
-    """
-    Gets the latest image from the given URL/regex image is of the format 'URL/regex'
-    """
-    basepath, _, regex = image.rpartition("/")
-    return fetch_matching_link(basepath, re.compile(regex))
 
 
 def get_latest_tools_image(query):
@@ -54,21 +24,6 @@ def get_latest_tools_image(query):
     return None
 
 
-def apply_publiccloud_regex(settings):
-    """
-    Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
-    """
-    try:
-        settings["PUBLIC_CLOUD_IMAGE_LOCATION"] = get_latest_pc_image(
-            settings["PUBLIC_CLOUD_IMAGE_REGEX"]
-        )
-        return settings
-    except BaseException as e:
-        log.warning(f"PUBLIC_CLOUD_IMAGE_REGEX handling failed: {e}")
-        settings["PUBLIC_CLOUD_IMAGE_LOCATION"] = None
-        return settings
-
-
 def apply_pc_tools_image(settings):
     """
     Use PUBLIC_CLOUD_TOOLS_IMAGE_QUERY to get latest tools image and set it into
@@ -80,10 +35,9 @@ def apply_pc_tools_image(settings):
                 settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
             )
             del settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
-        return settings
     except BaseException as e:
         log.warning(f"PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed: {e}")
-        return settings
+    return settings
 
 
 @lru_cache(maxsize=None)
@@ -99,7 +53,6 @@ def apply_publiccloud_pint_image(settings):
     Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
     """
     try:
-        images = pint_query(settings["PUBLIC_CLOUD_PINT_QUERY"])["images"]
         region = (
             settings["PUBLIC_CLOUD_PINT_REGION"]
             if "PUBLIC_CLOUD_PINT_REGION" in settings
@@ -110,6 +63,9 @@ def apply_publiccloud_pint_image(settings):
         # See https://www.suse.com/c/suse-public-cloud-image-life-cycle/
         image = None
         for state in ["active", "inactive", "deprecated"]:
+            images = pint_query(f"{settings['PUBLIC_CLOUD_PINT_QUERY']}{state}.json")[
+                "images"
+            ]
             image = get_recent_pint_image(
                 images, settings["PUBLIC_CLOUD_PINT_NAME"], region, state=state
             )
@@ -120,7 +76,13 @@ def apply_publiccloud_pint_image(settings):
         settings["PUBLIC_CLOUD_IMAGE_ID"] = image[settings["PUBLIC_CLOUD_PINT_FIELD"]]
         settings["PUBLIC_CLOUD_IMAGE_NAME"] = image["name"]
         settings["PUBLIC_CLOUD_IMAGE_STATE"] = image["state"]
-        # Remove pint query settings. They are not required in the scheduled job
+    except BaseException as e:
+        log_error = "PUBLIC_CLOUD_PINT_QUERY handling failed"
+        if "PUBLIC_CLOUD_PINT_NAME" in settings:
+            log_error += f' for {settings["PUBLIC_CLOUD_PINT_NAME"]}'
+        log.warning(f"{log_error}: {e}")
+        settings["PUBLIC_CLOUD_IMAGE_ID"] = None
+    finally:
         if "PUBLIC_CLOUD_PINT_QUERY" in settings:
             del settings["PUBLIC_CLOUD_PINT_QUERY"]
         if "PUBLIC_CLOUD_PINT_NAME" in settings:
@@ -131,13 +93,7 @@ def apply_publiccloud_pint_image(settings):
             del settings["PUBLIC_CLOUD_PINT_REGION"]
         if "PUBLIC_CLOUD_PINT_FIELD" in settings:
             del settings["PUBLIC_CLOUD_PINT_FIELD"]
-        return settings
-    except BaseException as e:
-        log.warning(
-            f"PUBLIC_CLOUD_PINT_QUERY handling failed for {settings['PUBLIC_CLOUD_PINT_NAME']}: {e}"
-        )
-        settings["PUBLIC_CLOUD_IMAGE_ID"] = None
-        return settings
+    return settings
 
 
 def get_recent_pint_image(images, name_regex, region=None, state="active"):

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -10,11 +10,7 @@ from . import ProdVer, Repos
 from .. import DOWNLOAD_BASE, QEM_DASHBOARD
 from ..errors import NoTestIssues, SameBuildExists
 from ..loader.repohash import merge_repohash
-from ..pc_helper import (
-    apply_pc_tools_image,
-    apply_publiccloud_pint_image,
-    apply_publiccloud_regex,
-)
+from ..pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 from ..utils import retry3 as requests
 from .baseconf import BaseConf
 from .incident import Incident
@@ -155,14 +151,6 @@ class Aggregate(BaseConf):
                     )
                     continue
 
-            # parse Public-Cloud image REGEX if present
-            if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
-                settings = apply_publiccloud_regex(settings)
-                if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                    log.error(
-                        f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
-                    )
-                    continue
             # parse Public-Cloud pint query if present
             if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                 settings = apply_publiccloud_pint_image(settings)

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -5,11 +5,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from . import ArchVer, ProdVer, Repos
 from .. import QEM_DASHBOARD
-from ..pc_helper import (
-    apply_pc_tools_image,
-    apply_publiccloud_pint_image,
-    apply_publiccloud_regex,
-)
+from ..pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 from ..utils import retry3 as requests
 from .baseconf import BaseConf
 from .incident import Incident
@@ -261,14 +257,6 @@ class Incidents(BaseConf):
                             )
                             continue
 
-                    # parse Public-Cloud image REGEX if present
-                    if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
-                        settings = apply_publiccloud_regex(settings)
-                        if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                            log.error(
-                                f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
-                            )
-                            continue
                     # parse Public-Cloud pint query if present
                     if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                         settings = apply_publiccloud_pint_image(settings)

--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright SUSE LLC
+# SPDX-License-Identifier: MIT
+from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
+from openqabot.main import create_logger
+
+
+def main():
+    """
+    This code is used only for testing purpose.
+    Allowing to prove that Public Cloud related logic is actually working without executing
+    a lot of code which is unrelated to pc_helper
+    """
+    log = create_logger()
+    settings = {
+        "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "https://openqa.suse.de/group_overview/276.json"
+    }
+    log.info("Calling apply_pc_tools_image with :\n%s", settings)
+    apply_pc_tools_image(settings)
+    log.info("Setting after the call to apply_pc_tools_image:\n%s", settings)
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
+        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-12-sp5-v[0-9]{8}-hvm-ssd-x86_64",
+        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
+        "PUBLIC_CLOUD_PINT_FIELD": "id",
+    }
+    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
+    apply_publiccloud_pint_image(settings)
+    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
+        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-15-sp2-chost-byos-v[0-9]{8}-hvm-ssd-x86_64",
+        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
+        "PUBLIC_CLOUD_PINT_FIELD": "id",
+    }
+    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
+    apply_publiccloud_pint_image(settings)
+    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ requests
 osc
 openqa-client
 ruamel.yaml
-beautifulsoup4
 black
 jsonschema
 urllib3<2 # responses needs <2, see https://github.com/getsentry/responses/issues/635

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ osc
 openqa-client
 requests
 ruamel.yaml
-beautifulsoup4
 jsonschema

--- a/tests/test_pc_helper.py
+++ b/tests/test_pc_helper.py
@@ -1,0 +1,160 @@
+import re
+import responses
+from openqabot.pc_helper import (
+    apply_pc_tools_image,
+    apply_publiccloud_pint_image,
+    get_latest_tools_image,
+    get_recent_pint_image,
+)
+import openqabot.pc_helper
+
+
+def test_apply_pc_tools_image(monkeypatch):
+    known_return = "test"
+    monkeypatch.setattr(
+        openqabot.pc_helper,
+        "get_latest_tools_image",
+        lambda *args, **kwargs: known_return,
+    )
+    settings = {}
+    apply_pc_tools_image(settings)
+    settings = {"PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "test"}
+    apply_pc_tools_image(settings)
+    assert "PUBLIC_CLOUD_TOOLS_IMAGE_BASE" in settings
+    assert settings["PUBLIC_CLOUD_TOOLS_IMAGE_BASE"] == known_return
+    assert "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" not in settings
+
+
+def test_apply_publiccloud_pint_image(monkeypatch):
+    monkeypatch.setattr(
+        openqabot.pc_helper, "pint_query", lambda *args, **kwargs: {"images": []}
+    )
+    monkeypatch.setattr(
+        openqabot.pc_helper,
+        "get_recent_pint_image",
+        lambda *args, **kwargs: {"name": "test", "state": "active", "image_id": "111"},
+    )
+    settings = {}
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] is None
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+    assert "PUBLIC_CLOUD_REGION" not in settings
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "test",
+        "PUBLIC_CLOUD_PINT_NAME": "test",
+        "PUBLIC_CLOUD_PINT_FIELD": "image_id",
+    }
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] == "111"
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+    assert "PUBLIC_CLOUD_REGION" not in settings
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "test",
+        "PUBLIC_CLOUD_PINT_NAME": "test",
+        "PUBLIC_CLOUD_PINT_FIELD": "image_id",
+        "PUBLIC_CLOUD_PINT_REGION": "south",
+    }
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] == "111"
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert settings["PUBLIC_CLOUD_REGION"] == "south"
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+
+    monkeypatch.setattr(
+        openqabot.pc_helper, "get_recent_pint_image", lambda *args, **kwargs: None
+    )
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "test",
+        "PUBLIC_CLOUD_PINT_NAME": "test",
+        "PUBLIC_CLOUD_PINT_FIELD": "image_id",
+        "PUBLIC_CLOUD_PINT_REGION": "south",
+    }
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] is None
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert settings["PUBLIC_CLOUD_REGION"] == "south"
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+
+
+def test_get_recent_pint_image():
+    images = []
+    ret = get_recent_pint_image(images, "test")
+    assert ret is None
+
+    img1 = {
+        "name": "test",
+        "state": "active",
+        "publishedon": "20231212",
+        "region": "south",
+    }
+    images.append(img1)
+    ret = get_recent_pint_image(images, "test")
+    assert ret == img1
+
+    ret = get_recent_pint_image(images, "AAAAA")
+    assert ret is None
+
+    ret = get_recent_pint_image(images, "test", "north")
+    assert ret is None
+
+    ret = get_recent_pint_image(images, "test", "south")
+    assert ret == img1
+
+    ret = get_recent_pint_image(images, "test", "south", "inactive")
+    assert ret is None
+
+    img2 = {
+        "name": "test",
+        "state": "inactive",
+        "publishedon": "20231212",
+        "region": "south",
+    }
+    images.append(img2)
+    ret = get_recent_pint_image(images, "test", "south", "inactive")
+    assert ret == img2
+
+    img3 = {
+        "name": "test",
+        "state": "inactive",
+        "publishedon": "30231212",
+        "region": "south",
+    }
+    images.append(img3)
+    ret = get_recent_pint_image(images, "test", "south", "inactive")
+    assert ret == img3
+
+
+@responses.activate
+def test_get_latest_tools_image():
+    responses.add(
+        responses.GET,
+        re.compile(r"http://url/.*"),
+        json={"build_results": []},
+    )
+    ret = get_latest_tools_image("http://url/results")
+    assert ret is None
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://url/.*"),
+        json={
+            "build_results": [
+                {"failed": 10, "build": "AAAAA"},
+                {"failed": 0, "build": "test"},
+            ]
+        },
+    )
+    ret = get_latest_tools_image("http://url/results")
+    assert ret == "publiccloud_tools_test.qcow2"


### PR DESCRIPTION
PR contains several commits :
-   Add ability allowing to check Public Cloud related logic outside of bot-ng
-   Drop function because it is not used anymore
-   Drop use of variable PUBLIC_CLOUD_PINT_QUERY    
-   Add tests for pc_helper
-   Switch to pythonic documentation format
