### PR TITLE
Give openQA tests a chance to finish with depriorization instead of obsoletion

### DIFF
--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -167,10 +167,10 @@ class Aggregate(BaseConf):
                 if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
                     continue
 
+            self.set_obsoletion(settings)
             full_post["openqa"].update(settings)
             full_post["openqa"]["FLAVOR"] = self.flavor
             full_post["openqa"]["ARCH"] = arch
-            full_post["openqa"]["_OBSOLETE"] = 1
 
             for template, issues in test_incidents.items():
                 full_post["openqa"][template] = ",".join(str(x) for x in issues)

--- a/openqabot/types/baseconf.py
+++ b/openqabot/types/baseconf.py
@@ -27,3 +27,8 @@ class BaseConf(metaclass=ABCMeta):
 
     def filter_embargoed(self) -> bool:
         return any(k.startswith("PUBLIC") for k in self.settings.keys())
+
+    @staticmethod
+    def set_obsoletion(settings: dict) -> None:
+        if "_OBSOLETE" not in settings:
+            settings["_DEPRIORITIZEBUILD"] = 1

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -101,6 +101,7 @@ class Incidents(BaseConf):
                     full_post["qem"] = {}
                     full_post["openqa"] = {}
                     full_post["openqa"].update(self.settings)
+                    self.set_obsoletion(full_post["openqa"])
                     full_post["qem"]["incident"] = inc.id
                     full_post["openqa"]["ARCH"] = arch
                     full_post["qem"]["arch"] = arch
@@ -110,7 +111,6 @@ class Incidents(BaseConf):
                     full_post["qem"]["version"] = self.settings["VERSION"]
                     full_post["openqa"]["DISTRI"] = self.settings["DISTRI"]
                     full_post["openqa"]["_ONLY_OBSOLETE_SAME_BUILD"] = "1"
-                    full_post["openqa"]["_OBSOLETE"] = "1"
                     full_post["openqa"]["INCIDENT_ID"] = inc.id
 
                     if ci_url:


### PR DESCRIPTION
This gives older builds a chance to finish while new ones are being triggered
regardless of the reason. The approach taken here should still allow for
externally provided settings to override the new default of
"_DEPRIORITIZEBUILD" with the "_OBSOLETE" switch as required. See
http://open.qa/docs/#_spawning_multiple_jobs_based_on_templates_isos_post for
more details about the scheduling flags.

The only test I conducted so far is executing all unit tests which pass.
I did not check if that settings actually end up in the scheduled product
nor if overriding still works.

Related progress issue: https://progress.opensuse.org/issues/94606