### PR TITLE
Prevent CI warning about ruff version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: astral-sh/ruff-action@v3
+        with:
+          version: "latest"
       - name: Check format
         run: ruff format --check
       - uses: actions/setup-python@v6


### PR DESCRIPTION
this is to prevent the following warning in CI

```Found ruff version in pyproject.toml: undefined
Warning: Could not parse version from
/home/runner/work/qem-bot/qem-bot/pyproject.toml. Using latest version.
```