### PR TITLE
Fix debug option broken by #123


### DIFF
--- a/openqabot/main.py
+++ b/openqabot/main.py
@@ -1,5 +1,6 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
+import logging
 import sys
 
 from .utils import create_logger


### PR DESCRIPTION
Import of logging package was removed in https://github.com/asmorodskyi/qem-bot/commit/5d66d5e9c271ed24765425d64570ccf6d44311b5
but it is still needed by setting DEBUG log level.
Revert import removal solve the problem
