### PR TITLE
Avoid warning about useless use of `bad-continuation` in pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -2,7 +2,6 @@
 
 disable=
   missing-docstring,
-  bad-continuation,
   C0103, # invalid-name
   C0114, # missing-module-docstring
   C0115, # missing-class-docstring


### PR DESCRIPTION
This option was removed in https://github.com/pylint-dev/pylint/pull/3571.