### PR TITLE
Prevent too verbose 'Meta-data channel' logs

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -152,7 +152,7 @@ class Incidents(BaseConf):
 
         log.debug("Incident channels: %s", inc.channels)
         for issue, channel in data["issues"].items():
-            log.info(
+            log.debug(
                 "Meta-data channel: %s, %s, %s", channel.product, channel.version, arch
             )
             f_channel = Repos(channel.product, channel.version, arch)


### PR DESCRIPTION
As found in gitlab CI logs the complete logs could not be collected as
the message about 'Meta-data channel' is too verbose.