### PR TITLE
Simplify code by moving computation of revisions out of loop

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -74,10 +74,10 @@ class Incidents(BaseConf):
         if isinstance(jobs, dict) and "error" in jobs:
             return False
 
+        revs = inc.revisions_with_fallback(arch, ver)
+        if not revs:
+            return False
         for job in jobs:
-            revs = inc.revisions_with_fallback(arch, ver)
-            if not revs:
-                continue
             if (
                 job["flavor"] == flavor
                 and job["arch"] == arch


### PR DESCRIPTION
The revisions don't depend on the jobs being iterated here so it is more efficient and clearer to compute them outside of the loop.

Related ticket: https://progress.opensuse.org/issues/180812