### PR TITLE
Allow single full filename as -c args

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ tool for schedule maintenance jobs + sync SMELT/OpenQA to QEM-Dashboard
     optional arguments:
       -h, --help            show this help message and exit
       -c CONFIGS, --configs CONFIGS
-                            Directory with openqabot configuration metadata
+                            Directory or single file with openqabot configuration metadata
       --dry                 Dry run, do not post any data
       -d, --debug           Enable debug output
       -t TOKEN, --token TOKEN

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -80,7 +80,7 @@ def get_parser():
         "--configs",
         type=Path,
         default=Path("/etc/openqabot"),
-        help="Directory with openqabot configuration metadata",
+        help="Directory or single file with openqabot configuration metadata",
     )
 
     parser.add_argument(

--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -14,6 +14,15 @@ from ..types.incidents import Incidents
 log = getLogger("bot.loader.config")
 
 
+def get_yml_list(path: Path) -> List[Path]:
+    yml_list = []
+    if path.is_file() and path.match("*.yml"):
+        yml_list.append(path)
+    else:
+        yml_list = [p for p in path.glob("*.yml")]
+    return yml_list
+
+
 def load_metadata(
     path: Path, aggregate: bool, incidents: bool, extrasettings: Set[str]
 ) -> List[Union[Aggregate, Incidents]]:
@@ -21,7 +30,7 @@ def load_metadata(
 
     loader = YAML(typ="safe")
 
-    for p in path.glob("*.yml"):
+    for p in get_yml_list(path):
         try:
             data = loader.load(p)
         except Exception as e:
@@ -58,7 +67,7 @@ def read_products(path: Path) -> List[Data]:
     loader = YAML(typ="safe")
     ret = []
 
-    for p in path.glob("*.yml"):
+    for p in get_yml_list(path):
         data = loader.load(p)
 
         if not data:

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -61,12 +61,12 @@ class OpenQABot:
             post += worker(self.incidents, self.token, self.ci, self.ignore_onetime)
 
         if self.dry:
-            log.info("Would trigger %s products in openQA" % len(post))
+            log.info("Would trigger %d products in openQA" % len(post))
             for job in post:
                 log.info(job)
 
         else:
-            log.info("Triggering %s products in openQA" % len(post))
+            log.info("Triggering %d products in openQA" % len(post))
             for job in post:
                 log.info("Triggering %s" % str(job))
                 try:

--- a/tests/test_loader_config.py
+++ b/tests/test_loader_config.py
@@ -28,7 +28,15 @@ def test_load_metadata_aggregate(caplog):
     assert "No 'test_issues' in BAD15SP3 config" in messages
 
 
-def test_load_metadata_incdents(caplog):
+def test_load_metadata_aggregate_file(caplog):
+    caplog.set_level(logging.DEBUG, logger="bot.loader.config")
+    file_path = Path(__file__).parent / "fixtures/config/05_normal.yml"
+    result = load_metadata(file_path, False, True, set())
+
+    assert "<Aggregate product: SOME15SP3>" in str(result[0])
+
+
+def test_load_metadata_incidents(caplog):
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
 
     result = load_metadata(__root__, True, False, set())
@@ -88,3 +96,34 @@ def test_read_products(caplog):
     assert any(x.endswith("empty config") for x in messages)
     assert any(x.endswith("does not have aggregate") for x in messages)
     assert "'DISTRI'" in messages
+
+
+def test_read_products_file(caplog):
+    caplog.set_level(logging.DEBUG, logger="bot.loader.config")
+
+    result = read_products(Path(__file__).parent / "fixtures/config/05_normal.yml")
+
+    assert len(result) == 2
+    assert (
+        Data(
+            incident=0,
+            settings_id=0,
+            flavor="Server-DVD-Updates",
+            arch="x86_64",
+            distri="bar",
+            version="15-SP3",
+            build="",
+            product="SOME15SP3",
+        )
+        in result
+    )
+    assert Data(
+        incident=0,
+        settings_id=0,
+        flavor="Server-DVD-Updates",
+        arch="aarch64",
+        distri="bar",
+        version="15-SP3",
+        build="",
+        product="SOME15SP3",
+    )


### PR DESCRIPTION
`-c` now support both directory with multiple .yml and single .yml filename.