### PR TITLE
Use interpreter from environment to better support virtual environments

### DIFF
--- a/qem-bot.py
+++ b/qem-bot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
 from openqabot.main import main


### PR DESCRIPTION
This requests `qem-bot.py` to use the python interpreter configured in the current users environment. It is mainly useful for systems where not all requirements can be installed system-wide (e.g. on my system, I have to install `osc` via pip into an virtual environment). Without this change:

```shell
nicksinger@workstation git/qem-bot ‹master› » pip freeze | grep osc  # system python does not have the osc module available
nicksinger@workstation git/qem-bot ‹master› » ./qem-bot.py --debug --configs metadata/qem-bot -s metadata/qem-bot/singlearch.yml -t "${token}" --dry increment-approve --increment-config metadata/qem-bot  # traceback expected since venv not activated, using system python
Traceback (most recent call last):
  File "/home/sqozz/git/qem-bot/./qem-bot.py", line 7, in <module>
    main()
    ~~~~^^
  File "/home/sqozz/git/qem-bot/openqabot/main.py", line 32, in main
    sys.exit(cfg.func(cfg))
             ~~~~~~~~^^^^^
  File "/home/sqozz/git/qem-bot/openqabot/args.py", line 83, in do_increment_approve
    from .incrementapprover import IncrementApprover
  File "/home/sqozz/git/qem-bot/openqabot/incrementapprover.py", line 11, in <module>
    import osc.conf
ModuleNotFoundError: No module named 'osc'
nicksinger@workstation git/qem-bot ‹master› » . ./venv/bin/activate
(venv) nicksinger@workstation git/qem-bot ‹master› » pip freeze | grep osc  # proof that osc is installed in the now active environment
osc==1.22.0
(venv) nicksinger@workstation git/qem-bot ‹master› » ./qem-bot.py --debug --configs metadata/qem-bot -s metadata/qem-bot/singlearch.yml -t "${token}" --dry increment-approve --increment-config metadata/qem-bot  # invocation still fails because wrong interpreter is used
Traceback (most recent call last):
  File "/home/sqozz/git/qem-bot/./qem-bot.py", line 7, in <module>
    main()
    ~~~~^^
  File "/home/sqozz/git/qem-bot/openqabot/main.py", line 32, in main
    sys.exit(cfg.func(cfg))
             ~~~~~~~~^^^^^
  File "/home/sqozz/git/qem-bot/openqabot/args.py", line 83, in do_increment_approve
    from .incrementapprover import IncrementApprover
  File "/home/sqozz/git/qem-bot/openqabot/incrementapprover.py", line 11, in <module>
    import osc.conf
ModuleNotFoundError: No module named 'osc'
```

With this change:

```shell
nicksinger@workstation git/qem-bot ‹use_env› » ./qem-bot.py --debug --configs metadata/qem-bot -s metadata/qem-bot/singlearch.yml -t "${token}" --dry increment-approve --increment-config metadata/qem-bot  # still fails with system python, expected
Traceback (most recent call last):
  File "/home/sqozz/git/qem-bot/./qem-bot.py", line 7, in <module>
    main()
    ~~~~^^
  File "/home/sqozz/git/qem-bot/openqabot/main.py", line 32, in main
    sys.exit(cfg.func(cfg))
             ~~~~~~~~^^^^^
  File "/home/sqozz/git/qem-bot/openqabot/args.py", line 83, in do_increment_approve
    from .incrementapprover import IncrementApprover
  File "/home/sqozz/git/qem-bot/openqabot/incrementapprover.py", line 11, in <module>
    import osc.conf
ModuleNotFoundError: No module named 'osc'
nicksinger@workstation git/qem-bot ‹use_env› » . ./venv/bin/activate
(venv) nicksinger@workstation git/qem-bot ‹use_env› » pip freeze | grep osc
osc==1.22.0
(venv) nicksinger@workstation git/qem-bot ‹use_env› » ./qem-bot.py --debug --configs metadata/qem-bot -s metadata/qem-bot/singlearch.yml -t "${token}" --dry increment-approve --increment-config metadata/qem-bot  # now uses the interpreter from venv
2025-11-18 13:53:29 INFO     Using lxml for XML parsing when computing repo diff
2025-11-18 13:53:29 INFO     Reading config file 'metadata/qem-bot/ha12sp3.yml'
2025-11-18 13:53:29 INFO     Reading config file 'metadata/qem-bot/ha12sp5-es.yml'
[…]
```