### PR TITLE
Init process of using embargoed field for Incidents

### DIFF
--- a/openqabot/smeltsync.py
+++ b/openqabot/smeltsync.py
@@ -116,6 +116,10 @@ class SMELTSync:
         incident["approved"] = approved
         incident["rr_number"] = rr_number
         incident["inReviewQAM"] = inReviewQAM
+        # this is temporary solution. At first stage we will just push this field into dashboard
+        # next we will add logic to store it in dashboard and then finally we will replace
+        # here dummy value with real one from smelt
+        incident["embargoed"] = False
 
         return incident
 


### PR DESCRIPTION


Because of usage of same data structures in two independent applications (qem-bot and qem-dashboard)
we need to do introduction of new field in several stages. At first stage we will start pushing
this field into qem-dashboard from qem-bot. So after deploying this we can than read propely
this field coming from bot
