### PR TITLE
Fix broken responses version conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "qem-bot"
 dynamic = ["version"]
 description = "Tool for scheduling maintenance tests on openQA based on [SMELT](https://tools.io.suse.de/smelt) incidents and Gitea PRs."
 readme = "Readme.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 license = "MIT"
 authors = [
     { name = "SUSE LLC" },


### PR DESCRIPTION
The requested `responses`-version of >= 0.21.0 requires python >= 3.7 and causes `uv sync` to break due to a non resolvable dependency. Python 3.8 shows test failures and is [EoL](https://endoflife.date/python) so using 3.9 as new required minimum.

Currently the documented steps using `pip` still work but I assume it breaks some version requirement in the back automatically and silently as [upstream clearly states requiring python >=3.7](https://github.com/getsentry/responses/blob/0.21.0/README.rst?plain=1#L20).
I found this by trying to install the projects dependencies locally with `uv sync --active --extra dev` which should result in the same outcome as the [documented pip-call](https://github.com/openSUSE/qem-bot?tab=readme-ov-file#local-testing)