### PR TITLE
Don't crash in case of unexpected build date format

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -168,7 +168,7 @@ class Approver:
         try:
             current_build_date = datetime.strptime(current_build, "%Y%m%d")
         except (ValueError, TypeError):
-            log.info("Could not parse build date %s", current_build)
+            log.info("Could not parse build date %s. Won't try to look at older jobs for approval.", current_build)
             return False
 
         # Use at most X days old build. Don't go back in time too much to reduce risk of using invalid tests
@@ -184,7 +184,7 @@ class Approver:
             try:
                 job_build_date = datetime.strptime(job_build, "%Y%m%d")
             except (ValueError, TypeError):
-                log.info("Could not parse build date %s", current_build)
+                log.info("Could not parse build date %s. Won't consider this job as alternative for approval.", current_build)
                 continue
 
             # Check the job is not too old

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -165,7 +165,11 @@ class Approver:
             return False
 
         current_build = older_jobs["data"][0]["build"][:-2]
-        current_build_date = datetime.strptime(current_build, "%Y%m%d")
+        try:
+            current_build_date = datetime.strptime(current_build, "%Y%m%d")
+        except (ValueError, TypeError):
+            log.info("Could not parse build date %s", current_build)
+            return False
 
         # Use at most X days old build. Don't go back in time too much to reduce risk of using invalid tests
         oldest_build_usable = current_build_date - timedelta(
@@ -177,7 +181,11 @@ class Approver:
         for i in range(1, len(older_jobs["data"])):
             job = older_jobs["data"][i]
             job_build = job["build"][:-2]
-            job_build_date = datetime.strptime(job_build, "%Y%m%d")
+            try:
+                job_build_date = datetime.strptime(job_build, "%Y%m%d")
+            except (ValueError, TypeError):
+                log.info("Could not parse build date %s", current_build)
+                continue
 
             # Check the job is not too old
             if job_build_date < oldest_build_usable:


### PR DESCRIPTION
try to parse the date, if unsuccessful, give up instead of crashing entirely

This is to fix cases like https://gitlab.suse.de/qa-maintenance/bot-ng/-/jobs/2463822 
where a manually cloned job with unexpected build strings confuse the bot logic. 