### PR TITLE
Avoid retrying on 404 not found errors

### DIFF
--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -84,7 +84,7 @@ def __retry(retries: Optional[int], backoff_factor: float) -> Session:
         max_retries=Retry(
             retries,
             backoff_factor=backoff_factor,
-            status_forcelist=frozenset({404, 403, 413, 429, 503}),
+            status_forcelist=frozenset({403, 413, 429, 503}),
         )
     )
     http = Session()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,10 +100,14 @@ if has_registries:
         rsp1 = responses.add(responses.GET, "http://host.some", status=503)
         rsp2 = responses.add(responses.GET, "http://host.some", status=503)
         rsp3 = responses.add(responses.GET, "http://host.some", status=200)
+        rsp4 = responses.add(responses.GET, "http://host.some", status=404)
 
         req = retry3.get("http://host.some")
         assert req.status_code == 200
         assert rsp3.call_count == 1
+        req = retry3.get("http://host.some")
+        assert req.status_code == 404
+        assert rsp4.call_count == 1
 
 
 def test_get_yml_list_single_file_yml(tmp_path):


### PR DESCRIPTION
This can result in long delays when the file is not expected to become available that quickly.

The retry was introduced in https://github.com/openSUSE/qem-bot/commit/94a7e5db81bcf3fffe8e2ac472d52521bb7f9512
with no reason why we should retry on 404.

See: https://progress.opensuse.org/issues/190047#3