### PR TITLE
Fix test behaviour urllib3 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     "pytest-cov",
     "coverage",
     "responses>=0.21.0",
-    "urllib3<2",
+    "urllib3",
     "ruff",
 ]
 


### PR DESCRIPTION
When running tests with urllib3 v2.0 or later test_openqaclient failed with

```
requests.exceptions.ChunkedEncodingError: ('Connection broken: IncompleteRead(13 bytes read, -6 more expected)', IncompleteRead(13 bytes read, -6 more expected))"
```

which is likely due to stricter enforcement of HTTP standards for chunked
transfer encoding. We can simplify the mock and correct the assertion to fix
this in a way compatible for old and new versions of urllib.

Related progress issue: https://progress.opensuse.org/issues/192433