### PR TITLE
 Approve jobs if at least older jobs passed

### DIFF
--- a/openqabot/__init__.py
+++ b/openqabot/__init__.py
@@ -9,3 +9,4 @@ OBS_GROUP = "qam-openqa"
 OPENQA_URL = "openqa.suse.de"
 DEVELOPMENT_PARENT_GROUP_ID = 9
 DOWNLOAD_BASE = "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+OLDEST_APPROVAL_JOB_DAYS = 6

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -105,3 +105,28 @@ class openQAInterface:
         return (
             ret[0]["parent_id"] == DEVELOPMENT_PARENT_GROUP_ID if ret else True
         )  # ID of Development Group
+
+    @lru_cache(maxsize=256)
+    def get_single_job(self, job_id: int):
+        ret = None
+        try:
+            ret = self.openqa.openqa_request(
+                "GET",
+                "jobs/%s" % job_id,
+            )["job"]
+        except RequestError as e:
+            log.exception(e)
+        return ret
+
+    @lru_cache(maxsize=256)
+    def get_older_jobs(self, job_id: int, limit: int):
+        ret = []
+        try:
+            ret = self.openqa.openqa_request(
+                "GET",
+                "/tests/%s/ajax?previous_limit=%s&next_limit=0" % (job_id, limit),
+                retries=self.retries,
+            )
+        except RequestError as e:
+            log.exception(e)
+        return ret


### PR DESCRIPTION
https://progress.opensuse.org/issues/97118

- if aggregate update failed, do not give up immediately
- look at openQA previous jobs, if present, green, not too old and including the update under test: ignore that failure

This is to reduce the impact of one test being broken one day, a different test another day and the update not being approved even if combined result give all green, just not at the same time.

I did not touch the tests yet. Before investing more I would like to discuss about the new logic and it's implementation.