### PR TITLE
pc_helper: Add tests and cleanup unused code

### DIFF
--- a/openqabot/main.py
+++ b/openqabot/main.py
@@ -1,25 +1,13 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
-import logging
 import sys
 
+from .utils import create_logger
 from .args import get_parser
 
 
-def create_logger() -> logging.Logger:
-    log = logging.getLogger("bot")
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter(
-        fmt="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
-    )
-    handler.setFormatter(formatter)
-    log.addHandler(handler)
-    log.setLevel(logging.INFO)
-    return log
-
-
 def main() -> None:
-    log = create_logger()
+    log = create_logger("bot")
     parser = get_parser()
 
     if len(sys.argv) < 1:

--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -31,17 +31,20 @@ def fetch_matching_link(url, regex):
     raise ValueError("No matching links found")
 
 
-# Gets the latest image from the given URL/regex
-# image is of the format 'URL/regex'
 def get_latest_pc_image(image):
+    """
+    Gets the latest image from the given URL/regex image is of the format 'URL/regex'
+    """
     basepath, _, regex = image.rpartition("/")
     return fetch_matching_link(basepath, re.compile(regex))
 
 
 def get_latest_tools_image(query):
-    # 'publiccloud_tools_<BUILD NUM>.qcow2' is generic name for image used by Public Cloud tests to run
-    # in openQA. query suppose to look like this "https://openqa.suse.de/group_overview/276.json" to get
-    # value for <BUILD NUM>
+    """
+    'publiccloud_tools_<BUILD NUM>.qcow2' is a generic name for an image used by Public Cloud tests to run
+    in openQA. A query is supposed to look like this "https://openqa.suse.de/group_overview/276.json" to get
+    a value for <BUILD NUM>
+    """
 
     ## Get the first not-failing item
     build_results = requests.get(query).json()["build_results"]
@@ -51,8 +54,10 @@ def get_latest_tools_image(query):
     return None
 
 
-# Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
 def apply_publiccloud_regex(settings):
+    """
+    Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
+    """
     try:
         settings["PUBLIC_CLOUD_IMAGE_LOCATION"] = get_latest_pc_image(
             settings["PUBLIC_CLOUD_IMAGE_REGEX"]
@@ -65,6 +70,10 @@ def apply_publiccloud_regex(settings):
 
 
 def apply_pc_tools_image(settings):
+    """
+    Use PUBLIC_CLOUD_TOOLS_IMAGE_QUERY to get latest tools image and set it into
+    PUBLIC_CLOUD_TOOLS_IMAGE_BASE
+    """
     try:
         if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
             settings["PUBLIC_CLOUD_TOOLS_IMAGE_BASE"] = get_latest_tools_image(
@@ -77,14 +86,18 @@ def apply_pc_tools_image(settings):
         return settings
 
 
-# Perform a pint query. Sucessive queries are cached
 @lru_cache(maxsize=None)
 def pint_query(query):
+    """
+    Perform a pint query. Sucessive queries are cached
+    """
     return requests.get(query).json()
 
 
-# Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
 def apply_publiccloud_pint_image(settings):
+    """
+    Applies PUBLIC_CLOUD_IMAGE_LOCATION based on the given PUBLIC_CLOUD_IMAGE_REGEX
+    """
     try:
         images = pint_query(settings["PUBLIC_CLOUD_PINT_QUERY"])["images"]
         region = (

--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -1,12 +1,12 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
 from functools import lru_cache
-import logging
 import re
 
 from .utils import retry5 as requests
+from .utils import create_logger
 
-log = logging.getLogger("bot.openqabot.pc_helper")
+log = create_logger("pc_helper")
 
 
 def get_latest_tools_image(query):

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -10,11 +10,7 @@ from . import ProdVer, Repos
 from .. import DOWNLOAD_BASE, QEM_DASHBOARD
 from ..errors import NoTestIssues, SameBuildExists
 from ..loader.repohash import merge_repohash
-from ..pc_helper import (
-    apply_pc_tools_image,
-    apply_publiccloud_pint_image,
-    apply_publiccloud_regex,
-)
+from ..pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 from ..utils import retry3 as requests
 from .baseconf import BaseConf
 from .incident import Incident
@@ -147,29 +143,14 @@ class Aggregate(BaseConf):
             # if set, we use this query to detect latest public cloud tools image which used for running
             # all public cloud related tests in openQA
             if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
-                query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
                 settings = apply_pc_tools_image(settings)
                 if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
-                    log.error(
-                        f"Failed to query latest publiccloud tools image using {query}"
-                    )
                     continue
 
-            # parse Public-Cloud image REGEX if present
-            if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
-                settings = apply_publiccloud_regex(settings)
-                if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                    log.error(
-                        f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
-                    )
-                    continue
             # parse Public-Cloud pint query if present
             if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                 settings = apply_publiccloud_pint_image(settings)
                 if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
-                    log.error(
-                        f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
-                    )
                     continue
 
             full_post["openqa"].update(settings)

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -5,11 +5,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from . import ArchVer, ProdVer, Repos
 from .. import QEM_DASHBOARD
-from ..pc_helper import (
-    apply_pc_tools_image,
-    apply_publiccloud_pint_image,
-    apply_publiccloud_regex,
-)
+from ..pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 from ..utils import retry3 as requests
 from .baseconf import BaseConf
 from .incident import Incident
@@ -253,29 +249,14 @@ class Incidents(BaseConf):
                     # if set, we use this query to detect latest public cloud tools image which used for running
                     # all public cloud related tests in openQA
                     if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
-                        query = settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
                         settings = apply_pc_tools_image(settings)
                         if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
-                            log.error(
-                                f"Failed to query latest publiccloud tools image using {query}"
-                            )
                             continue
 
-                    # parse Public-Cloud image REGEX if present
-                    if "PUBLIC_CLOUD_IMAGE_REGEX" in settings:
-                        settings = apply_publiccloud_regex(settings)
-                        if not settings.get("PUBLIC_CLOUD_IMAGE_LOCATION", False):
-                            log.error(
-                                f"No publiccloud image found for {settings['PUBLIC_CLOUD_IMAGE_REGEX']}"
-                            )
-                            continue
                     # parse Public-Cloud pint query if present
                     if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                         settings = apply_publiccloud_pint_image(settings)
                         if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
-                            log.error(
-                                f"No publiccloud image fetched from pint for for {settings['PUBLIC_CLOUD_PINT_QUERY']}"
-                            )
                             continue
 
                     full_post["openqa"] = settings

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -1,11 +1,24 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
+import logging
 from copy import deepcopy
 from typing import Optional
 
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+
+def create_logger(name: str) -> logging.Logger:
+    log = logging.getLogger(name)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+    return log
 
 
 def walk(inc):

--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright SUSE LLC
+# SPDX-License-Identifier: MIT
+from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
+from openqabot.main import create_logger
+
+
+def main():
+    """
+    This code is used only for testing purpose.
+    Allowing to prove that Public Cloud related logic is actually working without executing
+    a lot of code which is unrelated to pc_helper
+    """
+    log = create_logger()
+    settings = {
+        "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "https://openqa.suse.de/group_overview/276.json"
+    }
+    log.info("Calling apply_pc_tools_image with :\n%s", settings)
+    apply_pc_tools_image(settings)
+    log.info("Setting after the call to apply_pc_tools_image:\n%s", settings)
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
+        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-12-sp5-v[0-9]{8}-hvm-ssd-x86_64",
+        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
+        "PUBLIC_CLOUD_PINT_FIELD": "id",
+    }
+    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
+    apply_publiccloud_pint_image(settings)
+    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
+        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-15-sp2-chost-byos-v[0-9]{8}-hvm-ssd-x86_64",
+        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
+        "PUBLIC_CLOUD_PINT_FIELD": "id",
+    }
+    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
+    apply_publiccloud_pint_image(settings)
+    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
+
+
+if __name__ == "__main__":
+    main()

--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -2,7 +2,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
 from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
-from openqabot.main import create_logger
+from openqabot.utils import create_logger
 
 
 def main():
@@ -11,7 +11,7 @@ def main():
     Allowing to prove that Public Cloud related logic is actually working without executing
     a lot of code which is unrelated to pc_helper
     """
-    log = create_logger()
+    log = create_logger("pc_helper_online")
     settings = {
         "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "https://openqa.suse.de/group_overview/276.json"
     }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ requests
 osc
 openqa-client
 ruamel.yaml
-beautifulsoup4
 black
 jsonschema
 urllib3<2 # responses needs <2, see https://github.com/getsentry/responses/issues/635

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ osc
 openqa-client
 requests
 ruamel.yaml
-beautifulsoup4
 jsonschema

--- a/tests/test_pc_helper.py
+++ b/tests/test_pc_helper.py
@@ -1,0 +1,159 @@
+import re
+import responses
+from openqabot.pc_helper import (
+    apply_pc_tools_image,
+    apply_publiccloud_pint_image,
+    get_latest_tools_image,
+    get_recent_pint_image,
+)
+import openqabot.pc_helper
+
+
+def test_apply_pc_tools_image(monkeypatch):
+    known_return = "test"
+    monkeypatch.setattr(
+        openqabot.pc_helper,
+        "get_latest_tools_image",
+        lambda *args, **kwargs: known_return,
+    )
+
+    settings = {"PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "test"}
+    apply_pc_tools_image(settings)
+    assert "PUBLIC_CLOUD_TOOLS_IMAGE_BASE" in settings
+    assert settings["PUBLIC_CLOUD_TOOLS_IMAGE_BASE"] == known_return
+    assert "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" not in settings
+
+
+def test_apply_publiccloud_pint_image(monkeypatch):
+    monkeypatch.setattr(
+        openqabot.pc_helper, "pint_query", lambda *args, **kwargs: {"images": []}
+    )
+    monkeypatch.setattr(
+        openqabot.pc_helper,
+        "get_recent_pint_image",
+        lambda *args, **kwargs: {"name": "test", "state": "active", "image_id": "111"},
+    )
+    settings = {}
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] is None
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+    assert "PUBLIC_CLOUD_REGION" not in settings
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "test",
+        "PUBLIC_CLOUD_PINT_NAME": "test",
+        "PUBLIC_CLOUD_PINT_FIELD": "image_id",
+    }
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] == "111"
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+    assert "PUBLIC_CLOUD_REGION" not in settings
+
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "test",
+        "PUBLIC_CLOUD_PINT_NAME": "test",
+        "PUBLIC_CLOUD_PINT_FIELD": "image_id",
+        "PUBLIC_CLOUD_PINT_REGION": "south",
+    }
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] == "111"
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert settings["PUBLIC_CLOUD_REGION"] == "south"
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+
+    monkeypatch.setattr(
+        openqabot.pc_helper, "get_recent_pint_image", lambda *args, **kwargs: None
+    )
+    settings = {
+        "PUBLIC_CLOUD_PINT_QUERY": "test",
+        "PUBLIC_CLOUD_PINT_NAME": "test",
+        "PUBLIC_CLOUD_PINT_FIELD": "image_id",
+        "PUBLIC_CLOUD_PINT_REGION": "south",
+    }
+    apply_publiccloud_pint_image(settings)
+    assert settings["PUBLIC_CLOUD_IMAGE_ID"] is None
+    assert "PUBLIC_CLOUD_PINT_QUERY" not in settings
+    assert settings["PUBLIC_CLOUD_REGION"] == "south"
+    assert "PUBLIC_CLOUD_PINT_NAME" not in settings
+    assert "PUBLIC_CLOUD_PINT_REGION" not in settings
+    assert "PUBLIC_CLOUD_PINT_FIELD" not in settings
+
+
+def test_get_recent_pint_image():
+    images = []
+    ret = get_recent_pint_image(images, "test")
+    assert ret is None
+
+    img1 = {
+        "name": "test",
+        "state": "active",
+        "publishedon": "20231212",
+        "region": "south",
+    }
+    images.append(img1)
+    ret = get_recent_pint_image(images, "test")
+    assert ret == img1
+
+    ret = get_recent_pint_image(images, "AAAAA")
+    assert ret is None
+
+    ret = get_recent_pint_image(images, "test", "north")
+    assert ret is None
+
+    ret = get_recent_pint_image(images, "test", "south")
+    assert ret == img1
+
+    ret = get_recent_pint_image(images, "test", "south", "inactive")
+    assert ret is None
+
+    img2 = {
+        "name": "test",
+        "state": "inactive",
+        "publishedon": "20231212",
+        "region": "south",
+    }
+    images.append(img2)
+    ret = get_recent_pint_image(images, "test", "south", "inactive")
+    assert ret == img2
+
+    img3 = {
+        "name": "test",
+        "state": "inactive",
+        "publishedon": "30231212",
+        "region": "south",
+    }
+    images.append(img3)
+    ret = get_recent_pint_image(images, "test", "south", "inactive")
+    assert ret == img3
+
+
+@responses.activate
+def test_get_latest_tools_image():
+    responses.add(
+        responses.GET,
+        re.compile(r"http://url/.*"),
+        json={"build_results": []},
+    )
+    ret = get_latest_tools_image("http://url/results")
+    assert ret is None
+
+    responses.add(
+        responses.GET,
+        re.compile(r"http://url/.*"),
+        json={
+            "build_results": [
+                {"failed": 10, "build": "AAAAA"},
+                {"failed": 0, "build": "test"},
+            ]
+        },
+    )
+    ret = get_latest_tools_image("http://url/results")
+    assert ret == "publiccloud_tools_test.qcow2"


### PR DESCRIPTION
PR contains several commits :

    - Add ability allowing to check Public Cloud related logic outside of bot-ng
    - Drop function because it is not used anymore
    - Drop use of variable PUBLIC_CLOUD_PINT_QUERY
    - Add tests for pc_helper
    - Switch to pythonic documentation format
    - Fix logging in pc_helper 
    - Call python3 binary in officially recommended way
 

Related ticket : https://progress.opensuse.org/issues/115211

NOTE : this is second attempt of merging #121 which was reverted #122  due to exception thrown during run . Difference between #121  and this one is that in case of failure we not logging the problem in caller but only inside called function . Also I add extra commit which fixing logging within pc_helper 

