### PR TITLE
Schedule products if it already exists but the version differs

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -81,6 +81,7 @@ class Incidents(BaseConf):
             if (
                 job["flavor"] == flavor
                 and job["arch"] == arch
+                and job["version"] == ver
                 and job["settings"]["REPOHASH"] == revs
             ):
                 return True


### PR DESCRIPTION
The bot is not scheduling products that have already been scheduled. It
will log a message like this instead:
```
not scheduling: Flavor: Foo-Bar-Incidents, version: 15.99 incident: 165 , arch: x86_64  - exists in openQA
```

Even though this message states the version of the product this version is
not actually taken into account. So an existing product of *any* version
will lead to the "not scheduling" behavior as long as flavor, arch and the
repo revision match.

To me this seems not very intuitive (especially because the log insinuates
that the version would be relevant) and it would make generally more sense
to schedule the product again in such a case.

This is useful when just the product version changes, e.g. because we
change how handle versions when scheduling. I suppose normally this doesn't
make much of a difference because when the product version changes the repo
hash is very likely different anyway. So I don't think this will cause a
regression in other use cases.

Related ticket: https://progress.opensuse.org/issues/180812