### PR TITLE
Teach pc_helper_online to process metadata

### DIFF
--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
+from argparse import ArgumentParser
+from pathlib import Path
+from ruamel.yaml import YAML
 from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 from openqabot.utils import create_logger
 
@@ -9,35 +12,44 @@ def main():
     """
     This code is used only for testing purpose.
     Allowing to prove that Public Cloud related logic is actually working without executing
-    a lot of code which is unrelated to pc_helper
+    a lot of code which is unrelated to pc_helper.
+    As input it getting directory with openqabot configuration metadata (same folder as bot-ng )
+    but processing only variables related to openqabot.pc_helper module
     """
     log = create_logger("pc_helper_online")
-    settings = {
-        "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "https://openqa.suse.de/group_overview/276.json"
-    }
-    log.info("Calling apply_pc_tools_image with :\n%s", settings)
-    apply_pc_tools_image(settings)
-    log.info("Setting after the call to apply_pc_tools_image:\n%s", settings)
-
-    settings = {
-        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
-        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-12-sp5-v[0-9]{8}-hvm-ssd-x86_64",
-        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
-        "PUBLIC_CLOUD_PINT_FIELD": "id",
-    }
-    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
-    apply_publiccloud_pint_image(settings)
-    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
-
-    settings = {
-        "PUBLIC_CLOUD_PINT_QUERY": "https://susepubliccloudinfo.suse.com/v1/amazon/images/",
-        "PUBLIC_CLOUD_PINT_NAME": "suse-sles-15-sp2-chost-byos-v[0-9]{8}-hvm-ssd-x86_64",
-        "PUBLIC_CLOUD_PINT_REGION": "us-east-1",
-        "PUBLIC_CLOUD_PINT_FIELD": "id",
-    }
-    log.info("Calling apply_publiccloud_pint_image with :\n%s", settings)
-    apply_publiccloud_pint_image(settings)
-    log.info("Setting after the call to apply_publiccloud_pint_image:\n%s", settings)
+    parser = ArgumentParser(
+        prog="pc_helper_online",
+        description="Dummy code to test functionality related to pc_helper code",
+    )
+    parser.add_argument(
+        "-c",
+        "--configs",
+        type=Path,
+        default=Path("/etc/openqabot"),
+        help="Directory with openqabot configuration metadata",
+    )
+    args = parser.parse_args()
+    log.info(f"Parsing configuration files from {args.configs}")
+    loader = YAML(typ="safe")
+    for p in Path(args.configs).glob("*.yml"):
+        try:
+            data = loader.load(p)
+            log.info(f"Processing {p}")
+            if "settings" in data:
+                settings = data["settings"]
+                if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
+                    apply_pc_tools_image(settings)
+                    if "PUBLIC_CLOUD_TOOLS_IMAGE_BASE" not in settings:
+                        log.error(
+                            f"Failed to get PUBLIC_CLOUD_TOOLS_IMAGE_BASE from {data}"
+                        )
+                if "PUBLIC_CLOUD_PINT_QUERY" in settings:
+                    apply_publiccloud_pint_image(settings)
+                    if "PUBLIC_CLOUD_IMAGE_ID" not in settings:
+                        log.error(f"Failed to get PUBLIC_CLOUD_IMAGE_ID from {data}")
+        except Exception as e:
+            log.exception(e)
+            continue
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Initial version was doing only two function calls with dummy data
This time we taking same folder with metadat as bot-ng. But instead
of going through all actions done by bot-ng we concentrating on two variables
which matter for Public Cloud. PUBLIC_CLOUD_TOOLS_IMAGE_QUERY and PUBLIC_CLOUD_PINT_QUERY
