### PR TITLE
Allow configuring multiple product repos

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 import concurrent.futures as CT
 from logging import getLogger
-from typing import Any, List, Set, Dict, Tuple, Optional
+from typing import Any, List, Set, Dict, Tuple, Optional, Union
 import re
 import xml.etree.ElementTree as ET
 
@@ -108,20 +108,28 @@ def compute_repo_url(
 
 
 def compute_repo_url_for_job_setting(
-    base: str, repo: Repos, product_repo: Optional[str], product_version: Optional[str]
+    base: str,
+    repo: Repos,
+    product_repo: Optional[Union[List[str], str]],
+    product_version: Optional[str],
 ) -> str:
-    product_name = (
+    product_names = (
         get_product_name(repo.version) if product_repo is None else product_repo
     )
     product_version = (
         repo.product_version if product_version is None else product_version
     )
-    return compute_repo_url(
-        base,
-        product_name,
-        (repo.product, repo.version, product_version),
-        repo.arch,
-        "",
+    return ",".join(
+        map(
+            lambda p: compute_repo_url(
+                base,
+                p,
+                (repo.product, repo.version, product_version),
+                repo.arch,
+                "",
+            ),
+            product_names if isinstance(product_names, list) else [product_names],
+        )
     )
 
 

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import date
 from itertools import chain
 from logging import getLogger
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from . import ProdVer, Repos
 from .. import DOWNLOAD_BASE, QEM_DASHBOARD, SMELT_URL
@@ -23,7 +23,7 @@ class Aggregate(BaseConf):
     def __init__(
         self,
         product: str,
-        product_repo: Optional[str],
+        product_repo: Optional[Union[List[str], str]],
         product_version: Optional[str],
         settings,
         config,

--- a/openqabot/types/baseconf.py
+++ b/openqabot/types/baseconf.py
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
 from abc import ABCMeta, abstractmethod, abstractstaticmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from .incident import Incident
 
@@ -10,7 +10,7 @@ class BaseConf(metaclass=ABCMeta):
     def __init__(
         self,
         product: str,
-        product_repo: Optional[str],
+        product_repo: Optional[Union[List[str], str]],
         product_version: Optional[str],
         settings,
         config,  # pylint: disable=unused-argument

--- a/openqabot/types/incident.py
+++ b/openqabot/types/incident.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 import re
 from logging import getLogger
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple, Optional, Union
 
 from . import ArchVer, Repos
 from ..errors import EmptyChannels, EmptyPackagesError, NoRepoFoundError
@@ -89,7 +89,9 @@ class Incident:
         self.livepatch: bool = self._is_livepatch(self.packages)
 
     def compute_revisions_for_product_repo(
-        self, product_repo: Optional[str], product_version: Optional[str]
+        self,
+        product_repo: Optional[Union[List[str], str]],
+        product_version: Optional[str],
     ):
         self.revisions = self._rev(
             self.arch_filter, self.channels, self.project, product_repo, product_version
@@ -114,7 +116,7 @@ class Incident:
         arch_filter: Optional[List[str]],
         channels: List[Repos],
         project: str,
-        product_repo: Optional[str],
+        product_repo: Optional[Union[List[str], str]],
         product_version: Optional[str],
     ) -> Dict[ArchVer, int]:
         rev: Dict[ArchVer, int] = {}
@@ -138,8 +140,15 @@ class Incident:
 
         if tmpdict:
             for archver, lrepos in tmpdict.items():
+                last_product_repo = (
+                    product_repo[-1] if isinstance(product_repo, list) else product_repo
+                )
                 max_rev = get_max_revision(
-                    lrepos, archver.arch, project, product_repo, product_version
+                    lrepos,
+                    archver.arch,
+                    project,
+                    last_product_repo,
+                    product_version,
                 )
                 if max_rev > 0:
                     rev[archver] = max_rev

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -23,7 +23,7 @@ class Incidents(BaseConf):
     def __init__(
         self,
         product: str,
-        product_repo: Optional[str],
+        product_repo: Optional[Union[List[str], str]],
         product_version: Optional[str],
         settings,
         config,

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -12,6 +12,7 @@ import pytest
 import responses
 
 from openqabot import QEM_DASHBOARD, OBS_URL
+from openqabot.types import Repos
 from openqabot.giteasync import GiteaSync
 from openqabot.loader.gitea import (
     read_utf8,
@@ -20,6 +21,7 @@ from openqabot.loader.gitea import (
     review_pr,
     get_product_name,
     get_product_name_and_version_from_scmsync,
+    compute_repo_url_for_job_setting,
 )
 import openqabot.loader.gitea
 
@@ -203,3 +205,15 @@ def test_extracting_product_name_and_version():
 @responses.activate
 def test_reviewing_pr(fake_gitea_api_post_review_comment):
     review_pr({"token": "foo"}, "orga/repo", 42, "accepted", "12345")
+
+
+def test_computing_repo_url():
+    repos = Repos("product", "1.2", "x86_64")
+
+    url = compute_repo_url_for_job_setting("base", repos, "Foo", "16.0")
+    expected_url = "base/product:/1.2/product/repo/Foo-16.0-x86_64/"
+    assert url == expected_url
+
+    url = compute_repo_url_for_job_setting("base", repos, ["Foo", "Foo-Bar"], "16.0")
+    expected_url += ",base/product:/1.2/product/repo/Foo-Bar-16.0-x86_64/"
+    assert url == expected_url


### PR DESCRIPTION
With this it is possible to put e.g.:

```
product_repo:
  - SLES
  - SLES-HA
```

into meta-data leading to jobs being scheduled with:

```
INCIDENT_REPO=http://…/product/repo/SLES-16.0-x86_64/,http://…/product/repo/SLES-HA-16.0-x86_64/
```

Related ticket: https://progress.opensuse.org/issues/190743