### PR TITLE
Improve error handling for missing fake data in repo-diff

### DIFF
--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -126,7 +126,11 @@ class RepoDiff:
 
     def __call__(self) -> int:
         args = self.args
-        diff, count = self.compute_diff(args.repo_a, args.repo_b)
+        try:
+            diff, count = self.compute_diff(args.repo_a, args.repo_b)
+        except FileNotFoundError as e:
+            log.critical("Fake data file not found. Consider generating that with `--dump-data`: %s", e)
+            raise SystemExit from None
         log.debug(
             "Repo %s contains %i packages that are not in repo %s",
             args.repo_b,


### PR DESCRIPTION
Instead of a lengthy traceback provide a concise one-line message to the
caller when fake data can not be found.

Example output:

```
2025-11-21 15:51:10 CRITICAL Fake data file not found. Consider generating that with `--dump-data`: [Errno 2] No such file or directory: 'responses/repodata-listing-SUSE:SLFO:Products:SLES:16.0:TEST_product.json'
```