### PR TITLE
Fix direction of comparison in source report based repo diff

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -151,12 +151,15 @@ class IncrementApprover:
     def _compute_packages_of_request_from_source_report(
         self, request: osc.core.Request | None
     ) -> tuple[defaultdict[str, set[Package]], int]:
-        tgt_packages = defaultdict(set)
-        src_packages = defaultdict(set)
+        repo_a = defaultdict(set)
+        repo_b = defaultdict(set)
         for action in request.actions:
-            self._add_packages_for_action_project(action, action.tgt_project, "images", "local", tgt_packages)
-            self._add_packages_for_action_project(action, action.src_project, "product", "local", src_packages)
-        return RepoDiff.compute_diff_for_packages("source project", src_packages, "target project", tgt_packages)
+            log.debug("Checking action '%s' -> '%s' of request %s", action.src_project, action.tgt_project, request.id)
+            # add packages for target project (e.g. `SUSE:Products:SLE-Product-SLES:16.0:aarch64`), that is repo "A"
+            self._add_packages_for_action_project(action, action.tgt_project, "images", "local", repo_a)
+            # add packages for source project (e.g. `SUSE:SLFO:Products:SLES:16.0:TEST`), that is repo "B"
+            self._add_packages_for_action_project(action, action.src_project, "product", "local", repo_b)
+        return RepoDiff.compute_diff_for_packages("product repo", repo_a, "TEST repo", repo_b)
 
     @cache
     def _get_obs_request_list(self, project: str, req_state: tuple) -> list:

--- a/tests/test_incrementapprover.py
+++ b/tests/test_incrementapprover.py
@@ -121,8 +121,8 @@ def fake_get_request_list(url: str, project: str, **_kwargs: Any) -> list[osc.co
     req.reviews = [ReviewState("review", OBS_GROUP)]
     req.actions = [
         Action(
-            tgt_project="SUSE:Products:SLE-Product-SLES:16.0:TEST",
-            src_project="SUSE:Products:SLE-Product-SLES:16.0",
+            tgt_project="SUSE:Products:SLE-Product-SLES:16.0",
+            src_project="SUSE:Products:SLE-Product-SLES:16.0:TEST",
             src_package="000productcompose:sles_aarch64",
         )
     ]
@@ -132,18 +132,18 @@ def fake_get_request_list(url: str, project: str, **_kwargs: Any) -> list[osc.co
 def fake_get_repos_of_project(url: str, prj: str) -> list[Repo]:
     assert url == OBS_URL
     if prj == "SUSE:Products:SLE-Product-SLES:16.0:TEST":
-        return [Repo("images", "local")]
+        return [Repo("product", "local")]
     # example for "SUSE:Products:SLE-Product-SLES:16.0":
-    return [Repo("product", "local")]
+    return [Repo("images", "local")]
 
 
 def fake_get_binarylist(url: str, prj: str, repo: str, arch: str, package: str) -> list[str]:
     assert url == OBS_URL
     assert package == "000productcompose:sles_aarch64"
     assert arch == "local"
-    if prj == "SUSE:Products:SLE-Product-SLES:16.0:TEST" and repo == "images":
+    if prj == "SUSE:Products:SLE-Product-SLES:16.0:TEST" and repo == "product":
         return ["SLES-16.0-aarch64-Build160.4-Source.report", "foo"]
-    # example for prj == "SUSE:Products:SLE-Product-SLES:16.0" and repo == "product":
+    # example for prj == "SUSE:Products:SLE-Product-SLES:16.0" and repo == "images":
     return ["SLES-16.0-aarch64-Build160.4-Source.report", "bar"]
 
 


### PR DESCRIPTION
* Swap "repo a" and "repo b" so that:
    * "repo a" is the *target* project of the request action (e.g. `SUSE:Products:SLE-Product-SLES:16.0:aarch64`)
    * "repo b" is the *source* project of the request action (e.g. `SUSE:SLFO:Products:SLES:16.0:TEST`)
    * Note that from the point of view of the request the *source* is the request report and the *target* is the regular report. For diffing however, we need to consider the regular report "version A" and the request report "version B".
* Avoid using `tgt_packages` and `src_packages` in `_compute_packages_of_request_from_source_report` as this naming leads to confusion
* Tested against request https://build.suse.de/request/show/396740 which is open at the time of making this request and I've got results which are consistent with the Perl prototype.
* See https://progress.opensuse.org/issues/190542#note-61