### PR TITLE
Update default `--obs-project` for `increment-approve` command

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -248,7 +248,7 @@ def get_parser():
         "--obs-project",
         required=False,
         type=str,
-        default="SUSE:SLFO:Products:SLES:15.99:TEST",
+        default="SUSE:SLFO:Products:SLES:16.0:TEST",
         help="The project on OBS",
     )
     cmdincrementapprove.add_argument(


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/190248