### PR TITLE
Use _OBSOLETE=1 for SLFO incidents

### DIFF
--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -6,7 +6,7 @@ from itertools import chain
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Union
 
-from openqabot import DOWNLOAD_MAINTENANCE, QEM_DASHBOARD, SMELT_URL
+from openqabot import DEPRIORITIZE_LIMIT, DOWNLOAD_MAINTENANCE, QEM_DASHBOARD, SMELT_URL
 from openqabot.dashboard import get_json
 from openqabot.errors import NoTestIssues, SameBuildExists
 from openqabot.loader.repohash import merge_repohash
@@ -166,10 +166,13 @@ class Aggregate(BaseConf):
                 if not settings.get("PUBLIC_CLOUD_IMAGE_ID", False):
                     continue
 
-            self.set_obsoletion(settings)
             full_post["openqa"].update(settings)
             full_post["openqa"]["FLAVOR"] = self.flavor
             full_post["openqa"]["ARCH"] = arch
+            full_post["openqa"]["_DEPRIORITIZEBUILD"] = 1
+
+            if DEPRIORITIZE_LIMIT is not None:
+                full_post["openqa"]["_DEPRIORITIZE_LIMIT"] = DEPRIORITIZE_LIMIT
 
             for template, issues in test_incidents.items():
                 full_post["openqa"][template] = ",".join(str(x) for x in issues)

--- a/openqabot/types/baseconf.py
+++ b/openqabot/types/baseconf.py
@@ -3,8 +3,6 @@
 from abc import ABC, abstractmethod, abstractstaticmethod
 from typing import Any, Dict, List, Optional, Union
 
-from openqabot import DEPRIORITIZE_LIMIT
-
 from .incident import Incident
 
 
@@ -41,10 +39,3 @@ class BaseConf(ABC):
         return any(k.startswith("PUBLIC") for k in self.settings) or any(
             flavor.startswith(s) for s in ("Azure", "EC2", "GCE")
         )
-
-    @staticmethod
-    def set_obsoletion(settings: dict) -> None:
-        if "_OBSOLETE" not in settings:
-            settings["_DEPRIORITIZEBUILD"] = 1
-            if DEPRIORITIZE_LIMIT is not None:
-                settings["_DEPRIORITIZE_LIMIT"] = DEPRIORITIZE_LIMIT

--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -131,7 +131,6 @@ class Incidents(BaseConf):
         full_post["qem"] = {}
         full_post["openqa"] = {}
         full_post["openqa"].update(self.settings)
-        self.set_obsoletion(full_post["openqa"])
         full_post["qem"]["incident"] = inc.id
         full_post["openqa"]["ARCH"] = arch
         full_post["qem"]["arch"] = arch
@@ -141,6 +140,7 @@ class Incidents(BaseConf):
         full_post["qem"]["version"] = self.settings["VERSION"]
         full_post["openqa"]["DISTRI"] = self.settings["DISTRI"]
         full_post["openqa"]["_ONLY_OBSOLETE_SAME_BUILD"] = "1"
+        full_post["openqa"]["_OBSOLETE"] = "1"
         full_post["openqa"]["INCIDENT_ID"] = inc.id
 
         if ci_url:

--- a/tests/test_baseconf.py
+++ b/tests/test_baseconf.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
-import openqabot.types.baseconf
 from openqabot.types.baseconf import BaseConf, Incident
 
 
@@ -50,11 +49,3 @@ def test_is_embargoed(baseconf_gen: FakeBaseConf) -> None:
 
     assert baseconf_gen.filter_embargoed("Noone") is False
     assert baseconf_gen.filter_embargoed("Azure-test")
-
-
-def test_set_obsoletion(baseconf_gen: FakeBaseConf, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(openqabot.types.baseconf, "DEPRIORITIZE_LIMIT", "50")
-    settings = {}
-    baseconf_gen.set_obsoletion(settings)
-    assert settings["_DEPRIORITIZEBUILD"] == 1
-    assert settings["_DEPRIORITIZE_LIMIT"] == "50"


### PR DESCRIPTION
It's been agreed to use _OBSOLETE=1 for incidents in SLFO stagings. The reason is to cancel previous jobs and keep the new ones only to avoid jobs queueing up in openQA.

https://progress.opensuse.org/issues/192424