### PR TITLE
Allow scheduling products for product increments

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -242,46 +242,56 @@ def get_parser():
 
     cmdincrementapprove = commands.add_parser(
         "increment-approve",
-        help="Approve the specified product increment if tests passed",
+        help="Approve the most recent product increment for an OBS project if tests passed",
     )
     cmdincrementapprove.add_argument(
         "--obs-project",
         required=False,
         type=str,
         default="SUSE:SLFO:Products:SLES:16.0:TEST",
-        help="The project on OBS",
+        help="The project on OBS to monitor, schedule jobs for (if --schedule is specified) and approve (if all tests passd)",
     )
     cmdincrementapprove.add_argument(
         "--distri",
         required=False,
         type=str,
-        default="sle",
-        help="The DISTRI parameter of relevant scheduled products on openQA",
+        default="any",
+        help="Monitor and schedule only products with the specified DISTRI parameter",
     )
     cmdincrementapprove.add_argument(
         "--version",
         required=False,
         type=str,
-        default="15.99",
-        help="The VERSION parameter of relevant scheduled products on openQA",
+        default="any",
+        help="Monitor and schedule only products with the specified VERSION parameter",
     )
     cmdincrementapprove.add_argument(
         "--flavor",
         required=False,
         type=str,
-        default="Online-Increments",
-        help="The FLAVOR parameter of relevant scheduled products on openQA",
+        default="any",
+        help="Monitor and schedule only products with the specified FLAVOR parameter",
+    )
+    cmdincrementapprove.add_argument(
+        "--schedule",
+        action="store_true",
+        help="Schedule a new product (if none exists or if the most recent product has no jobs)",
+    )
+    cmdincrementapprove.add_argument(
+        "--reschedule",
+        action="store_true",
+        help="Always schedule a new product (even if one already exists)",
     )
     cmdincrementapprove.add_argument(
         "--accepted",
         action="store_true",
-        help="Consider accepted requests/reviews as well",
+        help="Consider accepted product increment requests as well",
     )
     cmdincrementapprove.add_argument(
         "--request-id",
         required=False,
         type=int,
-        help="Approve the specified request specifically",
+        help="Check/approve the specified request (instead of the most recent one)",
     )
     cmdincrementapprove.set_defaults(func=do_increment_approve, no_config=True)
 

--- a/responses/test-product-repo.json
+++ b/responses/test-product-repo.json
@@ -1,0 +1,12 @@
+{
+   "data": [
+      {"name": "SLES-16.0-Online-x86_64-Build139.1.spdx.json"},
+      {"name": "SLES-16.0-Online-aarch64-Build139.1.spdx.json"},
+      {"name": "SLES-16.0-Online-s390x-Build139.1.spdx.json"},
+      {"name": "SLES-16.0-Online-ppc64le-Build139.1.spdx.json"},
+      {"name": "SLES-SAP-16.0-Online-x86_64-Build139.1.spdx.json"},
+      {"name": "SLES-SAP-16.0-Online-aarch64-Build139.1.spdx.json"},
+      {"name": "SLES-SAP-16.0-Online-s390x-Build139.1.spdx.json"},
+      {"name": "SLES-SAP-16.0-Online-ppc64le-Build139.1.spdx.json"}
+   ]
+}


### PR DESCRIPTION
* Determine relevant architectures and build numbers from the files in the directory listing of the download repository of the OBS/IBS project targeted by the product increment request
* Add additional flag to create a scheduled product if no jobs have been created yet

This PR depends on https://github.com/os-autoinst/openQA/pull/6798.

Related ticket: https://progress.opensuse.org/issues/190251