### PR TITLE
Teach pc_helper_online to process metadata

### DIFF
--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -1,6 +1,5 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
-from logging import getLogger
 from pathlib import Path
 from typing import List, Set, Union
 
@@ -8,10 +7,11 @@ from ruamel.yaml import YAML  # type: ignore
 
 from ..errors import NoTestIssues
 from ..types import Data
+from ..utils import create_logger
 from ..types.aggregate import Aggregate
 from ..types.incidents import Incidents
 
-log = getLogger("bot.loader.config")
+log = create_logger("bot.loader.config")
 
 
 def load_metadata(

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -39,6 +39,7 @@ def get_incidents(token: Dict[str, str]) -> List[Incident]:
     xs = []
     for i in incidents:
         try:
+            log.error(i)
             xs.append(Incident(i))
         except NoRepoFoundError as e:
             log.info(

--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -1,25 +1,51 @@
 #!/usr/bin/env python3
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
+from argparse import ArgumentParser
 from pathlib import Path
+from ruamel.yaml import YAML  # type: ignore
 from openqabot.utils import create_logger
-from openqabot.loader.config import load_metadata
-from openqabot.types.incident import Incident
+from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 
 
 def main():
     """
     This code is used only for testing purpose.
     Allowing to prove that Public Cloud related logic is actually working without executing
-    a lot of code which is unrelated to pc_helper
+    a lot of code which is unrelated to pc_helper.
+    As input it getting same folder as bot-ng but processing only two variables which are related to Public Cloud
     """
     log = create_logger("pc_helper_online")
-    products = load_metadata(Path('/home/asmorodskyi/source/metadata/bot-ng/'),False,True, {})
-    incidents = []
-    incidents.append(Incident({'approved': False, 'channels': ['SUSE:Updates:OpenStack-Cloud:9:x86_64'], 'emu': False, 'inReview': False, 'inReviewQAM': False, 'isActive': True, 'number': 17958, 'packages': ['ndctl'], 'project': 'SUSE:Maintenance:17958', 'rr_number': None}))
-    for product in products:
-        log.error(f" Calling for {product}")
-        product(incidents,{"token": "DDDDD"}, "DDDDD", True)
+    parser = ArgumentParser(
+                    prog='pc_helper_online',
+                    description='Dummy code to test functionality related to pc_helper code')
+    parser.add_argument(
+        "-c",
+        "--configs",
+        type=Path,
+        default=Path("/etc/openqabot"),
+        help="Directory with openqabot configuration metadata",
+    )
+    args = parser.parse_args()
+    loader = YAML(typ="safe")
+    log.info(f"Parsing configuration files from {args.configs}")
+    for p in Path(args.configs).glob("*.yml"):
+        try:
+            data = loader.load(p)
+            log.info(f"Processing {p}")
+            if "settings" in data:
+                settings = data["settings"]
+                if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
+                    apply_pc_tools_image(settings)
+                    if not settings.get("PUBLIC_CLOUD_TOOLS_IMAGE_BASE", False):
+                        log.error(f"Failed to get PUBLIC_CLOUD_TOOLS_IMAGE_BASE from {data}")
+                if "PUBLIC_CLOUD_PINT_QUERY" in settings:
+                    apply_publiccloud_pint_image(settings)
+                    if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
+                        log.error(f"Failed to get PUBLIC_CLOUD_IMAGE_ID from {data}")
+        except Exception as e:
+            log.exception(e)
+            continue
 
 
 

--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
-from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
+from pathlib import Path
 from openqabot.utils import create_logger
+from openqabot.loader.config import load_metadata
+from openqabot.types.incident import Incident
 
 
 def main():
@@ -12,33 +14,14 @@ def main():
     a lot of code which is unrelated to pc_helper
     """
     log = create_logger("pc_helper_online")
-    settings = {
-        "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "https://openqa.suse.de/group_overview/276.json"
-    }
-    log.info("Calling apply_pc_tools_image with :\n%s", settings)
-    apply_pc_tools_image(settings)
-    log.info("Setting after the call to apply_pc_tools_image:\n%s", settings)
-
-    settings = {
-        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
-        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-12-sp5-v[0-9]{8}-hvm-ssd-x86_64",
-        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
-        "PUBLIC_CLOUD_PINT_FIELD": "id",
-    }
-    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
-    apply_publiccloud_pint_image(settings)
-    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
-
-    settings = {
-        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
-        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-15-sp2-chost-byos-v[0-9]{8}-hvm-ssd-x86_64",
-        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
-        "PUBLIC_CLOUD_PINT_FIELD": "id",
-    }
-    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
-    apply_publiccloud_pint_image(settings)
-    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
+    products = load_metadata(Path('/home/asmorodskyi/source/metadata/bot-ng/'),False,True, {})
+    incidents = []
+    incidents.append(Incident({'approved': False, 'channels': ['SUSE:Updates:OpenStack-Cloud:9:x86_64'], 'emu': False, 'inReview': False, 'inReviewQAM': False, 'isActive': True, 'number': 17958, 'packages': ['ndctl'], 'project': 'SUSE:Maintenance:17958', 'rr_number': None}))
+    for product in products:
+        log.error(f" Calling for {product}")
+        product(incidents,{"token": "DDDDD"}, "DDDDD", True)
 
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
Initial version was doing only two function calls with dummy data
This time we taking same folder with metadat as bot-ng. But instead
of going through all actions done by bot-ng we concentrating on two variables
which matter for Public Cloud. PUBLIC_CLOUD_TOOLS_IMAGE_QUERY and PUBLIC_CLOUD_PINT_QUERY
