### PR TITLE
Avoid error if priority is absent after f1d4d5c4a6

### DIFF
--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -20,7 +20,7 @@ class Incident:
         self.rrid = f"{self.project}:{self.rr}" if self.rr else None
         self.staging = not incident["inReview"]
         self.embargoed = incident["embargoed"]
-        self.priority = incident["priority"]
+        self.priority = incident.get("priority")
 
         self.channels = [
             Repos(p, v, a)


### PR DESCRIPTION
See https://progress.opensuse.org/issues/156301