### PR TITLE
Parameterize checking build in increment approver

### DIFF
--- a/openqabot/__init__.py
+++ b/openqabot/__init__.py
@@ -31,3 +31,5 @@ OPENQA_URL = os.environ.get("MAIN_OPENQA_DOMAIN", "openqa.suse.de")
 # this account, see
 # https://confluence.suse.com/spaces/~adrianSuSE/pages/1865908580/Group+Review+Bot+Setup#GroupReviewBotSetup-Suggestedgroupnames
 GIT_REVIEW_BOT = os.environ.get("GIT_REVIEW_BOT", OBS_GROUP + "-review")
+
+BUILD_REGEX = "(?P<product>.*)-(?P<version>[^\\-]*?)-(?P<flavor>\\D+[^\\-]*?)-(?P<arch>[^\\-]*?)-Build(?P<build>.*?)\\.spdx.json"

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -3,7 +3,7 @@
 from argparse import ArgumentParser
 from pathlib import Path
 from urllib.parse import urlparse
-from . import AMQP_URL, OBS_GROUP
+from . import AMQP_URL, BUILD_REGEX, OBS_GROUP
 
 
 def do_full_schedule(args):
@@ -292,6 +292,20 @@ def get_parser():
         required=False,
         type=int,
         help="Check/approve the specified request (instead of the most recent one)",
+    )
+    cmdincrementapprove.add_argument(
+        "--build-listing-sub-path",
+        required=False,
+        type=str,
+        default="product",
+        help="The sub path of the file listing used to determine BUILD and other parameters",
+    )
+    cmdincrementapprove.add_argument(
+        "--build-regex",
+        required=False,
+        type=str,
+        default=BUILD_REGEX,
+        help="The regex used to determine BUILD and other parameters from the file listing",
     )
     cmdincrementapprove.set_defaults(func=do_increment_approve, no_config=True)
 

--- a/tests/test_incrementapprover.py
+++ b/tests/test_incrementapprover.py
@@ -11,7 +11,7 @@ import responses
 
 import openqabot
 from openqabot.openqa import openQAInterface
-from openqabot import OBS_URL, OBS_DOWNLOAD_URL, OBS_GROUP
+from openqabot import BUILD_REGEX, OBS_URL, OBS_DOWNLOAD_URL, OBS_GROUP
 from openqabot.loader.gitea import read_json
 from openqabot.incrementapprover import IncrementApprover
 
@@ -30,6 +30,8 @@ _namespace = namedtuple(
         "flavor",
         "schedule",
         "reschedule",
+        "build_listing_sub_path",
+        "build_regex",
     ),
 )
 
@@ -124,6 +126,8 @@ def run_approver(caplog, monkeypatch, schedule: bool = False):
         "Online-Increments",
         schedule,
         False,
+        "product",
+        BUILD_REGEX,
     )
     increment_approver = IncrementApprover(args)
     errors = increment_approver()


### PR DESCRIPTION
So it can also schedule jobs for e.g. SL-Micro:

```
./bot-ng.py … increment-approve --obs-project 'SUSE:SLFO:Products:SL-Micro:6.2:ToTest --schedule --build-listing-sub-path product/iso --build-regex '(?P<product>.*)-(?P<version>[^\-]*?)-(?P<arch>[^\-]*?)-Build(?P<build>.*?)\.spdx\.json'
2025-10-14 12:09:33 INFO     Skipping approval, there are no relevant jobs on openQA for SL-Micro … of flavor Online-Increments
2025-10-14 12:09:33 INFO     Scheduling jobs for SL-Micro … of flavor Online-Increments
…
```

Related ticket: https://progress.opensuse.org/issues/190251