### PR TITLE
Use lxml consistently

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,8 +7,8 @@ RUN zypper ar https://download.opensuse.org/repositories/SUSE:/CA/openSUSE_Tumbl
         ca-certificates-suse \
         git \
         openssh-clients \
-        python3-defusedxml \
         python3-jsonschema \
+        python3-lxml \
         python3-openqa_client \
         python3-osc \
         python3-pika \

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -12,8 +12,7 @@ import osc.core
 import osc.util.xml
 import urllib3
 import urllib3.exceptions
-from defusedxml import ElementTree
-from defusedxml.ElementTree import parse
+from lxml import etree
 from osc.core import MultibuildFlavorResolver
 
 from .. import GIT_REVIEW_BOT, GITEA, OBS_DOWNLOAD_URL, OBS_GROUP, OBS_PRODUCTS, OBS_REPO_TYPE, OBS_URL
@@ -58,8 +57,8 @@ def read_json(name: str) -> Any:
         return json.loads(json_file.read())
 
 
-def read_xml(name: str) -> ElementTree:
-    return parse("responses/%s.xml" % name)
+def read_xml(name: str) -> etree.ElementTree:
+    return etree.parse("responses/%s.xml" % name)
 
 
 def reviews_url(repo_name: str, number: int) -> str:

--- a/openqabot/loader/repohash.py
+++ b/openqabot/loader/repohash.py
@@ -4,8 +4,8 @@ from hashlib import md5
 from logging import getLogger
 from typing import List, Optional, Tuple
 
+import lxml.etree as ET
 import requests
-from defusedxml import ElementTree as ET
 from requests.exceptions import RetryError
 
 from .. import OBS_DOWNLOAD_URL, OBS_PRODUCTS
@@ -49,7 +49,7 @@ def get_max_revision(
             url = f"{url_base}/SUSE_Updates_{repo[0]}_{repo[1]}_{arch}/repodata/repomd.xml"
 
         try:
-            root = ET.fromstring(retried_requests.get(url).text)
+            root = ET.fromstring(retried_requests.get(url).content)
             cs = root.find(".//{http://linux.duke.edu/metadata/repo}revision")
         except (
             ET.ParseError,

--- a/openqabot/osclib/comments.py
+++ b/openqabot/osclib/comments.py
@@ -4,13 +4,13 @@ import re
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple, Union
 
-from defusedxml.etree import ElementTree as ET
+from lxml import etree
 from osc.core import http_DELETE, http_GET, http_POST, makeurl
 
 from ..utc import UTC
 
 
-def _comment_as_dict(comment_element: ET.Element) -> Dict[str, Any]:
+def _comment_as_dict(comment_element: etree.Element) -> Dict[str, Any]:
     """Convert an XML element comment into a dictionary.
 
     :param comment_element: XML element that store a comment.
@@ -70,7 +70,7 @@ class CommentAPI(object):
         :returns: A list of comments (as a dictionary).
         """
         url = self._prepare_url(request_id, project_name, package_name)
-        root = ET.parse(http_GET(url)).getroot()
+        root = etree.parse(http_GET(url)).getroot()
         comments = {}
         for c in root.findall("comment"):
             c = _comment_as_dict(c)

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from logging import getLogger
 from typing import Any, DefaultDict, Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
+import lxml.etree as ET
 import zstandard
 
 from . import OBS_DOWNLOAD_URL
@@ -20,16 +21,6 @@ name_tag = ns + "name"
 version_tag = ns + "version"
 arch_tag = ns + "arch"
 primary_re = re.compile(r".*-primary.xml(?:.(gz|zst))?$")
-
-
-try:
-    import lxml.etree as ET
-
-    log.info("Using lxml for XML parsing when computing repo diff")
-except ImportError:
-    import defusedxml.ElementTree as ET
-
-    log.warning("Using built-in XML parsing when computing repo diff")
 
 
 class Package(NamedTuple):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
 ]
 dependencies = [
     "dataclasses",
-    "defusedxml",
     "osc",
     "openqa-client",
     "pika",

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 import logging
 import re
-import xml.etree.ElementTree as ET
 from collections import namedtuple
 from pathlib import Path
 from typing import Any, Tuple
@@ -11,6 +10,7 @@ from urllib.parse import urljoin
 import osc.conf
 import osc.core
 import pytest
+from lxml import etree as ET
 from pytest import LogCaptureFixture, MonkeyPatch
 
 import openqabot.loader.gitea


### PR DESCRIPTION
We have lxml available where we care. The change to introduce defused
introduced a problem for the type checks. The easiest and most
consistent approach is if we just rely on lxml everywhere.