### PR TITLE
Deduplicate handling of unversioned modules

### DIFF
--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -71,6 +71,18 @@ class Incident:
         self.revisions = self._rev(self.channels, self.project)
         self.livepatch: bool = self._is_livepatch(self.packages)
 
+    def revisions_with_fallback(self, arch: str, ver: str):
+        try:
+            arch_ver = ArchVer(arch, ver)
+            # An unversioned SLE12 module will have ArchVer version "12"
+            # but settings["VERSION"] can be any of "12","12-SP1" ... "12-SP5".
+            if arch_ver not in self.revisions and ver.startswith("12"):
+                arch_ver = ArchVer(arch, "12")
+            return self.revisions[arch_ver]
+        except KeyError:
+            log.debug("Incident %s does not have %s arch in %s" % (self.id, arch, ver))
+            return None
+
     @staticmethod
     def _rev(channels: List[Repos], project: str) -> Dict[ArchVer, int]:
         rev: Dict[ArchVer, int] = {}

--- a/tests/test_incident.py
+++ b/tests/test_incident.py
@@ -101,3 +101,19 @@ def test_inc_nochannels2(mock_good):
     ]
     with pytest.raises(EmptyChannels):
         Incident(bad_data)
+
+
+def test_inc_revisions(mock_good):
+    incident = Incident(test_data)
+    assert incident.revisions_with_fallback("x86_64", "15-SP4")
+    assert incident.revisions_with_fallback("aarch64", "15-SP4")
+
+    unversioned_data = deepcopy(test_data)
+    unversioned_data["channels"] = [
+        "SUSE:Updates:SLE-Module-HPC:12:x86_64",
+    ]
+    incident = Incident(unversioned_data)
+    assert incident.revisions_with_fallback("x86_64", "12")
+    assert incident.revisions_with_fallback("x86_64", "12-SP5")
+    assert not incident.revisions_with_fallback("aarch64", "12")
+    assert not incident.revisions_with_fallback("aarch64", "12-SP5")


### PR DESCRIPTION
The logic should be the same to avoid different behavior in the same case.

See: https://progress.opensuse.org/issues/137006