### PR TITLE
Rename `INCIDENT_REPO` to `INCREMENT_REPO` for product increments

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -322,7 +322,7 @@ class IncrementApprover:
             "FLAVOR": build_info.flavor,
             "ARCH": build_info.arch,
             "BUILD": build_info.build,
-            "INCIDENT_REPO": config.build_project_url() + repo_sub_path,
+            "INCREMENT_REPO": config.build_project_url() + repo_sub_path,
         }
         IncrementApprover._populate_params_from_env(base_params, "CI_JOB_URL")
         base_params.update(config.settings)

--- a/tests/test_incrementapprover.py
+++ b/tests/test_incrementapprover.py
@@ -186,7 +186,7 @@ def test_scheduling_with_no_openqa_jobs(caplog, fake_no_jobs, fake_product_repo,
             "FLAVOR": "Online-Increments",
             "BUILD": "139.1",
             "ARCH": arch,
-            "INCIDENT_REPO": "http://download.suse.de/ibs/OBS:/PROJECT:/TEST/product",
+            "INCREMENT_REPO": "http://download.suse.de/ibs/OBS:/PROJECT:/TEST/product",
             "__CI_JOB_URL": ci_job_url,
         } in jobs, f"{arch} jobs created"
 
@@ -213,7 +213,7 @@ def test_scheduling_extra_livepatching_builds_with_no_openqa_jobs(caplog, fake_n
         "VERSION": "16.0",
         "FLAVOR": "Online-Increments",
         "BUILD": "139.1",
-        "INCIDENT_REPO": "http://download.suse.de/ibs/OBS:/PROJECT:/TEST/product",
+        "INCREMENT_REPO": "http://download.suse.de/ibs/OBS:/PROJECT:/TEST/product",
         "FOO": "bar",
     }
     for arch in ["x86_64", "aarch64", "ppc64le"]:


### PR DESCRIPTION
As discussed on Slack, `INCIDENT_REPO` should not be used (despite tests currently requiring it).