### PR TITLE
Consider stale review requests on Gitea as well

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -120,8 +120,8 @@ def add_reviews(incident: Dict[str, Any], reviews: List[Any]) -> int:
     pending_qam = 0
     reviews_by_qam = 0
     for review in reviews:
-        # ignore stale and dismissed reviews
-        if review.get("stale", True) or review.get("dismissed", True):
+        # ignore dismissed reviews
+        if review.get("dismissed", True):
             continue
         # accumulate number of reviews per state
         state = review.get("state", "")

--- a/responses/reviews-124.json
+++ b/responses/reviews-124.json
@@ -27,7 +27,7 @@
         "state": "REQUEST_REVIEW",
         "body": "",
         "commit_id": "",
-        "stale": false,
+        "stale": true,
         "official": false,
         "dismissed": false,
         "submitted_at": "2025-04-30T15:14:33+02:00",


### PR DESCRIPTION
It looks like review *requests* can already be stale in production PRs and users still expect the bot to consider those PRs.

Related ticket: https://progress.opensuse.org/issues/180812