### PR TITLE
PART 2: Remove all redundant re-raises - After #286

### DIFF
--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -62,11 +62,7 @@ def get_incidents(token: Dict[str, str]) -> List[Incident]:
 
 
 def get_active_incidents(token: Dict[str, str]) -> Sequence[int]:
-    try:
-        data = get_json("api/incidents", headers=token)
-    except Exception:
-        log.exception("")
-        raise
+    data = get_json("api/incidents", headers=token)
     return list({i["number"] for i in data})
 
 
@@ -107,12 +103,7 @@ def get_incident_settings(inc: int, token: Dict[str, str], *, all_incidents: boo
 
 def get_incident_settings_data(token: Dict[str, str], number: int) -> Sequence[Data]:
     log.info("Getting settings for %s", number)
-    try:
-        data = get_json("api/incident_settings/" + f"{number}", headers=token)
-    except Exception:
-        log.exception("")
-        raise
-
+    data = get_json("api/incident_settings/" + f"{number}", headers=token)
     if "error" in data:
         log.warning("Incident %s contains error: %s", number, data["error"])
         return []
@@ -137,12 +128,8 @@ def get_incident_results(inc: int, token: Dict[str, str]) -> List[Dict[str, Any]
 
     ret = []
     for job_aggr in settings:
-        try:
-            data = get_json("api/jobs/incident/" + f"{job_aggr.id}", headers=token)
-            ret += data
-        except Exception:
-            log.exception("")
-            raise
+        data = get_json("api/jobs/incident/" + f"{job_aggr.id}", headers=token)
+        ret += data
         if "error" in data:
             raise ValueError(data["error"])
 
@@ -164,12 +151,7 @@ def get_aggregate_settings(inc: int, token: Dict[str, str]) -> List[JobAggr]:
 
 def get_aggregate_settings_data(token: Dict[str, str], data: Data) -> Sequence[Data]:
     url = "api/update_settings" + f"?product={data.product}&arch={data.arch}"
-    try:
-        settings = get_json(url, headers=token)
-    except Exception:
-        log.exception("")
-        raise
-
+    settings = get_json(url, headers=token)
     if not settings:
         log.info("Product: %s on arch: %s does not have any settings", data.product, data.arch)
         return []
@@ -197,12 +179,8 @@ def get_aggregate_results(inc: int, token: Dict[str, str]) -> List[Dict[str, Any
 
     ret = []
     for job_aggr in settings:
-        try:
-            data = get_json("api/jobs/update/" + f"{job_aggr.id}", headers=token)
-            ret += data
-        except Exception:
-            log.exception("")
-            raise
+        data = get_json("api/jobs/update/" + f"{job_aggr.id}", headers=token)
+        ret += data
         if "error" in data:
             raise ValueError(data["error"])
 

--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -59,9 +59,6 @@ def get_max_revision(
         ) as e:  # for now, use logger.exception to determine possible exceptions in this code :D
             log.info("%s not found -- skipping incident", url)
             raise NoRepoFoundError from e
-        except Exception:
-            log.exception("")
-            raise
 
         if cs is None:
             log.error("%s's revision is None", url)

--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -125,11 +125,7 @@ INCIDENT_SCHEMA = {
 
 
 def get_json(query: str, host: str = SMELT) -> Dict[str, Any]:
-    try:
-        return retried_requests.get(host, params={"query": query}, verify=False).json()
-    except Exception:
-        log.exception("")
-        raise
+    return retried_requests.get(host, params={"query": query}, verify=False).json()
 
 
 def get_active_incidents() -> Set[int]:

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -64,14 +64,7 @@ class openQAInterface:
         param["build"] = data.build
         param["version"] = data.version
         param["arch"] = data.arch
-
-        ret = None
-        try:
-            ret = self.openqa.openqa_request("GET", "jobs", param)["jobs"]
-        except Exception:
-            log.exception("")
-            raise
-        return ret
+        return self.openqa.openqa_request("GET", "jobs", param)["jobs"]
 
     @lru_cache(maxsize=512)
     def get_job_comments(self, job_id: int) -> List[Dict[str, str]]:
@@ -89,14 +82,7 @@ class openQAInterface:
 
     @lru_cache(maxsize=256)
     def is_devel_group(self, groupid: int) -> bool:
-        ret = None
-
-        try:
-            ret = self.openqa.openqa_request("GET", f"job_groups/{groupid}")
-        except Exception:
-            log.exception("")
-            raise
-
+        ret = self.openqa.openqa_request("GET", f"job_groups/{groupid}")
         # return True as safe option if ret = None
         return ret[0]["parent_id"] == DEVELOPMENT_PARENT_GROUP_ID if ret else True  # ID of Development Group
 

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -45,16 +45,8 @@ class OpenQABot:
             )
             return
 
-        try:
-            res = put(api, headers=self.token, json=data)
-            log.info(
-                "Put to dashboard result %s, database id: %s",
-                res.status_code,
-                res.json().get("id", "No id?"),
-            )
-        except Exception:
-            log.exception("")
-            raise
+        res = put(api, headers=self.token, json=data)
+        log.info("Put to dashboard result %s, database id: %s", res.status_code, res.json().get("id", "No id?"))
 
     def post_openqa(self, data: Dict[str, Any]) -> None:
         self.openqa.post_job(data)

--- a/tests/test_repohash.py
+++ b/tests/test_repohash.py
@@ -112,11 +112,8 @@ def test_get_max_revison_empty_xml(caplog: LogCaptureFixture) -> None:
 def test_get_max_revison_exception(caplog: LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.repohash")
     add_sles_sled_response(BufferError("other error"))
-
     with pytest.raises(BufferError):
         rp.get_max_revision(repos, arch, PROJECT)
-
-    assert caplog.records[0].exc_info[0] is BufferError
 
 
 def test_merge_repohash() -> None:


### PR DESCRIPTION
* Remove all redundant re-raises

Tested manually with

```
while_inotifywait sh -c 'make test && for i in incidents-run updates-run smelt-sync gitea-sync inc-approve inc-comment inc-sync-results aggr-sync-results increment-approve repo-diff amqp; do echo "### $i" && timeout 6 ./qem-bot.py -t 1234 -c metadata/bot-ng --singlearch metadata/bot-ng/singlearch.yml --dry --fake-data $i ; done'
```

After:
* #286

Before:
* #252