### PR TITLE
PART 7: refactor: Use proper pytest import instead of low-level one - After #308

### DIFF
--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -7,7 +7,7 @@ from typing import NamedTuple
 from unittest.mock import patch
 from urllib.parse import urlparse
 
-from _pytest.logging import LogCaptureFixture
+import pytest
 
 import responses
 from openqabot.amqp import AMQP
@@ -60,7 +60,7 @@ def test_call() -> None:
 
 
 @responses.activate
-def test_handling_incident(caplog: LogCaptureFixture) -> None:
+def test_handling_incident(caplog: pytest.LogCaptureFixture) -> None:
     # define response for get_incident_settings_data
     data = [
         {
@@ -119,7 +119,7 @@ def test_handling_incident(caplog: LogCaptureFixture) -> None:
 
 
 @responses.activate
-def test_handling_aggregate(caplog: LogCaptureFixture) -> None:
+def test_handling_aggregate(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     amqp.on_message("", fake_job_done, "", json.dumps({"BUILD": "12345678-9"}))
 
@@ -127,7 +127,7 @@ def test_handling_aggregate(caplog: LogCaptureFixture) -> None:
     assert "Aggregate build 12345678-9 done" in messages  # currently noop
 
 
-def test_on_message_bad_routing_key(caplog: LogCaptureFixture) -> None:
+def test_on_message_bad_routing_key(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     fake_job_fail = FakeMethod("suse.openqa.job.fail")
     amqp.on_message(
@@ -139,20 +139,20 @@ def test_on_message_bad_routing_key(caplog: LogCaptureFixture) -> None:
     assert not caplog.text
 
 
-def test_on_message_no_build(caplog: LogCaptureFixture) -> None:
+def test_on_message_no_build(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     amqp.on_message("", fake_job_done, "", json.dumps({"NOBUILD": "12345678-9"}))
     assert not caplog.text
 
 
-def test_on_message_bad_build(caplog: LogCaptureFixture) -> None:
+def test_on_message_bad_build(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     amqp.on_message("", fake_job_done, "", json.dumps({"BUILD": "badbuild"}))
     assert not caplog.text
 
 
 @responses.activate
-def test_handle_incident_value_error(caplog: LogCaptureFixture) -> None:
+def test_handle_incident_value_error(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     with patch("openqabot.amqp.get_incident_settings_data", side_effect=ValueError):
         amqp.handle_incident(33222, {})

--- a/tests/test_approve.py
+++ b/tests/test_approve.py
@@ -12,7 +12,6 @@ from urllib.parse import urlparse
 import osc.conf
 import osc.core
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 import openqabot.approver
 import responses
@@ -273,7 +272,7 @@ def approver(incident: int = 0) -> int:
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem")
-def test_no_jobs(caplog: LogCaptureFixture) -> None:
+def test_no_jobs(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     responses.add(responses.GET, re.compile(f"{QEM_DASHBOARD}api/jobs/.*/.*"), json={})
     approver()
@@ -287,7 +286,7 @@ def test_no_jobs(caplog: LogCaptureFixture) -> None:
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem")
-def test_single_incident(caplog: LogCaptureFixture) -> None:
+def test_single_incident(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     responses.add(
         responses.GET,
@@ -347,7 +346,7 @@ def test_single_incident(caplog: LogCaptureFixture) -> None:
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs")
-def test_all_passed(caplog: LogCaptureFixture) -> None:
+def test_all_passed(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     assert len(caplog.records) >= 1, "we rely on log messages in tests"
@@ -363,7 +362,7 @@ def test_all_passed(caplog: LogCaptureFixture) -> None:
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["aggr"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs")
-def test_inc_passed_aggr_without_results(caplog: LogCaptureFixture) -> None:
+def test_inc_passed_aggr_without_results(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     assert len(caplog.records) >= 1, "we rely on log messages in tests"
@@ -380,7 +379,7 @@ def test_inc_passed_aggr_without_results(caplog: LogCaptureFixture) -> None:
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["inc"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs")
-def test_inc_without_results(caplog: LogCaptureFixture) -> None:
+def test_inc_without_results(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     assert len(caplog.records) >= 1, "we rely on log messages in tests"
@@ -400,7 +399,7 @@ class ObsHTTPError(HTTPError):
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs", "fake_responses_for_creating_pr_review", "f_osconf")
 def test_403_response(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
@@ -420,7 +419,7 @@ def test_403_response(
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs", "f_osconf")
-def test_404_response(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_404_response(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*_args: Any, **_kwds: Any) -> NoReturn:
@@ -438,7 +437,7 @@ def test_404_response(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs", "f_osconf")
 def test_500_response(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
@@ -461,7 +460,7 @@ def test_500_response(
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs", "f_osconf")
-def test_osc_unknown_exception(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_osc_unknown_exception(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*_args: Any, **_kwds: Any) -> NoReturn:
@@ -479,7 +478,7 @@ def test_osc_unknown_exception(caplog: LogCaptureFixture, monkeypatch: pytest.Mo
 @responses.activate
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_two_passed_jobs", "fake_responses_for_creating_pr_review", "f_osconf")
-def test_osc_all_pass(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_osc_all_pass(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     def f_osc_core(*_args: Any, **_kwds: Any) -> None:
@@ -531,7 +530,7 @@ def fake_incident_1_failed_2_passed(request: pytest.FixtureRequest) -> None:
     "fake_openqa_comment_api",
     "fake_responses_updating_job",
 )
-def test_one_incident_failed(caplog: LogCaptureFixture) -> None:
+def test_one_incident_failed(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     assert len(caplog.records) >= 1, "we rely on log messages in tests"
@@ -553,7 +552,7 @@ def test_one_incident_failed(caplog: LogCaptureFixture) -> None:
     "fake_responses_updating_job",
     "fake_openqa_older_jobs_api",
 )
-def test_one_aggr_failed(caplog: LogCaptureFixture) -> None:
+def test_one_aggr_failed(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     responses.add(
@@ -592,7 +591,7 @@ def test_one_aggr_failed(caplog: LogCaptureFixture) -> None:
     "fake_openqa_older_jobs_api",
 )
 def test_approval_unblocked_via_openqa_comment(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     fake_dashboard_remarks_api: list[responses.BaseResponse],
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
@@ -627,7 +626,7 @@ def test_approval_unblocked_via_openqa_comment(
     "fake_openqa_older_jobs_api",
 )
 def test_all_jobs_marked_as_acceptable_for_via_openqa_comment(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     fake_dashboard_remarks_api: list[responses.BaseResponse],
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
@@ -659,7 +658,7 @@ def test_all_jobs_marked_as_acceptable_for_via_openqa_comment(
     "fake_openqa_comment_api",
     "fake_openqa_older_jobs_api",
 )
-def test_approval_still_blocked_if_openqa_comment_not_relevant(caplog: LogCaptureFixture) -> None:
+def test_approval_still_blocked_if_openqa_comment_not_relevant(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
@@ -670,7 +669,7 @@ def test_approval_still_blocked_if_openqa_comment_not_relevant(caplog: LogCaptur
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.parametrize("fake_responses_for_unblocking_incidents_via_older_ok_result", [2], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_responses_for_unblocking_incidents_via_older_ok_result")
-def test_approval_unblocked_via_openqa_older_ok_job(caplog: LogCaptureFixture) -> None:
+def test_approval_unblocked_via_openqa_older_ok_job(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     responses.add(
         responses.GET,
@@ -686,7 +685,9 @@ def test_approval_unblocked_via_openqa_older_ok_job(caplog: LogCaptureFixture) -
 @pytest.mark.parametrize("fake_qem", ["NoResultsError isn't raised"], indirect=True)
 @pytest.mark.parametrize("fake_responses_for_unblocking_incidents_via_older_ok_result", [2], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_responses_for_unblocking_incidents_via_older_ok_result")
-def test_approval_still_blocked_via_openqa_older_ok_job_because_not_in_dashboard(caplog: LogCaptureFixture) -> None:
+def test_approval_still_blocked_via_openqa_older_ok_job_because_not_in_dashboard(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     responses.add(
         responses.GET,
@@ -706,7 +707,7 @@ def test_approval_still_blocked_via_openqa_older_ok_job_because_not_in_dashboard
     indirect=True,
 )
 @pytest.mark.usefixtures("fake_qem", "fake_responses_for_unblocking_incidents_via_older_ok_result")
-def test_approval_still_blocked_if_openqa_older_job_dont_include_incident(caplog: LogCaptureFixture) -> None:
+def test_approval_still_blocked_if_openqa_older_job_dont_include_incident(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     assert approver() == 0
     messages = [x[-1] for x in caplog.record_tuples]
@@ -727,7 +728,7 @@ def test_approval_still_blocked_if_openqa_older_job_dont_include_incident(caplog
 @pytest.mark.usefixtures("fake_qem", "fake_openqa_older_jobs_api", "fake_dashboard_remarks_api")
 def test_approval_unblocked_with_various_comment_formats(
     comment_text: str,
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 

--- a/tests/test_incrementapprover.py
+++ b/tests/test_incrementapprover.py
@@ -13,7 +13,6 @@ from urllib.parse import urlparse
 import osc.conf
 import osc.core
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 import openqabot
 import responses
@@ -170,7 +169,7 @@ def fake_change_review_state(apiurl: str, reqid: str, newstate: str, by_group: s
 
 
 def prepare_approver(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     *,
     schedule: bool = False,
@@ -213,7 +212,7 @@ def prepare_approver(
 
 
 def run_approver(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     *,
     schedule: bool = False,
@@ -245,7 +244,9 @@ def run_approver(
 
 @responses.activate
 @pytest.mark.usefixtures("fake_ok_jobs", "fake_product_repo")
-def test_approval_if_there_are_only_ok_openqa_jobs(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_approval_if_there_are_only_ok_openqa_jobs(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     run_approver(caplog, monkeypatch)
     last_message = [x[-1] for x in caplog.record_tuples][-1]
     assert "All 2 jobs on openQA have passed/softfailed" in last_message
@@ -253,7 +254,7 @@ def test_approval_if_there_are_only_ok_openqa_jobs(caplog: LogCaptureFixture, mo
 
 @responses.activate
 @pytest.mark.usefixtures("fake_ok_jobs", "fake_product_repo")
-def test_skipping_if_rescheduling(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_skipping_if_rescheduling(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     run_approver(caplog, monkeypatch, reschedule=True)
     last_message = [x[-1] for x in caplog.record_tuples][-1]
     assert "have passed" not in last_message
@@ -263,7 +264,7 @@ def test_skipping_if_rescheduling(caplog: LogCaptureFixture, monkeypatch: pytest
 @responses.activate
 @pytest.mark.usefixtures("fake_not_ok_jobs", "fake_ok_jobs", "fake_product_repo")
 def test_skipping_with_failing_openqa_jobs_for_one_config(
-    caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     increment_approver = prepare_approver(caplog, monkeypatch)
     increment_approver.config.append(increment_approver.config[0])
@@ -276,7 +277,7 @@ def test_skipping_with_failing_openqa_jobs_for_one_config(
 @responses.activate
 @pytest.mark.usefixtures("fake_no_jobs", "fake_product_repo")
 def test_skipping_with_no_openqa_jobs(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     run_approver(caplog, monkeypatch)
@@ -290,7 +291,7 @@ def test_skipping_with_no_openqa_jobs(
 @responses.activate
 @pytest.mark.usefixtures("fake_no_jobs", "fake_product_repo")
 def test_scheduling_with_no_openqa_jobs(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     ci_job_url = "https://some/ci/job/url"
@@ -360,7 +361,7 @@ def assert_run_with_extra_livepatching(errors: int, jobs: List, messages: List) 
 @responses.activate
 @pytest.mark.usefixtures("fake_no_jobs", "fake_product_repo")
 def test_scheduling_extra_livepatching_builds_with_no_openqa_jobs(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     path = Path("tests/fixtures/config-increment-approver/increment-definitions.yaml")
@@ -387,7 +388,7 @@ def test_scheduling_extra_livepatching_builds_with_no_openqa_jobs(
 @responses.activate
 @pytest.mark.usefixtures("fake_no_jobs", "fake_product_repo")
 def test_scheduling_extra_livepatching_builds_based_on_source_report(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(osc.core, "get_repos_of_project", fake_get_repos_of_project)
@@ -409,7 +410,7 @@ def test_scheduling_extra_livepatching_builds_based_on_source_report(
 
 @responses.activate
 @pytest.mark.usefixtures("fake_pending_jobs", "fake_product_repo")
-def test_skipping_with_pending_openqa_jobs(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_skipping_with_pending_openqa_jobs(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     run_approver(caplog, monkeypatch)
     messages = [x[-1] for x in caplog.record_tuples]
     assert (
@@ -421,7 +422,7 @@ def test_skipping_with_pending_openqa_jobs(caplog: LogCaptureFixture, monkeypatc
 @responses.activate
 @pytest.mark.usefixtures("fake_not_ok_jobs", "fake_product_repo")
 def test_listing_not_ok_openqa_jobs(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     run_approver(caplog, monkeypatch)
@@ -431,7 +432,7 @@ def test_listing_not_ok_openqa_jobs(
     assert "http://openqa-instance/tests/20" not in last_message
 
 
-def test_config_parsing(caplog: LogCaptureFixture) -> None:
+def test_config_parsing(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.increment_config")
     path = Path("tests/fixtures/config-increment-approver")
     configs = [*IncrementConfig.from_config_path(path)]
@@ -464,7 +465,7 @@ def test_config_parsing(caplog: LogCaptureFixture) -> None:
     assert "Reading config file 'tests/fixtures/config/03_no_tes" in messages
 
 
-def test_handling_specific_request(caplog: LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_handling_specific_request(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_request_from_api(apiurl: str, reqid: int) -> None:
         assert apiurl == OBS_URL
         assert reqid == "43"

--- a/tests/test_incsyncres.py
+++ b/tests/test_incsyncres.py
@@ -7,7 +7,6 @@ from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 import openqabot.incsyncres
 import responses
@@ -31,7 +30,7 @@ def get_a_i(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_i")
-def test_clone_dry(caplog: LogCaptureFixture) -> None:
+def test_clone_dry(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
 
     # get_incident_settings_data
@@ -91,7 +90,7 @@ def test_clone_dry(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_i")
-def test_nogroup_dry(caplog: LogCaptureFixture) -> None:
+def test_nogroup_dry(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
 
     # get_incident_settings_data
@@ -149,7 +148,7 @@ def test_nogroup_dry(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_i")
-def test_devel_fast_dry(caplog: LogCaptureFixture) -> None:
+def test_devel_fast_dry(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
 
     # get_incident_settings_data
@@ -209,7 +208,7 @@ def test_devel_fast_dry(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_i")
-def test_devel_dry(caplog: LogCaptureFixture) -> None:
+def test_devel_dry(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
 
     # get_incident_settings_data
@@ -273,7 +272,7 @@ def test_devel_dry(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_i")
-def test_passed_dry(caplog: LogCaptureFixture) -> None:
+def test_passed_dry(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
 
     # get_incident_settings_data

--- a/tests/test_loader_config.py
+++ b/tests/test_loader_config.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 
-from _pytest.logging import LogCaptureFixture
+import pytest
 
 from openqabot.loader.config import get_onearch, load_metadata, read_products
 from openqabot.types import Data
@@ -21,7 +21,7 @@ def test_singlearch_error() -> None:
     assert result == set()
 
 
-def test_load_metadata_aggregate(caplog: LogCaptureFixture) -> None:
+def test_load_metadata_aggregate(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
     result = load_metadata(__root__, aggregate=False, incidents=True, extrasettings=set())
 
@@ -32,7 +32,7 @@ def test_load_metadata_aggregate(caplog: LogCaptureFixture) -> None:
     assert "No 'test_issues' in BAD15SP3 config" in messages
 
 
-def test_load_metadata_aggregate_file(caplog: LogCaptureFixture) -> None:
+def test_load_metadata_aggregate_file(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
     file_path = Path(__file__).parent / "fixtures/config/05_normal.yml"
     result = load_metadata(file_path, aggregate=False, incidents=True, extrasettings=set())
@@ -40,7 +40,7 @@ def test_load_metadata_aggregate_file(caplog: LogCaptureFixture) -> None:
     assert "<Aggregate product: SOME15SP3>" in str(result[0])
 
 
-def test_load_metadata_incidents(caplog: LogCaptureFixture) -> None:
+def test_load_metadata_incidents(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
 
     result = load_metadata(__root__, aggregate=True, incidents=False, extrasettings=set())
@@ -51,7 +51,7 @@ def test_load_metadata_incidents(caplog: LogCaptureFixture) -> None:
     assert "Skipping invalid config" in messages[0]
 
 
-def test_load_metadata_all(caplog: LogCaptureFixture) -> None:
+def test_load_metadata_all(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
 
     result = load_metadata(__root__, aggregate=False, incidents=False, extrasettings=set())
@@ -65,7 +65,7 @@ def test_load_metadata_all(caplog: LogCaptureFixture) -> None:
     assert "No 'test_issues' in BAD15SP3 config" in messages
 
 
-def test_read_products(caplog: LogCaptureFixture) -> None:
+def test_read_products(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
 
     result = read_products(__root__)
@@ -102,7 +102,7 @@ def test_read_products(caplog: LogCaptureFixture) -> None:
     assert any(x.endswith("with no 'DISTRI' settings") for x in messages)
 
 
-def test_read_products_file(caplog: LogCaptureFixture) -> None:
+def test_read_products_file(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
 
     result = read_products(Path(__file__).parent / "fixtures/config/05_normal.yml")

--- a/tests/test_openqabot_simple.py
+++ b/tests/test_openqabot_simple.py
@@ -7,7 +7,6 @@ from typing import Any, NamedTuple, NoReturn
 from urllib.parse import ParseResult, urlparse
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 import openqabot.openqabot
 import responses
@@ -82,7 +81,7 @@ def mock_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_passed(caplog: LogCaptureFixture) -> None:
+def test_passed(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     args = Namespace(
         dry=False,
@@ -107,7 +106,7 @@ def test_passed(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_dry(caplog: LogCaptureFixture) -> None:
+def test_dry(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     args = Namespace(
         dry=True,
@@ -131,7 +130,7 @@ def test_dry(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_passed_non_osd(caplog: LogCaptureFixture) -> None:
+def test_passed_non_osd(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     args = Namespace(
         dry=False,
@@ -157,7 +156,7 @@ def test_passed_non_osd(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_exception")
-def test_passed_post_osd_failed(caplog: LogCaptureFixture) -> None:
+def test_passed_post_osd_failed(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     args = Namespace(
         dry=False,

--- a/tests/test_openqaclient.py
+++ b/tests/test_openqaclient.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from openqa_client.exceptions import RequestError
 
 import responses
@@ -59,7 +58,7 @@ def test_bool() -> None:
 
 
 @responses.activate
-def test_post_job_failed(caplog: LogCaptureFixture) -> None:
+def test_post_job_failed(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.openqa")
     client = oQAI(Args(urlparse("https://openqa.suse.de"), ""))
     client.retries = 0
@@ -75,7 +74,7 @@ def test_post_job_failed(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("fake_osd_rsp")
-def test_post_job_passed(caplog: LogCaptureFixture) -> None:
+def test_post_job_passed(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.openqa")
     client = oQAI(Args(urlparse("https://openqa.suse.de"), ""))
     client.post_job({"foo": "bar"})
@@ -89,7 +88,7 @@ def test_post_job_passed(caplog: LogCaptureFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("fake_responses_failing_job_update")
-def test_handle_job_not_found(caplog: LogCaptureFixture) -> None:
+def test_handle_job_not_found(caplog: pytest.LogCaptureFixture) -> None:
     client = oQAI(Args(urlparse("https://openqa.suse.de"), ""))
     client.handle_job_not_found(42)
     messages = [x[-1] for x in caplog.record_tuples]

--- a/tests/test_pc_helper.py
+++ b/tests/test_pc_helper.py
@@ -4,7 +4,6 @@ import re
 from unittest.mock import patch
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 import openqabot.pc_helper
 import responses
@@ -16,7 +15,7 @@ from openqabot.pc_helper import (
 )
 
 
-def test_apply_pc_tools_image(caplog: LogCaptureFixture) -> None:
+def test_apply_pc_tools_image(caplog: pytest.LogCaptureFixture) -> None:
     known_return = "test"
     settings = {"PUBLIC_CLOUD_TOOLS_IMAGE_QUERY": "test"}
     with patch("openqabot.pc_helper.get_latest_tools_image", return_value=known_return):

--- a/tests/test_repohash.py
+++ b/tests/test_repohash.py
@@ -6,7 +6,6 @@ import logging
 
 import pytest
 import requests
-from _pytest.logging import LogCaptureFixture
 from requests import ConnectionError, HTTPError  # noqa: A004
 
 import openqabot.loader.repohash as rp
@@ -67,7 +66,7 @@ def test_get_max_revison_3() -> None:
 
 
 @responses.activate
-def test_get_max_revison_connectionerror(caplog: LogCaptureFixture) -> None:
+def test_get_max_revison_connectionerror(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.repohash")
     add_sles_sled_response(requests.ConnectionError("Failed"))
 
@@ -79,7 +78,7 @@ def test_get_max_revison_connectionerror(caplog: LogCaptureFixture) -> None:
 
 
 @responses.activate
-def test_get_max_revison_httperror(caplog: LogCaptureFixture) -> None:
+def test_get_max_revison_httperror(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.repohash")
     add_sles_sled_response(requests.HTTPError("Failed"))
 
@@ -90,7 +89,7 @@ def test_get_max_revison_httperror(caplog: LogCaptureFixture) -> None:
 
 
 @responses.activate
-def test_get_max_revison_xmlerror(caplog: LogCaptureFixture) -> None:
+def test_get_max_revison_xmlerror(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.repohash")
     add_sles_sled_response("<invalid>")
 
@@ -101,7 +100,7 @@ def test_get_max_revison_xmlerror(caplog: LogCaptureFixture) -> None:
 
 
 @responses.activate
-def test_get_max_revison_empty_xml(caplog: LogCaptureFixture) -> None:
+def test_get_max_revison_empty_xml(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.repohash")
     add_sles_sled_response("<invalid></invalid>")
 
@@ -110,7 +109,7 @@ def test_get_max_revison_empty_xml(caplog: LogCaptureFixture) -> None:
 
 
 @responses.activate
-def test_get_max_revison_exception(caplog: LogCaptureFixture) -> None:
+def test_get_max_revison_exception(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.repohash")
     add_sles_sled_response(BufferError("other error"))
     with pytest.raises(BufferError):

--- a/tests/test_smeltsync.py
+++ b/tests/test_smeltsync.py
@@ -8,7 +8,6 @@ from collections import namedtuple
 from typing import Any
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 import openqabot.smeltsync
 import responses
@@ -95,7 +94,7 @@ def fake_dashboard_replyback() -> None:
     indirect=True,
 )
 @pytest.mark.usefixtures("fake_qem", "fake_smelt_api", "fake_dashboard_replyback")
-def test_sync_qam_inreview(caplog: LogCaptureFixture) -> None:
+def test_sync_qam_inreview(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.syncres")
     assert SMELTSync(_namespace(dry=False, token="123", retry=False))() == 0
     messages = [x[-1] for x in caplog.record_tuples]
@@ -116,7 +115,7 @@ def test_sync_qam_inreview(caplog: LogCaptureFixture) -> None:
 @pytest.mark.parametrize("fake_qem", [()], indirect=True)
 @pytest.mark.parametrize("fake_smelt_api", [["qam-openqa", "new", "review", None, None]], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_smelt_api", "fake_dashboard_replyback")
-def test_no_embragoed_and_priority_value(caplog: LogCaptureFixture) -> None:
+def test_no_embragoed_and_priority_value(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.syncres")
     assert SMELTSync(_namespace(dry=False, token="123", retry=False))() == 0
     assert len(responses.calls) == 2
@@ -135,7 +134,7 @@ def test_no_embragoed_and_priority_value(caplog: LogCaptureFixture) -> None:
 )
 @pytest.mark.usefixtures("fake_qem", "fake_smelt_api", "fake_dashboard_replyback")
 def test_sync_approved(
-    caplog: LogCaptureFixture,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.syncres")
     assert SMELTSync(_namespace(dry=False, token="123", retry=False))() == 0


### PR DESCRIPTION
The former 'from _pytest.logging …' was relying on a low-level
implementation library that does not promise API-level stability.

After:
* #308

Before:
* #311 