### PR TITLE
flavor_settings field within each Incidents flavor

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -112,8 +112,6 @@ incidents:
       excluded_packages:
         - pkgthree
         - pkgfour
-      flavor_settings:
-        SOMETHING: "some value"
     Other-Incident-FLavor:
       ...
 ```
@@ -128,6 +126,6 @@ incidents:
 * `override_priority` - optional, integer. Overrides the default priority of the job. (default = 50, with modifiers for `*Minimal`, EMU and staging Incidents)
 * `packages` - optional, list of package names (or first part of pkg name). The incident must contain a package from this list to be scheduled into openQA.
 * `excluded_packages` - optional, list of package names, opposite to `packages`. If the Incident contains a package in this list, it isn't scheduled.
-* `flavor_settings` - flavor specific settings. Merged with `settings` dictionary. `flavor_settings` values win over `settings`.
+* `params_expand` - flavor specific settings. Merged with `settings` dictionary. `params_expand` values win over `settings`. `DISTRI` and `VERSION` cannot be configured with `params_expand`.
 
 All optional keys can be omitted. By default qem-bot schedules Incidents for any matching `issue`, for any package in Incident, with computed job priority and with `aggregate_job: true`.

--- a/doc/config.md
+++ b/doc/config.md
@@ -1,6 +1,6 @@
 # Configuration format of qem-bot
 
-Configuration, in another way also called metadata of qem-bot, is held in yaml files with one file per "product". Additionally, there is one special config file called `singlearch.yml` which contains a list of packages that exist only on a single architecture.
+Configuration, also known as metadata of qem-bot, is held in yaml files with one file per "product". Additionally, there is one special config file called `singlearch.yml` which contains a list of packages that exist only on a single architecture.
 Configuration usually spans over multiple files. The default location accepted from qem-bot is `/etc/openqabot/`. All configuration files must have `.yml` or `.yaml` extension.
 
 ```bash
@@ -112,6 +112,8 @@ incidents:
       excluded_packages:
         - pkgthree
         - pkgfour
+      flavor_settings:
+        SOMETHING: "some value"
     Other-Incident-FLavor:
       ...
 ```
@@ -126,5 +128,6 @@ incidents:
 * `override_priority` - optional, integer. Overrides the default priority of the job. (default = 50, with modifiers for `*Minimal`, EMU and staging Incidents)
 * `packages` - optional, list of package names (or first part of pkg name). The incident must contain a package from this list to be scheduled into openQA.
 * `excluded_packages` - optional, list of package names, opposite to `packages`. If the Incident contains a package in this list, it isn't scheduled.
+* `flavor_settings` - flavor specific settings. Merged with `settings` dictionary. `flavor_settings` values win over `settings`.
 
 All optional keys can be omitted. By default qem-bot schedules Incidents for any matching `issue`, for any package in Incident, with computed job priority and with `aggregate_job: true`.

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -102,6 +102,15 @@ class Incidents(BaseConf):
                     full_post["openqa"] = {}
                     full_post["openqa"].update(self.settings)
                     if "flavor_settings" in data:
+                        if any(
+                            forbidden_key in data["flavor_settings"]
+                            for forbidden_key in ["DISTRI", "VERSION"]
+                        ):
+                            log.error(
+                                "flavor:%s ignored as DISTRI and VERSION not allowed in flavor_settings",
+                                flavor,
+                            )
+                            continue
                         full_post["openqa"].update(data["flavor_settings"])
 
                     full_post["qem"]["incident"] = inc.id

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -96,12 +96,30 @@ class Incidents(BaseConf):
                             inc.id,
                         )
                         continue
+                    full_post: Dict[str, Any] = {}
+                    full_post["api"] = "api/incident_settings"
+                    full_post["qem"] = {}
+                    full_post["openqa"] = {}
+                    full_post["openqa"].update(self.settings)
+                    if "flavor_settings" in data:
+                        full_post["openqa"].update(data["flavor_settings"])
 
+                    full_post["qem"]["incident"] = inc.id
+                    full_post["openqa"]["ARCH"] = arch
+                    full_post["qem"]["arch"] = arch
+                    full_post["openqa"]["FLAVOR"] = flavor
+                    full_post["qem"]["flavor"] = flavor
+                    full_post["openqa"]["VERSION"] = self.settings["VERSION"]
+                    full_post["qem"]["version"] = self.settings["VERSION"]
+                    full_post["openqa"]["DISTRI"] = self.settings["DISTRI"]
+                    full_post["openqa"]["_ONLY_OBSOLETE_SAME_BUILD"] = "1"
+                    full_post["openqa"]["_OBSOLETE"] = "1"
+                    full_post["openqa"]["INCIDENT_ID"] = inc.id
+
+                    if ci_url:
+                        full_post["openqa"]["__CI_JOB_URL"] = ci_url
                     if inc.staging:
                         continue
-
-                    if "flavor_settings" in data:
-                        self.settings.update(data["flavor_settings"])
 
                     if "packages" in data:
                         if not inc.contains_package(data["packages"]):
@@ -111,22 +129,6 @@ class Incidents(BaseConf):
                         if inc.contains_package(data["excluded_packages"]):
                             continue
 
-                    full_post: Dict[str, Any] = {}
-                    full_post["api"] = "api/incident_settings"
-                    full_post["qem"] = {}
-                    full_post["openqa"] = {}
-                    full_post["qem"]["incident"] = inc.id
-                    full_post["openqa"]["ARCH"] = arch
-                    full_post["qem"]["arch"] = arch
-                    full_post["openqa"]["FLAVOR"] = flavor
-                    full_post["qem"]["flavor"] = flavor
-                    full_post["openqa"]["_ONLY_OBSOLETE_SAME_BUILD"] = "1"
-                    full_post["openqa"]["_OBSOLETE"] = "1"
-                    full_post["openqa"]["INCIDENT_ID"] = inc.id
-
-                    if ci_url:
-                        full_post["openqa"]["__CI_JOB_URL"] = ci_url
-
                     if inc.livepatch:
                         full_post["openqa"]["KGRAFT"] = "1"
 
@@ -135,11 +137,6 @@ class Incidents(BaseConf):
                     if inc.rrid:
                         full_post["openqa"]["RRID"] = inc.rrid
 
-                    # Settings for the POST command
-                    full_post["openqa"].update(self.settings)
-                    full_post["openqa"]["VERSION"] = self.settings["VERSION"]
-                    full_post["qem"]["version"] = self.settings["VERSION"]
-                    full_post["openqa"]["DISTRI"] = self.settings["DISTRI"]
                     # old bot used variable "REPO_ID"
                     revs = inc.revisions_with_fallback(arch, self.settings["VERSION"])
                     if not revs:

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -96,27 +96,12 @@ class Incidents(BaseConf):
                             inc.id,
                         )
                         continue
-                    full_post: Dict[str, Any] = {}
-                    full_post["api"] = "api/incident_settings"
-                    full_post["qem"] = {}
-                    full_post["openqa"] = {}
-                    full_post["openqa"].update(self.settings)
-                    full_post["qem"]["incident"] = inc.id
-                    full_post["openqa"]["ARCH"] = arch
-                    full_post["qem"]["arch"] = arch
-                    full_post["openqa"]["FLAVOR"] = flavor
-                    full_post["qem"]["flavor"] = flavor
-                    full_post["openqa"]["VERSION"] = self.settings["VERSION"]
-                    full_post["qem"]["version"] = self.settings["VERSION"]
-                    full_post["openqa"]["DISTRI"] = self.settings["DISTRI"]
-                    full_post["openqa"]["_ONLY_OBSOLETE_SAME_BUILD"] = "1"
-                    full_post["openqa"]["_OBSOLETE"] = "1"
-                    full_post["openqa"]["INCIDENT_ID"] = inc.id
 
-                    if ci_url:
-                        full_post["openqa"]["__CI_JOB_URL"] = ci_url
                     if inc.staging:
                         continue
+
+                    if "flavor_settings" in data:
+                        self.settings.update(data["flavor_settings"])
 
                     if "packages" in data:
                         if not inc.contains_package(data["packages"]):
@@ -126,6 +111,22 @@ class Incidents(BaseConf):
                         if inc.contains_package(data["excluded_packages"]):
                             continue
 
+                    full_post: Dict[str, Any] = {}
+                    full_post["api"] = "api/incident_settings"
+                    full_post["qem"] = {}
+                    full_post["openqa"] = {}
+                    full_post["qem"]["incident"] = inc.id
+                    full_post["openqa"]["ARCH"] = arch
+                    full_post["qem"]["arch"] = arch
+                    full_post["openqa"]["FLAVOR"] = flavor
+                    full_post["qem"]["flavor"] = flavor
+                    full_post["openqa"]["_ONLY_OBSOLETE_SAME_BUILD"] = "1"
+                    full_post["openqa"]["_OBSOLETE"] = "1"
+                    full_post["openqa"]["INCIDENT_ID"] = inc.id
+
+                    if ci_url:
+                        full_post["openqa"]["__CI_JOB_URL"] = ci_url
+
                     if inc.livepatch:
                         full_post["openqa"]["KGRAFT"] = "1"
 
@@ -134,6 +135,11 @@ class Incidents(BaseConf):
                     if inc.rrid:
                         full_post["openqa"]["RRID"] = inc.rrid
 
+                    # Settings for the POST command
+                    full_post["openqa"].update(self.settings)
+                    full_post["openqa"]["VERSION"] = self.settings["VERSION"]
+                    full_post["qem"]["version"] = self.settings["VERSION"]
+                    full_post["openqa"]["DISTRI"] = self.settings["DISTRI"]
                     # old bot used variable "REPO_ID"
                     revs = inc.revisions_with_fallback(arch, self.settings["VERSION"])
                     if not revs:

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -101,18 +101,6 @@ class Incidents(BaseConf):
                     full_post["qem"] = {}
                     full_post["openqa"] = {}
                     full_post["openqa"].update(self.settings)
-                    if "flavor_settings" in data:
-                        if any(
-                            forbidden_key in data["flavor_settings"]
-                            for forbidden_key in ["DISTRI", "VERSION"]
-                        ):
-                            log.error(
-                                "flavor:%s ignored as DISTRI and VERSION not allowed in flavor_settings",
-                                flavor,
-                            )
-                            continue
-                        full_post["openqa"].update(data["flavor_settings"])
-
                     full_post["qem"]["incident"] = inc.id
                     full_post["openqa"]["ARCH"] = arch
                     full_post["qem"]["arch"] = arch
@@ -247,6 +235,16 @@ class Incidents(BaseConf):
                             full_post["openqa"]["_PRIORITY"] = BASE_PRIO + delta_prio
 
                     # add custom vars to job settings
+                    if "params_expand" in data and any(
+                        forbidden_key in data["params_expand"]
+                        for forbidden_key in ["DISTRI", "VERSION"]
+                    ):
+                        log.error(
+                            "flavor:%s ignored as DISTRI and VERSION not allowed in params_expand",
+                            flavor,
+                        )
+                        continue
+
                     if "params_expand" in data:
                         full_post["openqa"].update(data["params_expand"])
 

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -168,11 +168,11 @@ def test_incidents_call_with_packages(request_mock):
     assert len(res) == 1
 
 
-def test_incidents_call_with_flavor_settings(request_mock):
+def test_incidents_call_with_params_expand(request_mock):
     """
     Product configuration has 4 settings.
     Incident configuration has only 1 flavor.
-    The only flavor is using flavor_settings.
+    The only flavor is using params_expand.
     Set of setting in product and flavor:
     - match on SOMETHING: flavor value has to win
     - flavor set extend product set SOMETHING_NEW:
@@ -184,7 +184,7 @@ def test_incidents_call_with_flavor_settings(request_mock):
             "archs": [""],
             "issues": {"1234": ":"},
             "packages": ["Donalduck"],
-            "flavor_settings": {
+            "params_expand": {
                 "SOMETHING": "flavor win",
                 "SOMETHING_NEW": "something flavor specific",
             },
@@ -209,9 +209,9 @@ def test_incidents_call_with_flavor_settings(request_mock):
     assert res[0]["openqa"]["SOMETHING_NEW"] == "something flavor specific"
 
 
-def test_incidents_call_with_flavor_settings_distri_version(request_mock):
+def test_incidents_call_with_params_expand_distri_version(request_mock):
     """
-    DISTRI and VERSION settings cannot be changed using flavor_settings.
+    DISTRI and VERSION settings cannot be changed using params_expand.
     """
     test_config = {}
     test_config["FLAVOR"] = {
@@ -219,7 +219,7 @@ def test_incidents_call_with_flavor_settings_distri_version(request_mock):
             "archs": [""],
             "issues": {"1234": ":"},
             "packages": ["Donalduck"],
-            "flavor_settings": {
+            "params_expand": {
                 "DISTRI": "flavor distri",
                 "SOMETHING": "flavor win",
             },
@@ -228,7 +228,7 @@ def test_incidents_call_with_flavor_settings_distri_version(request_mock):
             "archs": [""],
             "issues": {"1234": ":"},
             "packages": ["Donalduck"],
-            "flavor_settings": {
+            "params_expand": {
                 "VERSION": "flavor version",
                 "SOMETHING": "flavor win",
             },
@@ -237,7 +237,7 @@ def test_incidents_call_with_flavor_settings_distri_version(request_mock):
             "archs": [""],
             "issues": {"1234": ":"},
             "packages": ["Donalduck"],
-            "flavor_settings": {
+            "params_expand": {
                 "SOMETHING": "flavor win",
             },
         },
@@ -260,11 +260,11 @@ def test_incidents_call_with_flavor_settings_distri_version(request_mock):
     assert res[0]["openqa"]["SOMETHING"] == "flavor win"
 
 
-def test_incidents_call_with_flavor_settings_isolated(request_mock):
+def test_incidents_call_with_params_expand_isolated(request_mock):
     """
     Product configuration has 4 settings.
     Incident configuration has 2 flavors.
-    Only the first flavor is using flavor_settings, the other is not.
+    Only the first flavor is using params_expand, the other is not.
     Test that POST for the second exactly and only contains the product settings.
     """
     test_config = {}
@@ -273,7 +273,7 @@ def test_incidents_call_with_flavor_settings_isolated(request_mock):
             "archs": [""],
             "issues": {"1234": ":"},
             "packages": ["Donalduck"],
-            "flavor_settings": {
+            "params_expand": {
                 "SOMETHING": "flavor win",
                 "SOMETHING_NEW": "something flavor specific",
             },

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -209,6 +209,57 @@ def test_incidents_call_with_flavor_settings(request_mock):
     assert res[0]["openqa"]["SOMETHING_NEW"] == "something flavor specific"
 
 
+def test_incidents_call_with_flavor_settings_distri_version(request_mock):
+    """
+    DISTRI and VERSION settings cannot be changed using flavor_settings.
+    """
+    test_config = {}
+    test_config["FLAVOR"] = {
+        "AAA": {
+            "archs": [""],
+            "issues": {"1234": ":"},
+            "packages": ["Donalduck"],
+            "flavor_settings": {
+                "DISTRI": "flavor distri",
+                "SOMETHING": "flavor win",
+            },
+        },
+        "BBB": {
+            "archs": [""],
+            "issues": {"1234": ":"},
+            "packages": ["Donalduck"],
+            "flavor_settings": {
+                "VERSION": "flavor version",
+                "SOMETHING": "flavor win",
+            },
+        },
+        "CCC": {
+            "archs": [""],
+            "issues": {"1234": ":"},
+            "packages": ["Donalduck"],
+            "flavor_settings": {
+                "SOMETHING": "flavor win",
+            },
+        },
+    }
+
+    inc = Incidents(
+        product="",
+        settings={
+            "VERSION": "1.2.3",
+            "DISTRI": "IM_A_DISTRI",
+            "SOMETHING": "original",
+        },
+        config=test_config,
+        extrasettings=set(),
+    )
+    res = inc(incidents=[MyIncident_3()], token={}, ci_url="", ignore_onetime=False)
+    assert len(res) == 1
+    assert res[0]["openqa"]["VERSION"] == "1.2.3"
+    assert res[0]["openqa"]["DISTRI"] == "IM_A_DISTRI"
+    assert res[0]["openqa"]["SOMETHING"] == "flavor win"
+
+
 def test_incidents_call_with_flavor_settings_isolated(request_mock):
     """
     Product configuration has 4 settings.


### PR DESCRIPTION
Add support for a new Incidents configuration field that allow to
specify flavor specific settings.

Keep separated settings for each flavor loop


Ticket: TEAM-8180