### PR TITLE
feat: Make number of retries overridable to ease development

### DIFF
--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from argparse import Namespace
 from functools import lru_cache
 from itertools import starmap
@@ -15,6 +14,7 @@ from openqa_client.client import OpenQA_Client
 from openqa_client.exceptions import RequestError
 
 from openqabot.config import DEVELOPMENT_PARENT_GROUP_ID, OPENQA_URL
+from openqabot.utils import number_of_retries
 
 from .errors import PostOpenQAError
 from .loader.qem import update_job
@@ -31,7 +31,7 @@ class openQAInterface:
     def __init__(self, args: Namespace) -> None:
         self.url: ParseResult = args.openqa_instance
         self.openqa = OpenQA_Client(server=self.url.netloc, scheme=self.url.scheme)
-        self.retries = 0 if "PYTEST_VERSION" in os.environ else 3
+        self.retries = number_of_retries()
         user_agent = {"User-Agent": "python-OpenQA_Client/qem-bot/1.0.0"}
         self.openqa.session.headers.update(user_agent)
         self.qem_token: dict[str, str] = {"Authorization": f"Token {args.token}"}

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -81,10 +81,14 @@ def merge_dicts(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, Any]:
     return copy
 
 
-def __retry(retries: int | None, backoff_factor: float) -> Session:
+def number_of_retries(fallback: int = 3) -> int:
+    return int(os.environ.get("QEM_BOT_RETRIES", 0 if "PYTEST_VERSION" in os.environ else fallback))
+
+
+def make_retry_session(retries: int | None, backoff_factor: float) -> Session:
     adapter = HTTPAdapter(
         max_retries=Retry(
-            None if "PYTEST_VERSION" in os.environ else retries,
+            number_of_retries(retries),
             backoff_factor=backoff_factor,
             status_forcelist=frozenset({403, 413, 429, 503}),
         ),
@@ -96,7 +100,7 @@ def __retry(retries: int | None, backoff_factor: float) -> Session:
     return http
 
 
-no_retry = __retry(None, 0)
-retry3 = __retry(3, 2)
-retry5 = __retry(5, 1)
-retry10 = __retry(10, 0.1)
+no_retry = make_retry_session(None, 0)
+retry3 = make_retry_session(3, 2)
+retry5 = make_retry_session(5, 1)
+retry10 = make_retry_session(10, 0.1)


### PR DESCRIPTION
During development it is usually better to get an error message immediately instead of having to wait several retries.