### PR TITLE
Add linting support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
           cache: 'pip'
       - name: Setup enviroment
         run: pip install -r requirements-dev.txt
+      - name: Linting
+        run: make lint
       - name: Run tests + cov report
         run: make test-with-coverage
       - name: Check style

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
           cache: 'pip'
       - name: Setup enviroment
         run: pip install -r requirements-dev.txt
-      - name: Linting
-        run: make lint
       - name: Run tests + cov report
         run: make test-with-coverage
       - name: Check style

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ all:
 only-test:
 	python3 -m pytest
 
-.PHONY: checkstyle
-checkstyle:
+.PHONY: black
+black:
 	black --check ./
 
 .PHONY: tidy
@@ -21,12 +21,17 @@ pylint:
 flake8:
 	flake8 ./openqabot pc_helper_online.py --config=setup.cfg
 
-.PHONY: lint
-lint: pylint flake8
-
 .PHONY: test-with-coverage
 test-with-coverage:
 	python3 -m pytest -v --cov=./openqabot --cov-report=xml --cov-report=term
 
+# aggregate targets
+
+.PHONY: lint
+lint: pylint flake8
+
+.PHONY: checkstyle
+checkstyle: black lint
+
 .PHONY: test
-test: only-test checkstyle lint
+test: only-test checkstyle

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,20 @@ checkstyle:
 tidy:
 	black ./
 
+.PHONY: pylint
+pylint:
+	pylint ./openqabot pc_helper_online.py --rcfile=pylintrc
+
+.PHONY: flake8
+flake8:
+	flake8 ./openqabot pc_helper_online.py --config=setup.cfg
+
+.PHONY: lint
+lint: pylint flake8
+
 .PHONY: test-with-coverage
 test-with-coverage:
 	python3 -m pytest -v --cov=./openqabot --cov-report=xml --cov-report=term
 
 .PHONY: test
-test: only-test checkstyle
+test: only-test checkstyle lint

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -35,20 +35,25 @@ def _mi2str(inc: IncReq) -> str:
 def _handle_http_error(e: HTTPError, inc: IncReq) -> bool:
     if e.code == 403:
         log.info(
-            "Received '%s'. Request %s likely already approved, ignoring"
-            % (e.reason, inc.req)
+            "Received '%s'. Request %s likely already approved, ignoring",
+            e.reason,
+            inc.req,
         )
         return True
     elif e.code == 404:
         log.info(
-            "Received '%s'. Request %s removed or problem on OBS side: %s"
-            % (e.reason, inc.req, e.read().decode())
+            "Received '%s'. Request %s removed or problem on OBS side: %s",
+            e.reason,
+            inc.req,
+            e.read().decode(),
         )
         return False
     else:
         log.error(
-            "Received error %s, reason: '%s' for Request %s - problem on OBS side"
-            % (e.code, e.reason, inc.req)
+            "Received error %s, reason: '%s' for Request %s - problem on OBS side",
+            e.code,
+            e.reason,
+            inc.req,
         )
         return False
 
@@ -74,7 +79,7 @@ class Approver:
 
         log.info("Incidents to approve:")
         for inc in incidents_to_approve:
-            log.info("* %s" % _mi2str(inc))
+            log.info("* %s", _mi2str(inc))
 
         if not self.dry:
             osc.conf.get_config(override_apiurl=OBS_URL)
@@ -97,19 +102,19 @@ class Approver:
             log.info(e)
 
             if any(i.withAggregate for i in i_jobs):
-                log.info("Aggregate missing for %s" % _mi2str(inc))
+                log.info("Aggregate missing for %s", _mi2str(inc))
                 return False
 
             u_jobs = []
 
         if not self.get_incident_result(i_jobs, "api/jobs/incident/", inc.inc):
-            log.info("%s has at least one failed job in incident tests" % _mi2str(inc))
+            log.info("%s has at least one failed job in incident tests", _mi2str(inc))
             return False
 
         if any(i.withAggregate for i in i_jobs):
             if not self.get_incident_result(u_jobs, "api/jobs/update/", inc.inc):
                 log.info(
-                    "%s has at least one failed job in aggregate tests" % _mi2str(inc)
+                    "%s has at least one failed job in aggregate tests", _mi2str(inc)
                 )
                 return False
 
@@ -140,14 +145,18 @@ class Approver:
                 continue
             if self.is_job_marked_acceptable_for_incident(res["job_id"], inc):
                 log.info(
-                    "Ignoring failed job %s/t%s for incident %s due to openQA comment"
-                    % (str(self.client.url.geturl()), res["job_id"], inc)
+                    "Ignoring failed job %s/t%s for incident %s due to openQA comment",
+                    str(self.client.url.geturl()),
+                    res["job_id"],
+                    inc,
                 )
                 res["status"] = "passed"
             else:
                 log.info(
-                    "Found failed, not-ignored job %s/t%s for incident %s"
-                    % (str(self.client.url.geturl()), res["job_id"], inc)
+                    "Found failed, not-ignored job %s/t%s for incident %s",
+                    str(self.client.url.geturl()),
+                    res["job_id"],
+                    inc,
                 )
                 break
 
@@ -178,11 +187,7 @@ class Approver:
         msg = (
             "Request accepted for '" + OBS_GROUP + "' based on data in " + QEM_DASHBOARD
         )
-        log.info(
-            "Accepting review for "
-            + OBS_MAINT_PRJ
-            + ":%s:%s" % (str(inc.inc), str(inc.req))
-        )
+        log.info("Accepting review for %s:%s:%s", OBS_MAINT_PRJ, inc.inc, inc.req)
 
         try:
             osc.core.change_review_state(

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -5,10 +5,10 @@ from functools import lru_cache
 from logging import getLogger
 from typing import List
 from urllib.error import HTTPError
+import re
 
 import osc.conf
 import osc.core
-import re
 
 from openqa_client.exceptions import RequestError
 from openqabot.errors import NoResultsError
@@ -40,7 +40,7 @@ def _handle_http_error(e: HTTPError, inc: IncReq) -> bool:
             inc.req,
         )
         return True
-    elif e.code == 404:
+    if e.code == 404:
         log.info(
             "Received '%s'. Request %s removed or problem on OBS side: %s",
             e.reason,
@@ -48,14 +48,13 @@ def _handle_http_error(e: HTTPError, inc: IncReq) -> bool:
             e.read().decode(),
         )
         return False
-    else:
-        log.error(
-            "Received error %s, reason: '%s' for Request %s - problem on OBS side",
-            e.code,
-            e.reason,
-            inc.req,
-        )
-        return False
+    log.error(
+        "Received error %s, reason: '%s' for Request %s - problem on OBS side",
+        e.code,
+        e.reason,
+        inc.req,
+    )
+    return False
 
 
 class Approver:

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -44,12 +44,12 @@ class Commenter:
 
             state = "none"
             if any(j["status"] in ["running"] for j in i_jobs + u_jobs):
-                log.info("%s needs to wait a bit longer" % inc)
+                log.info("%s needs to wait a bit longer", inc)
             else:
                 if any(
                     j["status"] not in ["passed", "softfailed"] for j in i_jobs + u_jobs
                 ):
-                    log.info("There is a failed job for %s" % inc)
+                    log.info("There is a failed job for %s", inc)
                     state = "failed"
                 else:
                     state = "passed"
@@ -99,12 +99,12 @@ class Commenter:
             if not self.dry:
                 self.commentapi.delete(comment["id"])
             else:
-                log.info("Would delete comment %d" % int(comment["id"]))
+                log.info("Would delete comment %s", comment["id"])
 
         if not self.dry:
             self.commentapi.add_comment(comment=msg, **kw)
         else:
-            log.info("Would write comment to request %s" % inc)
+            log.info("Would write comment to request %s", inc)
             log.debug(pformat(msg))
 
     def summarize_message(self, jobs) -> str:
@@ -112,7 +112,7 @@ class Commenter:
         for job in jobs:
             if "job_group" not in job:
                 # workaround for experiments of some QAM devs
-                log.warning(f"group missing in {job['job_id']}")
+                log.warning("group missing in %s", job["job_id"])
                 continue
             gl = "{!s}@{!s}".format(
                 Commenter.emd(job["job_group"]), Commenter.emd(job["flavor"])

--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -36,7 +36,7 @@ def load_metadata(
             continue
 
         if "product" not in data:
-            log.debug("Skipping invalid config %s" % p)
+            log.debug("Skipping invalid config %s", p)
             continue
 
         if settings:
@@ -49,7 +49,7 @@ def load_metadata(
                     try:
                         ret.append(Aggregate(data["product"], settings, data[key]))
                     except NoTestIssues:
-                        log.warning("No 'test_issues' in %s config" % data["product"])
+                        log.warning("No 'test_issues' in %s config", data["product"])
                 else:
                     continue
     return ret
@@ -63,16 +63,16 @@ def read_products(path: Path) -> List[Data]:
         data = loader.load(p)
 
         if not data:
-            log.info("Skipping invalid config %s - empty config" % str(p))
+            log.info("Skipping invalid config %s - empty config", str(p))
             continue
         if not isinstance(data, dict):
-            log.info("Skipping invalid config %s - invalid format" % str(p))
+            log.info("Skipping invalid config %s - invalid format", str(p))
             continue
 
         try:
             flavor = data["aggregate"]["FLAVOR"]
         except KeyError:
-            log.info("Config %s does not have aggregate" % str(p))
+            log.info("Config %s does not have aggregate", str(p))
             continue
 
         try:

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -47,15 +47,15 @@ def get_incidents(token: Dict[str, str]) -> List[Incident]:
             xs.append(Incident(i))
         except NoRepoFoundError as e:
             log.info(
-                "Project %s can't calculate repohash %s .. skipping" % (i["project"], e)
+                "Project %s can't calculate repohash %s .. skipping", i["project"], e
             )
         except EmptyChannels:
             log.info(
-                "Project %s has empty channels - check incident in SMELT" % i["project"]
+                "Project %s has empty channels - check incident in SMELT", i["project"]
             )
         except EmptyPackagesError:
             log.info(
-                "Project %s has empty packages - check incident in SMELT" % i["project"]
+                "Project %s has empty packages - check incident in SMELT", i["project"]
             )
 
     return xs
@@ -101,7 +101,7 @@ def get_incident_settings(
 
 def get_incident_settings_data(token: Dict[str, str], number: int) -> Sequence[Data]:
     url = QEM_DASHBOARD + "api/incident_settings/" + f"{number}"
-    log.info("Getting settings for %s" % number)
+    log.info("Getting settings for %s", number)
     try:
         data = requests.get(url, headers=token).json()
     except Exception as e:
@@ -184,7 +184,7 @@ def get_aggregate_settings_data(token: Dict[str, str], data: Data):
             f"Product: {data.product} on arch: {data.arch} does not have any settings"
         )
 
-    log.debug("Getting id for %s" % pformat(data))
+    log.debug("Getting id for %s", pformat(data))
 
     # use last three schedule
     for s in settings[:3]:
@@ -241,8 +241,8 @@ def update_incidents(token: Dict[str, str], data, **kwargs) -> int:
                 log.info("Smelt Incidents updated")
             else:
                 log.error(
-                    "Smelt Incidents were not synced to dashboard: error %s"
-                    % ret.status_code
+                    "Smelt Incidents were not synced to dashboard: error %s",
+                    ret.status_code,
                 )
                 continue
         return 0

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -75,8 +75,10 @@ def get_incidents_approver(token: Dict[str, str]) -> List[IncReq]:
     return [IncReq(i["number"], i["rr_number"]) for i in incidents if i["inReviewQAM"]]
 
 
-def get_single_incident(token: Dict[str, str], id: int) -> List[IncReq]:
-    incident = requests.get(QEM_DASHBOARD + "api/incidents/" + id, headers=token).json()
+def get_single_incident(token: Dict[str, str], incident_id: int) -> List[IncReq]:
+    incident = requests.get(
+        QEM_DASHBOARD + "api/incidents/" + incident_id, headers=token
+    ).json()
     return [IncReq(incident["number"], incident["rr_number"])]
 
 
@@ -87,7 +89,7 @@ def get_incident_settings(
         QEM_DASHBOARD + "api/incident_settings/" + str(inc), headers=token
     ).json()
     if not settings:
-        raise NoResultsError("Inc %s does not have any job_settings" % str(inc))
+        raise NoResultsError(f"Inc {inc} does not have any job_settings")
 
     if not all_incidents:
         rrids = [i["settings"].get("RRID", None) for i in settings]
@@ -156,7 +158,7 @@ def get_aggregate_settings(inc: int, token: Dict[str, str]) -> List[JobAggr]:
         QEM_DASHBOARD + "api/update_settings/" + str(inc), headers=token
     ).json()
     if not settings:
-        raise NoResultsError("Inc %s does not have any aggregates settings" % str(inc))
+        raise NoResultsError(f"Inc {inc} does not have any aggregates settings")
 
     # is string comparsion ... so we need reversed sort
     settings = sorted(settings, key=itemgetter("build"), reverse=True)
@@ -236,15 +238,14 @@ def update_incidents(token: Dict[str, str], data, **kwargs) -> int:
         except Exception as e:
             log.exception(e)
             return 1
+        if ret.status_code == 200:
+            log.info("Smelt Incidents updated")
         else:
-            if ret.status_code == 200:
-                log.info("Smelt Incidents updated")
-            else:
-                log.error(
-                    "Smelt Incidents were not synced to dashboard: error %s",
-                    ret.status_code,
-                )
-                continue
+            log.error(
+                "Smelt Incidents were not synced to dashboard: error %s",
+                ret.status_code,
+            )
+            continue
         return 0
     return 2
 

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -49,11 +49,11 @@ def get_incidents(token: Dict[str, str]) -> List[Incident]:
             log.info(
                 "Project %s can't calculate repohash %s .. skipping" % (i["project"], e)
             )
-        except EmptyChannels as e:
+        except EmptyChannels:
             log.info(
                 "Project %s has empty channels - check incident in SMELT" % i["project"]
             )
-        except EmptyPackagesError as e:
+        except EmptyPackagesError:
             log.info(
                 "Project %s has empty packages - check incident in SMELT" % i["project"]
             )

--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -1,6 +1,5 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
-from datetime import datetime
 from hashlib import md5
 from logging import getLogger
 from typing import List, Tuple

--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -46,7 +46,7 @@ def get_max_revision(
             raise e
 
         if cs is None:
-            log.error("%s's revision is None" % url)
+            log.error("%s's revision is None", url)
             raise NoRepoFoundError
 
         rev = int(str(cs.text))

--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -151,7 +151,7 @@ def get_active_incidents() -> Set[int]:
         if has_next:
             cursor = incidents["pageInfo"]["endCursor"]
 
-    log.info("Loaded %s active incidents" % len(active))
+    log.info("Loaded %s active incidents", len(active))
 
     return active
 
@@ -159,16 +159,16 @@ def get_active_incidents() -> Set[int]:
 def get_incident(incident: int):
     query = INCIDENT % {"incident": incident}
 
-    log.info("Getting info about incident %s from SMELT" % incident)
+    log.info("Getting info about incident %s from SMELT", incident)
     inc_result = get_json(query)
     try:
         validate(instance=inc_result, schema=INCIDENT_SCHEMA)
         inc_result = walk(inc_result["data"]["incidents"]["edges"][0]["node"])
     except ValidationError:
-        log.exception("Invalid data from SMELT for incident %s" % incident)
+        log.exception("Invalid data from SMELT for incident %s", incident)
         return None
     except Exception as e:
-        log.error("Unknown error for incident %s" % incident)
+        log.error("Unknown error for incident %s", incident)
         log.exception(e)
         return None
 

--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -142,7 +142,7 @@ def get_active_incidents() -> Set[int]:
         ndata = get_json(query)
         try:
             validate(instance=ndata, schema=ACTIVE_INC_SCHEMA)
-        except ValidationError as e:
+        except ValidationError:
             log.exception("Invalid data from SMELT received")
             return []
         incidents = ndata["data"]["incidents"]
@@ -164,7 +164,7 @@ def get_incident(incident: int):
     try:
         validate(instance=inc_result, schema=INCIDENT_SCHEMA)
         inc_result = walk(inc_result["data"]["incidents"]["edges"][0]["node"])
-    except ValidationError as e:
+    except ValidationError:
         log.exception("Invalid data from SMELT for incident %s" % incident)
         return None
     except Exception as e:

--- a/openqabot/main.py
+++ b/openqabot/main.py
@@ -18,7 +18,7 @@ def main() -> None:
     cfg = parser.parse_args(sys.argv[1:])
 
     if not cfg.configs.exists() and not cfg.configs.is_dir():
-        log.error(f"Path {cfg.configs} is not a valid directory with config files")
+        log.error("Path %s is not a valid directory with config files", cfg.configs)
         sys.exit(1)
 
     if not hasattr(cfg, "func"):

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 import logging
 from pprint import pformat
 from urllib.parse import ParseResult
+from typing import Dict
 
 from openqa_client.client import OpenQA_Client
 from openqa_client.exceptions import RequestError

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -32,33 +32,29 @@ class openQAInterface:
 
     def post_job(self, settings) -> None:
         log.info(
-            "openqa-cli api --host %s -X post isos %s"
-            % (
-                self.url.geturl(),
-                " ".join(["%s=%s" % (k, v) for k, v in settings.items()]),
-            )
+            "openqa-cli api --host %s -X post isos %s",
+            self.url.geturl(),
+            " ".join(["%s=%s" % (k, v) for k, v in settings.items()]),
         )
         try:
             self.openqa.openqa_request(
                 "POST", "isos", data=settings, retries=self.retries
             )
         except RequestError as e:
-            log.error("openQA returned %s" % e.args[-1])
-            log.error("Post failed with {}".format(pformat(settings)))
+            log.error("openQA returned %s", e.args[-1])
+            log.error("Post failed with %s", pformat(settings))
             raise PostOpenQAError
         except Exception as e:
             log.exception(e)
-            log.error("Post failed with {}".format(pformat(settings)))
+            log.error("Post failed with %s", pformat(settings))
             raise PostOpenQAError
 
     def handle_job_not_found(self, job_id: int):
-        log.info(
-            "Job %s not found in openQA, marking as obsolete on dashboard" % job_id
-        )
+        log.info("Job %s not found in openQA, marking as obsolete on dashboard", job_id)
         update_job(self.qem_token, job_id, {"obsolete": True})
 
     def get_jobs(self, data: Data):
-        log.info("Getting openQA tests results for %s" % pformat(data))
+        log.info("Getting openQA tests results for %s", pformat(data))
         param = {}
         param["scope"] = "relevant"
         param["latest"] = "1"

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -81,7 +81,7 @@ class openQAInterface:
             )
             ret = list(map(lambda c: {"text": c.get("text", "")}, ret))
         except Exception as e:
-            (method, url, status_code, *other) = e.args
+            (_, _, status_code, *_) = e.args
             if status_code == 404:
                 self.handle_job_not_found(job_id)
             else:

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -21,7 +21,7 @@ class OpenQABot:
         self.ignore_onetime = args.ignore_onetime
         self.token = {"Authorization": "Token " + args.token}
         self.incidents = get_incidents(self.token)
-        log.info("%s incidents loaded from qem dashboard" % len(self.incidents))
+        log.info("%s incidents loaded from qem dashboard", len(self.incidents))
 
         extrasettings = get_onearch(args.singlearch)
 
@@ -35,8 +35,8 @@ class OpenQABot:
     def post_qem(self, data, api) -> None:
         if not self.openqa:
             log.warning(
-                "No valid openQA configuration specified: '%s' not posted to dashboard"
-                % data
+                "No valid openQA configuration specified: '%s' not posted to dashboard",
+                data,
             )
             return
 
@@ -44,8 +44,9 @@ class OpenQABot:
         try:
             res = requests.put(url, headers=self.token, json=data)
             log.info(
-                "Put to dashboard result %s, database id: %s"
-                % (res.status_code, res.json().get("id", "No id?"))
+                "Put to dashboard result %s, database id: %s",
+                res.status_code,
+                res.json().get("id", "No id?"),
             )
         except Exception as e:
             log.exception(e)
@@ -61,14 +62,14 @@ class OpenQABot:
             post += worker(self.incidents, self.token, self.ci, self.ignore_onetime)
 
         if self.dry:
-            log.info("Would trigger %d products in openQA" % len(post))
+            log.info("Would trigger %d products in openQA", len(post))
             for job in post:
                 log.info(job)
 
         else:
-            log.info("Triggering %d products in openQA" % len(post))
+            log.info("Triggering %d products in openQA", len(post))
             for job in post:
-                log.info("Triggering %s" % str(job))
+                log.info("Triggering %s", str(job))
                 try:
                     self.post_openqa(job["openqa"])
                 except PostOpenQAError:

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -74,7 +74,6 @@ class OpenQABot:
                     self.post_openqa(job["openqa"])
                 except PostOpenQAError:
                     log.info("POST failed, not updating dashboard")
-                    pass
                 else:
                     self.post_qem(job["qem"], job["api"])
 

--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -16,7 +16,7 @@ def get_latest_tools_image(query):
     a value for <BUILD NUM>
     """
 
-    ## Get the first not-failing item
+    # Get the first not-failing item
     build_results = requests.get(query).json()["build_results"]
     for build in build_results:
         if build["failed"] == 0:
@@ -35,7 +35,7 @@ def apply_pc_tools_image(settings):
                 settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
             )
     except BaseException as e:
-        log_error = f"PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed"
+        log_error = "PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed"
         if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
             log_error += f" PUBLIC_CLOUD_TOOLS_IMAGE_QUERY={settings['PUBLIC_CLOUD_TOOLS_IMAGE_QUERY']}"
         log.warning(f"{log_error} : {e}")

--- a/openqabot/pc_helper.py
+++ b/openqabot/pc_helper.py
@@ -38,7 +38,7 @@ def apply_pc_tools_image(settings):
         log_error = "PUBLIC_CLOUD_TOOLS_IMAGE_BASE handling failed"
         if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
             log_error += f" PUBLIC_CLOUD_TOOLS_IMAGE_QUERY={settings['PUBLIC_CLOUD_TOOLS_IMAGE_QUERY']}"
-        log.warning(f"{log_error} : {e}")
+        log.warning("%s : %s", log_error, e)
     finally:
         del settings["PUBLIC_CLOUD_TOOLS_IMAGE_QUERY"]
     return settings
@@ -84,7 +84,7 @@ def apply_publiccloud_pint_image(settings):
         log_error = "PUBLIC_CLOUD_PINT_QUERY handling failed"
         if "PUBLIC_CLOUD_PINT_NAME" in settings:
             log_error += f' for {settings["PUBLIC_CLOUD_PINT_NAME"]}'
-        log.warning(f"{log_error}: {e}")
+        log.warning("{%s: %s", log_error, e)
         settings["PUBLIC_CLOUD_IMAGE_ID"] = None
     finally:
         if "PUBLIC_CLOUD_PINT_QUERY" in settings:

--- a/openqabot/smeltsync.py
+++ b/openqabot/smeltsync.py
@@ -23,8 +23,8 @@ class SMELTSync:
         log.info("Start syncing incidents from smelt to dashboard")
 
         data = self._create_list(self.incidents)
-        log.info("Updating info about %s incidents" % str(len(data)))
-        log.info("Data: %s" % pformat(data))
+        log.info("Updating info about %s incidents", str(len(data)))
+        log.info("Data: %s", pformat(data))
 
         if not self.dry:
             ret = update_incidents(self.token, data, retry=self.retry)

--- a/openqabot/smeltsync.py
+++ b/openqabot/smeltsync.py
@@ -35,35 +35,25 @@ class SMELTSync:
         return ret
 
     @staticmethod
-    def _review_rrequest(requestSet):
-        if not requestSet:
+    def _review_rrequest(request_set):
+        if not request_set:
             return None
-        else:
-            rr = sorted(requestSet, key=itemgetter("requestId"), reverse=True)[0]
-            if rr["status"]["name"] in ("new", "review", "accepted", "revoked"):
-                return rr
-            else:
-                return None
+        rr = sorted(request_set, key=itemgetter("requestId"), reverse=True)[0]
+        if rr["status"]["name"] in ("new", "review", "accepted", "revoked"):
+            return rr
+        return None
 
     @staticmethod
     def _is_inreview(rr_number) -> bool:
         if rr_number["reviewSet"]:
-            if rr_number["status"]["name"] == "review":
-                return True
-            else:
-                return False
-        else:
-            return False
+            return rr_number["status"]["name"] == "review"
+        return False
 
     @staticmethod
     def _is_revoked(rr_number) -> bool:
         if rr_number["reviewSet"]:
-            if rr_number["status"]["name"] == "revoked":
-                return True
-            else:
-                return False
-        else:
-            return False
+            return rr_number["status"]["name"] == "revoked"
+        return False
 
     @staticmethod
     def _is_accepted(rr_number) -> bool:
@@ -72,8 +62,7 @@ class SMELTSync:
             or rr_number["status"]["name"] == "new"
         ):
             return True
-        else:
-            return False
+        return False
 
     @staticmethod
     def _has_qam_review(rr_number) -> bool:
@@ -91,17 +80,17 @@ class SMELTSync:
 
         rr_number = cls._review_rrequest(inc["requestSet"])
         if rr_number:
-            inReview = cls._is_inreview(rr_number)
+            in_review = cls._is_inreview(rr_number)
             approved = cls._is_accepted(rr_number)
-            inReviewQAM = cls._has_qam_review(rr_number)
+            in_review_qam = cls._has_qam_review(rr_number)
             revoked = cls._is_revoked(rr_number)
             # beware . this must be last.
             rr_number = rr_number["requestId"]
         # no request in requestest --> defaut values
         else:
-            inReview = False
+            in_review = False
             approved = False
-            inReviewQAM = False
+            in_review_qam = False
             revoked = False
 
         if approved or revoked:
@@ -112,10 +101,10 @@ class SMELTSync:
         incident["emu"] = inc["emu"]
         incident["packages"] = [package["name"] for package in inc["packages"]]
         incident["channels"] = [repo["name"] for repo in inc["repositories"]]
-        incident["inReview"] = inReview
+        incident["inReview"] = in_review
         incident["approved"] = approved
         incident["rr_number"] = rr_number
-        incident["inReviewQAM"] = inReviewQAM
+        incident["inReviewQAM"] = in_review_qam
         incident["embargoed"] = bool(inc["crd"])
 
         return incident

--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -58,13 +58,12 @@ class SyncRes:
             return False
 
         if data["clone_id"]:
-            log.info("Job '%s' already has a clone, ignoring" % data["clone_id"])
+            log.info("Job '%s' already has a clone, ignoring", data["clone_id"])
             return False
 
         if self._is_in_devel_group(data):
             log.info(
-                "Ignoring job '%s' in development group '%s'"
-                % (data["id"], data["group"])
+                "Ignoring job '%s' in development group '%s'", data["id"], data["group"]
             )
             return False
 
@@ -72,10 +71,12 @@ class SyncRes:
 
     def post_result(self, result):
         log.debug(
-            "Posting results of %s job %s with status %s"
-            % (self.operation, result["job_id"], result["status"])
+            "Posting results of %s job %s with status %s",
+            self.operation,
+            result["job_id"],
+            result["status"],
         )
-        log.debug("Full post data: %s" % pformat(result))
+        log.debug("Full post data: %s", pformat(result))
 
         if not self.dry and self.client:
             post_job(self.token, result)

--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -54,7 +54,7 @@ class SyncRes:
     def filter_jobs(self, data) -> bool:
         """Filter out invalid/development jobs from results"""
 
-        if not "group" in data:
+        if "group" not in data:
             return False
 
         if data["clone_id"]:

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -142,8 +142,9 @@ class Aggregate(BaseConf):
                 )
             except SameBuildExists:
                 log.info(
-                    "For %s aggreagate on %s there is existing build"
-                    % (self.product, arch)
+                    "For %s aggreagate on %s there is existing build",
+                    self.product,
+                    arch,
                 )
                 continue
 

--- a/openqabot/types/baseconf.py
+++ b/openqabot/types/baseconf.py
@@ -7,7 +7,9 @@ from .incident import Incident
 
 
 class BaseConf(metaclass=ABCMeta):
-    def __init__(self, product: str, settings, config) -> None:
+    def __init__(
+        self, product: str, settings, config  # pylint: disable=unused-argument
+    ) -> None:
         self.product = product
         self.settings = settings
 

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -80,7 +80,7 @@ class Incident:
                 arch_ver = ArchVer(arch, "12")
             return self.revisions[arch_ver]
         except KeyError:
-            log.debug("Incident %s does not have %s arch in %s" % (self.id, arch, ver))
+            log.debug("Incident %s does not have %s arch in %s", self.id, arch, ver)
             return None
 
     @staticmethod

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -150,7 +150,7 @@ class Incidents(BaseConf):
 
                     if not issue_dict:
                         log.debug(
-                            "No channels in %s for %s on %s" % (inc.id, flavor, arch)
+                            "No channels in %s for %s on %s", inc.id, flavor, arch
                         )
                         continue
 
@@ -162,8 +162,11 @@ class Incidents(BaseConf):
                         token, inc, arch, self.settings["VERSION"], flavor
                     ):
                         log.info(
-                            "not scheduling: Flavor: %s, version: %s incident: %s , arch: %s  - exists in openQA "
-                            % (flavor, self.settings["VERSION"], inc.id, arch)
+                            "not scheduling: Flavor: %s, version: %s incident: %s , arch: %s  - exists in openQA",
+                            flavor,
+                            self.settings["VERSION"],
+                            inc.id,
+                            arch,
                         )
                         continue
 
@@ -183,8 +186,8 @@ class Incidents(BaseConf):
                             )
                         ):
                             log.warning(
-                                "Kernel incident %s doesn't have product repository"
-                                % str(inc)
+                                "Kernel incident %s doesn't have product repository",
+                                str(inc),
                             )
                             continue
 
@@ -208,10 +211,10 @@ class Incidents(BaseConf):
 
                         if pos and not pos.isdisjoint(full_post["openqa"].keys()):
                             full_post["qem"]["withAggregate"] = False
-                            log.info("Aggregate not needed for incident %s" % inc.id)
+                            log.info("Aggregate not needed for incident %s", inc.id)
                         if neg and neg.isdisjoint(full_post["openqa"].keys()):
                             full_post["qem"]["withAggregate"] = False
-                            log.info("Aggregate not needed for incident %s" % inc.id)
+                            log.info("Aggregate not needed for incident %s", inc.id)
                         if not (neg and pos):
                             full_post["qem"]["withAggregate"] = False
 

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -3,7 +3,7 @@
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from . import ArchVer, ProdVer, Repos
+from . import ProdVer, Repos
 from .. import QEM_DASHBOARD
 from ..pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 from ..utils import retry3 as requests

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -46,7 +46,7 @@ def walk(inc):
         if len(inc) == 1:
             if "edges" in inc:
                 return walk(inc["edges"])
-            elif "node" in inc:
+            if "node" in inc:
                 tmp = deepcopy(inc["node"])
                 del inc["node"]
                 inc.update(tmp)

--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -29,24 +29,24 @@ def main():
         help="Directory with openqabot configuration metadata",
     )
     args = parser.parse_args()
-    log.info(f"Parsing configuration files from {args.configs}")
+    log.info("Parsing configuration files from %s", args.configs)
     loader = YAML(typ="safe")
     for p in get_yml_list(Path(args.configs)):
         try:
             data = loader.load(p)
-            log.info(f"Processing {p}")
+            log.info("Processing %s", p)
             if "settings" in data:
                 settings = data["settings"]
                 if "PUBLIC_CLOUD_TOOLS_IMAGE_QUERY" in settings:
                     apply_pc_tools_image(settings)
                     if "PUBLIC_CLOUD_TOOLS_IMAGE_BASE" not in settings:
                         log.error(
-                            f"Failed to get PUBLIC_CLOUD_TOOLS_IMAGE_BASE from {data}"
+                            "Failed to get PUBLIC_CLOUD_TOOLS_IMAGE_BASE from %s", data
                         )
                 if "PUBLIC_CLOUD_PINT_QUERY" in settings:
                     apply_publiccloud_pint_image(settings)
                     if "PUBLIC_CLOUD_IMAGE_ID" not in settings:
-                        log.error(f"Failed to get PUBLIC_CLOUD_IMAGE_ID from {data}")
+                        log.error("Failed to get PUBLIC_CLOUD_IMAGE_ID from %s", data)
         except Exception as e:
             log.exception(e)
             continue

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,43 @@
+[MASTER]
+
+disable=
+  C0103, # invalid-name
+  C0114, # missing-module-docstring
+  C0115, # missing-class-docstring
+  C0116, # missing-function-docstring
+  C0209, # consider-using-f-string
+  C0301, # line-too-long
+  C0411, # wrong-import-order
+  C0415, # import-outside-toplevel
+  C1802, # use-implicit-booleaness-not-len
+  E0602, # undefined-variable
+  E1136, # unsubscriptable-object
+  R0205, # useless-object-inheritance
+  R0801, # duplicated-code
+  R0902, # too-many-instance-attributes
+  R0903, # too-few-public-methods
+  R0912, # too-many-branches
+  R0913, # too-many-arguments
+  R0914, # too-many-locals
+  R0915, # too-many-statements
+  R1703, # simplifiable-if-statement
+  R1705, # no-else-return
+  R1718, # consider-using-set-comprehension
+  R1734, # use-list-literal
+  W0107, # unnecessary-pass
+  W0611, # unused-import
+  W0612, # unused-variable
+  W0613, # unused-argument
+  W0622, # redefined-builtin
+  W0707, # raise-missing-from
+  W0718, # broad-exception-caught
+  W0719, # broad-exception-raised
+  W1201, # logging-not-lazy
+  W1202, # logging-format-interpolation
+  W1203, # logging-fstring-interpolation
+  W1309, # f-string-without-interpolation
+  W3101, # missing-timeout
+  W4905, # deprecated-decorator
+
+recursive = true
+fail-under=9.9

--- a/pylintrc
+++ b/pylintrc
@@ -32,10 +32,7 @@ disable=
   W0707, # raise-missing-from
   W0718, # broad-exception-caught
   W0719, # broad-exception-raised
-  W1201, # logging-not-lazy
-  W1202, # logging-format-interpolation
-  W1203, # logging-fstring-interpolation
-  W1309, # f-string-without-interpolation
+  W1201, # Use lazy % formatting in logging functions (logging-not-lazy)
   W3101, # missing-timeout
   W4905, # deprecated-decorator
 

--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,6 @@ disable=
   C0116, # missing-function-docstring
   C0209, # consider-using-f-string
   C0301, # line-too-long
-  C0411, # wrong-import-order
   C0415, # import-outside-toplevel
   C1802, # use-implicit-booleaness-not-len
   E0602, # undefined-variable
@@ -20,14 +19,8 @@ disable=
   R0913, # too-many-arguments
   R0914, # too-many-locals
   R0915, # too-many-statements
-  R1703, # simplifiable-if-statement
-  R1705, # no-else-return
   R1718, # consider-using-set-comprehension
   R1734, # use-list-literal
-  W0107, # unnecessary-pass
-  W0611, # unused-import
-  W0612, # unused-variable
-  W0613, # unused-argument
   W0622, # redefined-builtin
   W0707, # raise-missing-from
   W0718, # broad-exception-caught

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,5 @@ ruamel.yaml
 black
 jsonschema
 urllib3<2 # responses needs <2, see https://github.com/getsentry/responses/issues/635
+pylint
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,9 @@
+[flake8]
+# E501 line too long
+# E266 to many #
+# E713 test menbership
+# F841 var not used
+# F401 import not used
+# F821 undevined name
+# F541 f-string
+extend-ignore = E501,E266,E713,F841,F401,F821,F541

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
 [flake8]
 # E501 line too long
-# E266 to many #
-# E713 test menbership
-# F841 var not used
-# F401 import not used
-# F821 undevined name
-# F541 f-string
-extend-ignore = E501,E266,E713,F841,F401,F821,F541
+extend-ignore = E501


### PR DESCRIPTION
Include flake8 and pylint as dev dependency.
Add configuration file for pylint and flake8, for the moment all
warnings currently present in the HEAD are disabled.
Add lint targets to the make project.
This commit also result in the github action to run the linter.
Fix simplest warnings.


Verification: https://github.com/openSUSE/qem-bot/actions/runs/6553300955/job/17798390468?pr=147#step:5:1