### PR TITLE
Fix invalid pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [project]
 name = "qem-bot"
+dynamic = ["version"]
+description = "Tool for scheduling maintenance tests on openQA based on [SMELT](https://tools.io.suse.de/smelt) incidents and Gitea PRs."
+readme = "Readme.md"
 requires-python = ">=3.6"
 
 [tool.ruff]


### PR DESCRIPTION
Toml file was missing the `version` field in the `project` table.

Ticket: https://progress.opensuse.org/issues/191328