### PR TITLE
Fix unpacking of exception

### DIFF
--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -84,7 +84,7 @@ class openQAInterface:
             )
             ret = list(map(lambda c: {"text": c.get("text", "")}, ret))
         except Exception as e:
-            (method, url, status_code) = e.args
+            (method, url, status_code, *other) = e.args
             if status_code == 404:
                 self.handle_job_not_found(job_id)
             else:


### PR DESCRIPTION
There was a new parameter added to the exception. `*other` will optionally unpack it.

Issue: https://progress.opensuse.org/issues/136151