### PR TITLE
Consider concrete reviews on Gitea via our bot account

### DIFF
--- a/openqabot/__init__.py
+++ b/openqabot/__init__.py
@@ -12,6 +12,7 @@ OBS_URL = os.environ.get("OBS_URL", "https://api.suse.de")
 OBS_DOWNLOAD_URL = os.environ.get("OBS_DOWNLOAD_URL", "http://download.suse.de/ibs")
 OBS_MAINT_PRJ = "SUSE:Maintenance"
 OBS_GROUP = "qam-openqa"
+ALLOW_DEVELOPMENT_GROUPS = os.environ.get("QEM_BOT_ALLOW_DEVELOPMENT_GROUPS")
 DEVELOPMENT_PARENT_GROUP_ID = 9
 DOWNLOAD_BASE = os.environ.get(
     "DOWNLOAD_BASE_URL", "http://%REPO_MIRROR_HOST%/ibs/SUSE:/Maintenance:/"

--- a/openqabot/giteasync.py
+++ b/openqabot/giteasync.py
@@ -44,4 +44,6 @@ class GiteaSync:
         if self.dry:
             log.info("Dry run, nothing synced")
             return 0
-        return update_incidents(self.dashboard_token, data, retry=self.retry)
+        return update_incidents(
+            self.dashboard_token, data, params={"type": "git"}, retry=self.retry
+        )

--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -22,6 +22,12 @@ def load_metadata(
 
     loader = YAML(typ="safe")
 
+    log.debug(
+        "Loading meta-data from %s (with incidents: %r, with aggregates: %r)",
+        path,
+        not incidents,
+        not aggregate,
+    )
     for p in get_yml_list(path):
         try:
             data = loader.load(p)
@@ -32,7 +38,7 @@ def load_metadata(
         try:
             settings = data.get("settings")
         except AttributeError:
-            # not valid yaml for bot settings
+            log.error("The YAML file '%s' contains no valid data for bot settings.", p)
             continue
 
         if "product" not in data:
@@ -52,6 +58,7 @@ def load_metadata(
                         log.warning("No 'test_issues' in %s config", data["product"])
                 else:
                     continue
+    log.debug("Loaded %i incidents/aggregates", len(ret))
     return ret
 
 
@@ -59,6 +66,7 @@ def read_products(path: Path) -> List[Data]:
     loader = YAML(typ="safe")
     ret = []
 
+    log.debug("Loading products from %s", path)
     for p in get_yml_list(path):
         data = loader.load(p)
 

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -300,7 +300,7 @@ def make_incident_from_pr(
             comments = get_json(comments_url(repo_name, number), token)
             files = get_json(changed_files_url(repo_name, number), token)
         if add_reviews(incident, reviews) < 1 and only_requested_prs:
-            log.info("Skipping PR %s, no review by ", number)
+            log.info("Skipping PR %s, no reviews by %s", number, OBS_GROUP)
             return None
         add_comments_and_referenced_build_results(incident, comments, dry)
         if len(incident["channels"]) == 0:

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -107,6 +107,11 @@ def review_pr(
     post_json(reviews_url(repo_name, pr_number), token, review_data)
 
 
+def get_name(review: Dict[str, Any], of: str, via: str):
+    entity = review.get(of)
+    return entity.get(via, "") if entity is not None else ""
+
+
 def add_reviews(incident: Dict[str, Any], reviews: List[Any]) -> int:
     approvals = 0
     changes_requested = 0
@@ -120,8 +125,10 @@ def add_reviews(incident: Dict[str, Any], reviews: List[Any]) -> int:
             continue
         # accumulate number of reviews per state
         state = review.get("state", "")
-        team = review.get("team")
-        if team is not None and team.get("name", "") == OBS_GROUP:
+        if OBS_GROUP in (
+            get_name(review, "user", "login"),  # concrete review via our bot account
+            get_name(review, "team", "name"),  # review request for team bot is part of
+        ):
             reviews_by_qam += 1
             if state == "APPROVED":
                 approvals += 1

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -223,10 +223,11 @@ def get_aggregate_results(inc: int, token: Dict[str, str]):
 
 def update_incidents(token: Dict[str, str], data, **kwargs) -> int:
     retry = kwargs.get("retry", 0)
+    query_params = kwargs.get("params", {})
     while retry >= 0:
         retry -= 1
         try:
-            ret = patch("api/incidents", headers=token, json=data)
+            ret = patch("api/incidents", headers=token, params=query_params, json=data)
         except Exception as e:  # pylint: disable=broad-except
             log.exception(e)
             return 1

--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -10,6 +10,7 @@ from .loader.qem import post_job
 from .openqa import openQAInterface
 from .types import Data
 from .utils import normalize_results
+from . import ALLOW_DEVELOPMENT_GROUPS
 
 log = getLogger("bot.syncres")
 
@@ -45,7 +46,7 @@ class SyncRes:
         return ret
 
     def _is_in_devel_group(self, data: Data) -> bool:
-        return (
+        return not ALLOW_DEVELOPMENT_GROUPS and (
             "Devel" in data["group"]
             or "Test" in data["group"]
             or self.client.is_devel_group(data["group_id"])

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -25,15 +25,11 @@ def create_logger(name: str) -> logging.Logger:
 
 def get_yml_list(path: Path) -> List[Path]:
     """Create a list of YML filenames from a folder or single file path."""
-    yml_list = []
-    extensions = ("yml", "yaml")
-    for ext in extensions:
-        if path.is_file():
-            if path.name.endswith("." + ext):
-                yml_list.append(path)
-        elif path.is_dir():
-            yml_list += list(path.glob("*." + ext))
-    return yml_list
+    return (
+        [f for ext in ("yml", "yaml") for f in path.glob("*." + ext)]
+        if path.is_dir()
+        else [path]
+    )
 
 
 def walk(inc):

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 import logging
 import re
 
-from responses import GET
+from responses import GET, matchers
 import osc.conf
 import osc.core
 import pytest
@@ -58,6 +58,7 @@ def fake_dashboard_replyback():
         responses.PATCH,
         re.compile(f"{QEM_DASHBOARD}api/incidents"),
         callback=reply_callback,
+        match=[matchers.query_param_matcher({"type": "git"})],
     )
 
 

--- a/tests/test_loader_config.py
+++ b/tests/test_loader_config.py
@@ -24,7 +24,7 @@ def test_load_metadata_aggregate(caplog):
     assert "<Aggregate product: SOME15SP3>" == str(result[0])
 
     messages = sorted([m[-1] for m in caplog.record_tuples])
-    assert "Skipping invalid config" in messages[1]
+    assert "Skipping invalid config" in messages[3]
     assert "No 'test_issues' in BAD15SP3 config" in messages
 
 
@@ -44,7 +44,7 @@ def test_load_metadata_incidents(caplog):
     assert "<Incidents product: SOME15SP3>" == str(result[0])
 
     messages = [m[-1] for m in caplog.record_tuples]
-    assert "Skipping invalid config" in messages[0]
+    assert "Skipping invalid config" in messages[1]
 
 
 def test_load_metadata_all(caplog):
@@ -57,7 +57,7 @@ def test_load_metadata_all(caplog):
     assert "<Incidents product: SOME15SP3>" == str(result[1])
 
     messages = sorted([m[-1] for m in caplog.record_tuples])
-    assert "Skipping invalid config" in messages[1]
+    assert "Skipping invalid config" in messages[3]
     assert "No 'test_issues' in BAD15SP3 config" in messages
 
 

--- a/tests/test_smeltsync.py
+++ b/tests/test_smeltsync.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import logging
 import re
 
+from responses import matchers
 import pytest
 import responses
 
@@ -86,6 +87,7 @@ def fake_dashboard_replyback():
         responses.PATCH,
         re.compile(f"{QEM_DASHBOARD}api/incidents"),
         callback=reply_callback,
+        match=[matchers.query_param_matcher({})],
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,22 +125,6 @@ def test_get_yml_list_single_file_yml(tmp_path):
         assert filename in res[0].name
 
 
-def test_get_yml_list_single_file_not_yml(tmp_path):
-    """
-    Create a folder with a single .txt file (so not a supported valid file)
-    Call the function with the path of the file
-    The expected behavior is the function to return
-    an empty list
-    """
-    d = tmp_path / "it_is_a_folder"
-    d.mkdir()
-    p = d / "hello.txt"
-    p.write_text("")
-    # here call the function with the file path
-    res = get_yml_list(Path(p))
-    assert len(res) == 0
-
-
 def test_get_yml_list_folder_with_single_file_yml(tmp_path):
     d = tmp_path / "it_is_a_folder"
     d.mkdir()


### PR DESCRIPTION
So far the code only checked reviews requested for the team the bot is part
of. It should also consider concrete reviews it has already made and thus
we also need to check `user.login`.

This PR also contains a few changes making development and demoing
easier. Those changes won't affect production.

Related ticket: https://progress.opensuse.org/issues/180812