### PR TITLE
Fix computation of product version for Gitea PRs

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -82,7 +82,7 @@ def get_product_name(obs_project: str) -> str:
 
 
 def get_product_name_and_version_from_scmsync(scmsync_url: str) -> Tuple[str, str]:
-    m = re.search(".*/products/(.*)#(.*)", scmsync_url)
+    m = re.search(".*/products/(.*)#([\\d\\.]{2,6})$", scmsync_url)
     return (m.group(1), m.group(2)) if m else ("", "")
 
 

--- a/responses/build-results-124-SUSE:SLFO:1.1.99:PullRequest:124:SLES.xml
+++ b/responses/build-results-124-SUSE:SLFO:1.1.99:PullRequest:124:SLES.xml
@@ -1,5 +1,7 @@
 <resultlist state="6e48177c5dc93e3281cdac1b5fdc1e04">
   <result project="SUSE:SLFO:1.1.99:PullRequest:124:SLES" repository="standard" arch="aarch64" code="published" state="published">
+    <!-- This scmsync element is supposed to be ignored as it only contains a Git hash and not the product version. -->
+    <scmsync>https://src.suse.de/products/SLES#18bfa2a23fb7985d5d0cc356474a96a19d91d2d8652442badf7f13bc07cd1f3d</scmsync>
     <scminfo>18bfa2a23fb7985d5d0cc356474a96a19d91d2d8652442badf7f13bc07cd1f3d</scminfo>
     <!-- The list of packages in this and other results is stripped down from the actual example on Gitea. -->
     <status package="base-image" code="excluded" />


### PR DESCRIPTION
This is a continuation of 7b80d165a5dd6473ea4fba5d43134b2834999a12. It makes the regex used to read the product version from `scmsync` elements more specific so it doesn't wrongly match on Git commit hashes. If it does not match, the code from 7b80d165a5dd6473ea4fba5d43134b2834999a12 will be used to determine the product version instead.

Related ticket: https://progress.opensuse.org/issues/191896