### PR TITLE
Avoid scheduling jobs for Gitea PRs in certain cases

### DIFF
--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -19,6 +19,11 @@ class Incident:
         self.id = incident["number"]
         self.rrid = f"{self.project}:{self.rr}" if self.rr else None
         self.staging = not incident["inReview"]
+        self.ongoing = (
+            incident["isActive"]
+            and incident["inReviewQAM"]
+            and not incident["approved"]
+        )
         self.embargoed = incident["embargoed"]
         self.priority = incident.get("priority")
         self.type = incident.get("type", "smelt")

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -98,6 +98,12 @@ class Incidents(BaseConf):
         ci_url: Optional[str],
         ignore_onetime: bool,
     ) -> Dict[str, Any]:
+        if inc.type == "git" and not inc.ongoing:
+            log.info(
+                "Scheduling no jobs for incident %s as the PR is either closed, approved or review is no longer requested.",
+                inc.id,
+            )
+            return None
         if self.filter_embargoed(flavor) and inc.embargoed:
             log.info(
                 "Incident %s is embargoed and filtering embargoed updates enabled",

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -61,6 +61,8 @@ class MyIncident_0(object):
         self.rrid = None
         self.revisions = {("", ""): None}
         self.project = None
+        self.ongoing = True
+        self.type = "smelt"
 
     def revisions_with_fallback(self, arch, version):
         pass


### PR DESCRIPTION
Otherwise we get jobs scheduled for PRs that have already been handled, e.g. jobs were scheduled again for PR 120 after the PR was already fully handled by a demo instance of the bot/dashboard.

Related ticket/comment: https://progress.opensuse.org/issues/180812#note-37