### PR TITLE
Use `%REPO_MIRROR_HOST%` in increment approver for `INCREMENT_REPO`

### DIFF
--- a/openqabot/__init__.py
+++ b/openqabot/__init__.py
@@ -16,7 +16,8 @@ OBS_REPO_TYPE = os.environ.get("OBS_REPO_TYPE", "product")
 OBS_PRODUCTS = set(os.environ.get("OBS_PRODUCTS", "SLES").split(","))
 ALLOW_DEVELOPMENT_GROUPS = os.environ.get("QEM_BOT_ALLOW_DEVELOPMENT_GROUPS")
 DEVELOPMENT_PARENT_GROUP_ID = 9
-DOWNLOAD_BASE = os.environ.get("DOWNLOAD_BASE_URL", "http://%REPO_MIRROR_HOST%/ibs/SUSE:/Maintenance:/")
+DOWNLOAD_BASE = os.environ.get("DOWNLOAD_BASE_URL", "http://%REPO_MIRROR_HOST%/ibs")
+DOWNLOAD_MAINTENANCE = os.environ.get("DOWNLOAD_MAINTENANCE_BASE_URL", DOWNLOAD_BASE + "/SUSE:/Maintenance:/")
 AMQP_URL = os.environ.get("AMQP_URL", "amqps://suse:suse@rabbit.suse.de")
 OLDEST_APPROVAL_JOB_DAYS = 6
 

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -13,7 +13,7 @@ import osc.core
 
 from openqabot.openqa import openQAInterface
 
-from . import OBS_GROUP, OBS_URL
+from . import DOWNLOAD_BASE, OBS_GROUP, OBS_URL
 from .errors import PostOpenQAError
 from .loader.incrementconfig import IncrementConfig
 from .repodiff import Package, RepoDiff
@@ -250,7 +250,7 @@ class IncrementApprover:
             "FLAVOR": build_info.flavor,
             "ARCH": build_info.arch,
             "BUILD": build_info.build,
-            "INCREMENT_REPO": config.build_project_url() + repo_sub_path,
+            "INCREMENT_REPO": config.build_project_url(DOWNLOAD_BASE) + repo_sub_path,
         }
         IncrementApprover._populate_params_from_env(base_params, "CI_JOB_URL")
         base_params.update(config.settings)

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -38,9 +38,9 @@ class IncrementConfig(NamedTuple):
     def diff_project(self) -> str:
         return self._concat_project(self.diff_project_suffix)
 
-    def build_project_url(self) -> str:
+    def build_project_url(self, base_url: str = OBS_DOWNLOAD_URL) -> str:
         base_path = self.build_project().replace(":", ":/")
-        return f"{OBS_DOWNLOAD_URL}/{base_path}"
+        return f"{base_url}/{base_path}"
 
     @staticmethod
     def from_config_entry(entry: Dict[str, str]) -> Any:

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -6,7 +6,7 @@ from itertools import chain
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Union
 
-from .. import DOWNLOAD_BASE, QEM_DASHBOARD, SMELT_URL
+from .. import DOWNLOAD_MAINTENANCE, QEM_DASHBOARD, SMELT_URL
 from ..dashboard import get_json
 from ..errors import NoTestIssues, SameBuildExists
 from ..loader.repohash import merge_repohash
@@ -107,11 +107,11 @@ class Aggregate(BaseConf):
                 for inc in incs:
                     if self.test_issues[issue].product.startswith("openSUSE"):
                         test_repos[tmpl].append(
-                            f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}/"
+                            f"{DOWNLOAD_MAINTENANCE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}/"
                         )
                     else:
                         test_repos[tmpl].append(
-                            f"{DOWNLOAD_BASE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}_{issues_arch}/"
+                            f"{DOWNLOAD_MAINTENANCE}{inc}/SUSE_Updates_{self.test_issues[issue].product}_{self.test_issues[issue].version}_{issues_arch}/"
                         )
 
             full_post["openqa"]["REPOHASH"] = merge_repohash(

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -3,7 +3,7 @@
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-from .. import GITEA, QEM_DASHBOARD, SMELT_URL
+from .. import DOWNLOAD_BASE, DOWNLOAD_MAINTENANCE, GITEA, QEM_DASHBOARD, SMELT_URL
 from ..errors import NoRepoFoundError
 from ..loader import gitea
 from ..pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
@@ -14,8 +14,6 @@ from .incident import Incident
 
 log = getLogger("bot.types.incidents")
 
-DOWNLOAD_BASE = "http://%REPO_MIRROR_HOST%/ibs"
-DOWNLOAD_MAINTENANCE = DOWNLOAD_BASE + "/SUSE:/Maintenance:/"
 BASE_PRIO = 50
 
 

--- a/tests/test_incrementapprover.py
+++ b/tests/test_incrementapprover.py
@@ -187,7 +187,7 @@ def test_scheduling_with_no_openqa_jobs(caplog, fake_no_jobs, fake_product_repo,
             "FLAVOR": "Online-Increments",
             "BUILD": "139.1",
             "ARCH": arch,
-            "INCREMENT_REPO": "http://download.suse.de/ibs/OBS:/PROJECT:/TEST/product",
+            "INCREMENT_REPO": "http://%REPO_MIRROR_HOST%/ibs/OBS:/PROJECT:/TEST/product",
             "__CI_JOB_URL": ci_job_url,
         } in jobs, f"{arch} jobs created"
 
@@ -214,7 +214,7 @@ def test_scheduling_extra_livepatching_builds_with_no_openqa_jobs(caplog, fake_n
         "VERSION": "16.0",
         "FLAVOR": "Online-Increments",
         "BUILD": "139.1",
-        "INCREMENT_REPO": "http://download.suse.de/ibs/OBS:/PROJECT:/TEST/product",
+        "INCREMENT_REPO": "http://%REPO_MIRROR_HOST%/ibs/OBS:/PROJECT:/TEST/product",
         "FOO": "bar",
     }
     for arch in ["x86_64", "aarch64", "ppc64le"]:


### PR DESCRIPTION
* Avoid duplicate definition of `DOWNLOAD_BASE`
* Avoid hardcoding download.suse.de as mentioned on Slack

Related ticket: https://progress.opensuse.org/issues/190251