### PR TITLE
Catch KeyError exception on incidents

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -64,12 +64,19 @@ class Incidents(BaseConf):
             return False
 
         for job in jobs:
-            if (
-                job["flavor"] == flavor
-                and job["arch"] == arch
-                and job["settings"]["REPOHASH"] == inc.revisions[ArchVer(arch, ver)]
-            ):
-                return True
+            try:
+                if (
+                    job["flavor"] == flavor
+                    and job["arch"] == arch
+                    and job["settings"]["REPOHASH"] == inc.revisions[ArchVer(arch, ver)]
+                ):
+                    return True
+            except KeyError:
+                log.debug(
+                    "Incident %s does not have %s arch in SLE-12 module version"
+                    % (inc.id, arch)
+                )
+                continue
 
         return False
 


### PR DESCRIPTION
Possibly missing from 0cc1b68777b2674fbef532315e6905bdc305d460

this is a naive HailMary attempt here https://progress.opensuse.org/issues/136331
