### PR TITLE
Ensure we run `mark_job_as_acceptable_for_incident` for all jobs

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -248,11 +248,12 @@ class Approver:
     def was_ok_before(self, failed_job_id: int, inc: int) -> bool:
         # We need a considerable amount of older jobs, since there could be many failed manual restarts from same day
         jobs = self.client.get_older_jobs(failed_job_id, 20)
-        if jobs == []:
+        data = jobs.get("data", [])
+        if len(data) == 0:
             log.info("Cannot find older jobs for %s", failed_job_id)
             return False
 
-        current_job, older_jobs = jobs["data"][0], jobs["data"][1:]
+        current_job, older_jobs = data[0], data[1:]
         current_build = current_job["build"][:-2]
         try:
             current_build_date = datetime.strptime(current_build, "%Y%m%d")

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -119,8 +119,8 @@ class openQAInterface:
         return ret
 
     @lru_cache(maxsize=256)
-    def get_older_jobs(self, job_id: int, limit: int):
-        ret = []
+    def get_older_jobs(self, job_id: int, limit: int) -> dict:
+        ret = {"data": []}
         try:
             ret = self.openqa.openqa_request(
                 "GET",

--- a/tests/test_incidents.py
+++ b/tests/test_incidents.py
@@ -4,6 +4,7 @@
 from openqabot.types.incidents import Incidents
 from openqabot.types import Repos, ArchVer
 from unittest import mock
+import responses
 import pytest
 
 
@@ -355,6 +356,7 @@ class MyIncident_5(MyIncident_2):
         return self.revisions[ArchVer(arch, version)]
 
 
+@responses.activate
 def test_gitea_incidents():
     # declare fields of Repos used in this test
     product = "SUSE:SLFO"  # "product" is used to store the name of the codestream in Gitea-based incidents …


### PR DESCRIPTION
* Move invocation of `mark_job_as_acceptable_for_incident` into separate function `mark_jobs_as_acceptable_for_incident` so it is invoked for *all* non-passing jobs (and not affected by the short-circuiting of the `all` function
* Rename `job_acceptable` to `is_job_acceptable` to make it clearer that the function has no side-effects
* Keep the logging within the `is_job_acceptable` to avoid changing the logging behavior for now
* Ensure test for Gitea incidents doesn't hang on timeout (separate commit
* See https://progress.opensuse.org/issues/186429