### PR TITLE
Avoid revision computation from failing early

### DIFF
--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -44,7 +44,10 @@ def get_incidents(token: Dict[str, str]) -> List[Incident]:
             xs.append(Incident(i))
         except NoRepoFoundError as e:
             log.info(
-                "Project %s can't calculate repohash %s .. skipping", i["project"], e
+                "Project %s can't calculate repohash of incident %i: %s .. skipping",
+                i["project"],
+                i["number"],
+                e,
             )
         except EmptyChannels:
             log.info(

--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -59,12 +59,7 @@ def get_max_revision(
             log.error("%s's revision is None", url)
             raise NoRepoFoundError
 
-        rev = int(str(cs.text))
-
-        max_rev = max(max_rev, rev)
-
-    if max_rev == 0:
-        raise NoRepoFoundError
+        max_rev = max(max_rev, int(str(cs.text)))
 
     return max_rev
 

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -119,13 +119,12 @@ class Incident:
 
         if tmpdict:
             for archver, lrepos in tmpdict.items():
-                try:
-                    max_rev = get_max_revision(lrepos, archver.arch, project)
-                    if max_rev > 0:
-                        rev[archver] = max_rev
-                except NoRepoFoundError as e:
-                    raise e
+                max_rev = get_max_revision(lrepos, archver.arch, project)
+                if max_rev > 0:
+                    rev[archver] = max_rev
 
+        if len(rev) == 0:
+            raise NoRepoFoundError
         return rev
 
     def __repr__(self):


### PR DESCRIPTION
Otherwise we run into `Project SLFO can't calculate repohash …` despite
skipping certain non-existent repositories via https://github.com/openSUSE/qem-bot/commit/767f89b9be3eb539ffe9c24f3aa261b4a4d80148.

We probably need to restructure this to use (the correct) product
repositories but this change simplifies the code so it is probably not bad
to have meanwhile.

Related ticket: https://progress.opensuse.org/issues/180812