### PR TITLE
Postpone job_result when reschedule

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -325,11 +325,11 @@ class IncrementApprover:
                 log.info("Skipping %s for %s, filtered out via 'packages' or 'archs' setting", config, build_info)
                 continue
             info_str = build_info.string_with_params(params[0])
-            res = self._request_openqa_job_results(build_info, params)
             if self.args.reschedule:
                 approval_status.reasons_to_disapprove.append("Re-scheduling jobs for " + info_str)
                 error_count += self._schedule_openqa_jobs(build_info, params)
                 continue
+            res = self._request_openqa_job_results(build_info, params)
             openqa_jobs_ready = self._check_openqa_jobs(res, build_info, params)
             if openqa_jobs_ready is None:
                 approval_status.reasons_to_disapprove.append("No jobs scheduled for " + info_str)


### PR DESCRIPTION
Postpone the call to request_openqa_job_result. This allow to completly skip this openQA request when IncrementApprover is configured with reschedule argument.