### PR TITLE
Adjust gitea log level + fix repo path

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -206,13 +206,13 @@ def add_build_results(incident: Dict[str, Any], obs_urls: List[str], dry: bool):
                     failed_packages,
                 )
     if len(unpublished_repos) > 0:
-        log.warning(
+        log.info(
             "Some repos for PR %i have not been published yet: %s",
             incident["number"],
             ", ".join(unpublished_repos),
         )
     if len(failed_packages) > 0:
-        log.warning(
+        log.info(
             "Some packages for PR %i have failed: %s",
             incident["number"],
             ", ".join(failed_packages),

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -83,7 +83,7 @@ class Incidents(BaseConf):
 
     def _make_repo_url(self, inc: Incident, chan: Repos):
         return (
-            f"{DOWNLOAD_SLFO}{chan.version}:/PullRequest:/{inc.id}:/SLES/standard/"
+            f"{DOWNLOAD_SLFO}{chan.version}:/PullRequest:/{inc.id}/standard/"
             if chan.product == "SLFO"
             else f"{DOWNLOAD_MAINTENANCE}{inc.id}/SUSE_Updates_{'_'.join(self._repo_osuse(chan))}"
         )


### PR DESCRIPTION
* Prevent warnings about observations which might not have consequences
* Adjust SLFO repo path to be product independant
* Prevent too verbose 'Meta-data channel' logs