### PR TITLE
Allow result sync after AMQP job done messages

### DIFF
--- a/openqabot/__init__.py
+++ b/openqabot/__init__.py
@@ -8,6 +8,7 @@ OBS_MAINT_PRJ = "SUSE:Maintenance"
 OBS_GROUP = "qam-openqa"
 DEVELOPMENT_PARENT_GROUP_ID = 9
 DOWNLOAD_BASE = "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+AMQP_URL = "amqps://suse:suse@rabbit.suse.de"
 OLDEST_APPROVAL_JOB_DAYS = 6
 
 # Url of the "main" openQA server, this is only used to decide if the dashboard database should be updated or not;

--- a/openqabot/amqp.py
+++ b/openqabot/amqp.py
@@ -43,8 +43,17 @@ class AMQP(SyncRes):
 
     def __call__(self) -> int:
         log.info("AMQP listening started")
-        self.channel.start_consuming()
+        try:
+            self.channel.start_consuming()
+        except KeyboardInterrupt:
+            pass
+        self.stop()
         return 0
+
+    def stop(self):
+        if self.connection:
+            log.info("Closing AMQP connection")
+            self.connection.close()
 
     def on_message(self, unused_channel, method, unused_properties, body) -> None:
         message = json.loads(body)

--- a/openqabot/amqp.py
+++ b/openqabot/amqp.py
@@ -1,0 +1,98 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: MIT
+from argparse import Namespace
+from logging import getLogger
+from pprint import pformat
+from typing import Dict, Sequence
+
+import json
+import re
+import pika
+
+from . import AMQP_URL
+from .syncres import SyncRes
+from .types import Data
+from .loader.qem import get_incident_settings_data
+from .utils import compare_incident_data
+from .approver import Approver
+
+
+log = getLogger("bot.amqp")
+build_inc_regex = re.compile(r":(\d+):.*")
+build_agg_regex = re.compile(r"\d{8}-\d+")
+
+
+class AMQP(SyncRes):
+    def __init__(self, args: Namespace) -> None:
+        super().__init__(args)
+        self.args = args
+        self.dry: bool = args.dry
+        self.token: Dict[str, str] = {"Authorization": f"Token {args.token}"}
+        # Based on https://rabbit.suse.de/files/amqp_get_suse.py
+        self.connection = pika.BlockingConnection(pika.URLParameters(AMQP_URL))
+        self.channel = self.connection.channel()
+        self.channel.exchange_declare(
+            exchange="pubsub", exchange_type="topic", passive=True, durable=True
+        )
+        result = self.channel.queue_declare("", exclusive=True)
+        queue_name = result.method.queue
+        self.channel.queue_bind(
+            exchange="pubsub", queue=queue_name, routing_key="suse.openqa.#"
+        )
+        self.channel.basic_consume(queue_name, self.on_message, auto_ack=True)
+
+    def __call__(self) -> int:
+        log.info("AMQP listening started")
+        self.channel.start_consuming()
+        return 0
+
+    def on_message(self, unused_channel, method, unused_properties, body) -> None:
+        message = json.loads(body)
+        if method.routing_key == "suse.openqa.job.done" and "BUILD" in message:
+            match = build_inc_regex.match(message["BUILD"])
+            if match:
+                inc_nr = match.group(1)
+                log.debug("Received AMQP message: %s", pformat(message))
+                log.info("Job for incident %s done", inc_nr)
+                return self.handle_incident(inc_nr, message)
+            match = build_agg_regex.match(message["BUILD"])
+            if match:
+                build_nr = match.group(0)
+                log.debug("Received AMQP message: %s", pformat(message))
+                log.info("Aggregate build %s done", build_nr)
+                return self.handle_aggregate(build_nr, message)
+        return None
+
+    def handle_incident(self, inc_nr: int, message) -> None:
+        # Load Data about current incident from dashboard database
+        try:
+            settings: Sequence[Data] = get_incident_settings_data(self.token, inc_nr)
+        except ValueError:
+            return
+
+        for inc in settings:
+            # Filter out not matching incident Data
+            if not compare_incident_data(inc, message):
+                continue
+            # Fetch results from openQA about this incident (AMQP data does not contain enough information)
+            for v in self.client.get_jobs(inc):
+                if not self.filter_jobs(v):
+                    continue
+                try:
+                    AMQP.operation = "incident"
+                    r = self.normalize_data(inc, v)
+                except KeyError:
+                    continue
+                # Post update about matching openQA job into dashboard database
+                if r["job_id"] == message["id"]:
+                    self.post_result(r)
+
+        # Try to approve incident
+        args = self.args
+        args.all_incidents = False
+        args.incident = inc_nr
+        approve = Approver(args)
+        approve()
+
+    def handle_aggregate(self, unused_build: str, unused_message) -> None:
+        return

--- a/openqabot/amqp.py
+++ b/openqabot/amqp.py
@@ -9,7 +9,6 @@ import json
 import re
 import pika
 
-from . import AMQP_URL
 from .syncres import SyncRes
 from .types import Data
 from .loader.qem import get_incident_settings_data
@@ -28,8 +27,10 @@ class AMQP(SyncRes):
         self.args = args
         self.dry: bool = args.dry
         self.token: Dict[str, str] = {"Authorization": f"Token {args.token}"}
+        if not args.url:
+            return
         # Based on https://rabbit.suse.de/files/amqp_get_suse.py
-        self.connection = pika.BlockingConnection(pika.URLParameters(AMQP_URL))
+        self.connection = pika.BlockingConnection(pika.URLParameters(args.url))
         self.channel = self.connection.channel()
         self.channel.exchange_declare(
             exchange="pubsub", exchange_type="topic", passive=True, durable=True

--- a/openqabot/amqp.py
+++ b/openqabot/amqp.py
@@ -88,10 +88,7 @@ class AMQP(SyncRes):
                     self.post_result(r)
 
         # Try to approve incident
-        args = self.args
-        args.all_incidents = False
-        args.incident = inc_nr
-        approve = Approver(args)
+        approve = Approver(self.args, inc_nr)
         approve()
 
     def handle_aggregate(self, unused_build: str, unused_message) -> None:

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -59,11 +59,15 @@ def _handle_http_error(e: HTTPError, inc: IncReq) -> bool:
 
 
 class Approver:
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: Namespace, single_incident=None) -> None:
         self.dry = args.dry
-        self.single_incident = args.incident
+        if single_incident is None:
+            self.single_incident = args.incident
+            self.all_incidents = args.all_incidents
+        else:
+            self.single_incident = single_incident
+            self.all_incidents = False
         self.token = {"Authorization": "Token {}".format(args.token)}
-        self.all_incidents = args.all_incidents
         self.client = openQAInterface(args)
 
     def __call__(self) -> int:

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser
 from pathlib import Path
 from urllib.parse import urlparse
+from . import AMQP_URL
 
 
 def do_full_schedule(args):
@@ -195,6 +196,9 @@ def get_parser():
     cmdaggrsync.set_defaults(func=do_sync_aggregate_results)
 
     cmdamqp = commands.add_parser("amqp", help="AMQP listener daemon")
+    cmdamqp.add_argument(
+        "--url", type=str, default=AMQP_URL, help="the URL of the AMQP server"
+    )
     cmdamqp.set_defaults(func=do_amqp)
 
     return parser

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -70,6 +70,13 @@ def do_sync_aggregate_results(args):
     return syncer()
 
 
+def do_amqp(args):
+    from .amqp import AMQP
+
+    amqp = AMQP(args)
+    return amqp()
+
+
 def get_parser():
     parser = ArgumentParser(
         description="QEM-Dashboard, SMELT and openQA connector", prog="qem-bot"
@@ -186,5 +193,8 @@ def get_parser():
         "aggr-sync-results", help="Sync results of openQA aggregates jobs to Dashboard"
     )
     cmdaggrsync.set_defaults(func=do_sync_aggregate_results)
+
+    cmdamqp = commands.add_parser("amqp", help="AMQP listener daemon")
+    cmdamqp.set_defaults(func=do_amqp)
 
     return parser

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+from .types import Data
 
 
 def create_logger(name: str) -> logging.Logger:
@@ -73,6 +74,13 @@ def normalize_results(result: str) -> str:
         return "failed"
 
     return "failed"
+
+
+def compare_incident_data(inc: Data, message) -> bool:
+    for key in ("BUILD", "FLAVOR", "ARCH", "DISTRI", "VERSION"):
+        if key in message and getattr(inc, key.lower()) != message[key]:
+            return False
+    return True
 
 
 def __retry(retries: Optional[int], backoff_factor: float) -> Session:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ responses>=0.21.0
 requests
 osc
 openqa-client
+pika
 ruamel.yaml
 black
 jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 osc
 openqa-client
+pika
 requests
 ruamel.yaml
 jsonschema

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -7,8 +7,8 @@ import responses
 from openqabot.amqp import AMQP
 from openqabot import QEM_DASHBOARD
 
-namespace = namedtuple("Namespace", ["dry", "token", "openqa_instance"])
-args = namespace(False, "ToKeN", urlparse("http://instance.qa"))
+namespace = namedtuple("Namespace", ["dry", "token", "openqa_instance", "url"])
+args = namespace(False, "ToKeN", urlparse("http://instance.qa"), None)
 amqp = AMQP(args)
 
 fake_method = namedtuple("Method", ["routing_key"])

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1,0 +1,82 @@
+from collections import namedtuple
+import logging
+import json
+from urllib.parse import urlparse
+import pytest
+import responses
+from openqabot.amqp import AMQP
+from openqabot import QEM_DASHBOARD
+
+namespace = namedtuple("Namespace", ["dry", "token", "openqa_instance"])
+args = namespace(False, "ToKeN", urlparse("http://instance.qa"))
+amqp = AMQP(args)
+
+fake_method = namedtuple("Method", ["routing_key"])
+fake_job_done = fake_method("suse.openqa.job.done")
+
+
+@responses.activate
+def test_handling_incident(caplog):
+    # define response for get_incident_settings_data
+    data = [
+        {
+            "id": 110,
+            "flavor": "FakeFlavor",
+            "arch": "arch",
+            "settings": {"DISTRI": "linux", "BUILD": "33222"},
+            "version": "13.3",
+            "withAggregate": False,
+        }
+    ]
+    responses.add(
+        method="GET",
+        url=f"{QEM_DASHBOARD}api/incident_settings/33222",
+        json=data,
+    )
+
+    # define response for get_aggregate_settings
+    data = [
+        {
+            "id": 110,
+            "flavor": "FakeFlavor",
+            "arch": "arch",
+            "settings": {"DISTRI": "linux", "BUILD": "33222"},
+            "version": "13.3",
+            "build": "33222",
+        }
+    ]
+    responses.add(
+        method="GET",
+        url=f"{QEM_DASHBOARD}api/update_settings/33222",
+        json=data,
+    )
+
+    # define response for get_jobs
+    responses.add(
+        method="GET",
+        url=f"{QEM_DASHBOARD}api/jobs/incident/110",
+        json=[{"incident_settings": 1000, "job_id": 110, "status": "passed"}],
+    )
+
+    # define incident
+    responses.add(
+        method="GET",
+        url=f"{QEM_DASHBOARD}api/incidents/33222",
+        json={"number": 33222, "rr_number": 42},
+    )
+
+    caplog.set_level(logging.DEBUG)
+    amqp.on_message("", fake_job_done, "", json.dumps({"BUILD": ":33222:emacs"}))
+
+    messages = [x[-1] for x in caplog.record_tuples]
+    assert "Job for incident 33222 done" in messages
+    assert "Accepting review for SUSE:Maintenance:33222:42" in messages
+
+
+@responses.activate
+def test_handling_aggregate(caplog):
+    caplog.set_level(logging.DEBUG)
+    amqp.on_message("", fake_job_done, "", json.dumps({"BUILD": "12345678-9"}))
+
+    messages = [x[-1] for x in caplog.record_tuples]
+    assert "Aggregate build 12345678-9 done" in messages  # currently noop

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -8,7 +8,7 @@ from openqabot.amqp import AMQP
 from openqabot import QEM_DASHBOARD
 
 namespace = namedtuple("Namespace", ["dry", "token", "openqa_instance", "url"])
-args = namespace(False, "ToKeN", urlparse("http://instance.qa"), None)
+args = namespace(True, "ToKeN", urlparse("http://instance.qa"), None)
 amqp = AMQP(args)
 
 fake_method = namedtuple("Method", ["routing_key"])
@@ -70,7 +70,8 @@ def test_handling_incident(caplog):
 
     messages = [x[-1] for x in caplog.record_tuples]
     assert "Job for incident 33222 done" in messages
-    assert "Accepting review for SUSE:Maintenance:33222:42" in messages
+    assert "Incidents to approve:" in messages
+    assert "* SUSE:Maintenance:33222:42" in messages
 
 
 @responses.activate


### PR DESCRIPTION
See https://progress.opensuse.org/issues/157741

---

This PR adds mainly tests on top of https://github.com/openSUSE/qem-bot/pull/175. What's still missing is handling aggregates, documentation and perhaps a systemd-unit file to run this on the dashboard host.