### PR TITLE
Avoid using operator from Python >= 3.9 in increment approval code

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -17,7 +17,7 @@ from openqabot.openqa import openQAInterface
 
 from .errors import PostOpenQAError
 from .repodiff import Package, RepoDiff
-from .utils import retry10 as requests
+from .utils import retry10 as requests, merge_dicts
 from . import OBS_GROUP, OBS_URL, OBS_DOWNLOAD_URL
 
 log = getLogger("bot.increment_approver")
@@ -305,7 +305,7 @@ class IncrementApprover:
             extra_params.extend(
                 self._extra_builds_for_kernel_livepatching(relevant_diff, build_info)
             )
-        return [*map(lambda p: base_params | p, extra_params)]
+        return [*map(lambda p: merge_dicts(base_params, p), extra_params)]
 
     def _schedule_openqa_jobs(
         self, build_info: BuildInfo, params: List[Dict[str, str]]

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 import logging
 from copy import deepcopy
-from typing import Optional, List
+from typing import Any, Dict, Optional, List
 from pathlib import Path
 
 from requests import Session
@@ -77,6 +77,13 @@ def compare_incident_data(inc: Data, message) -> bool:
         if key in message and getattr(inc, key.lower()) != message[key]:
             return False
     return True
+
+
+def merge_dicts(dict1: Dict[Any, Any], dict2: Dict[Any, Any]) -> Dict[Any, Any]:
+    # return `dict1 | dict2` supporting Python < 3.9 which does not yet support this operator
+    copy = dict1.copy()
+    copy.update(dict2)
+    return copy
 
 
 def __retry(retries: Optional[int], backoff_factor: float) -> Session:


### PR DESCRIPTION
So it can still run in our GitLab pipelines.

Related ticket: https://progress.opensuse.org/issues/190251