### PR TITLE
Use product version to schedule openQA jobs if present

### DIFF
--- a/openqabot/types/__init__.py
+++ b/openqabot/types/__init__.py
@@ -29,4 +29,4 @@ class Data(NamedTuple):
 
 class ArchVer(NamedTuple):
     arch: str
-    version: str
+    version: str  # the product version (and not the codestream version) if present in the context ArchVer is used

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -111,10 +111,12 @@ class Incident:
                 version = v.group(0)
 
             repo_info = (repo.product, repo.version, repo.product_version)
-            if ArchVer(repo.arch, version) in tmpdict:
-                tmpdict[ArchVer(repo.arch, version)].append(repo_info)
+            ver = repo.product_version or version
+            arch_ver = ArchVer(repo.arch, ver)
+            if arch_ver in tmpdict:
+                tmpdict[arch_ver].append(repo_info)
             else:
-                tmpdict[ArchVer(repo.arch, version)] = [repo_info]
+                tmpdict[arch_ver] = [repo_info]
 
         if tmpdict:
             for archver, lrepos in tmpdict.items():

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -177,7 +177,11 @@ class Incidents(BaseConf):
                 for inc_channel in inc.channels:
                     if (
                         inc_channel.product == "SUSE:SLFO"
-                        and inc_channel.version.startswith(channel.version)
+                        and (
+                            channel.product_version == inc_channel.product_version
+                            if len(inc_channel.product_version) > 0
+                            else inc_channel.version.startswith(channel.version)
+                        )
                         and channel.product_version in ("", inc_channel.product_version)
                         and inc_channel.arch == arch
                     ):

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -342,3 +342,9 @@ def test_making_repo_url():
     assert repo == exp_repo_start + "SUSE_Updates_openSUSE_15.7_x86_64"
     repo = incs._make_repo_url(inc, Repos("openSUSE-SLE", "15.7", "x86_64"))
     assert repo == exp_repo_start + "SUSE_Updates_openSUSE-SLE_15.7"
+    slfo_chan = Repos(
+        "SUSE:SLFO", "SUSE:SLFO:1.1.99:PullRequest:166:SLES", "x86_64", "15.99"
+    )
+    repo = incs._make_repo_url(inc, slfo_chan)
+    exp_repo = "http://%REPO_MIRROR_HOST%/ibs/SUSE:/SLFO:/SUSE:/SLFO:/1.1.99:/PullRequest:/166:/SLES/product/repo/SLES-15.99-x86_64/"
+    assert repo == exp_repo


### PR DESCRIPTION
Despite the most recent changes so far the bot still uses the codestream version (e.g. `1.1`) to schedule openQA jobs. With this change the product version (e.g. `15.99`) will be used instead (if it is present which is the case by default when use of product-specific repositories).

This means meta-data needs to change the `settings.VERSION` from e.g. `1.1` to `15.99`. This also means that the version in medium types (aka. products) and job templates in openQA also needs to be changed accordingly (as openQA will otherwise not create any jobs). Note that one might need to create new medium types first, change job templates and finally delete the old medium types.

Note that the version still must not be changed in openQA by putting e.g. `+VERSION=16.0` into medium type settings. Doing so will prevent qem-bot from tracking the jobs it created as it will still look for jobs with e.g. `VERSION=15.99`.

Related ticket: https://progress.opensuse.org/issues/180812