### PR TITLE
Skip Gitea PRs if no packages have been build/published

### DIFF
--- a/responses/empty-build-results.xml
+++ b/responses/empty-build-results.xml
@@ -1,0 +1,5 @@
+<resultlist>
+  <result project="SUSE:SLFO:1.1.99:PullRequest:124" repository="product" arch="aarch64" state="published">
+    <!-- no packages here -->
+  </result>
+</resultlist>


### PR DESCRIPTION
So far the check for skipping PRs only skipped PRs if there were were failing/unpublished packages. Based on the feedback from comment https://progress.opensuse.org/issues/180812#note-64 we also need to check whether there is at least one successfully built and published package as IBS can apparently be in a state where no packages are present at all (or only excluded packages which we ignore).