### PR TITLE
fix: Fix regression after making retries configurable

### DIFF
--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -100,7 +100,7 @@ def make_retry_session(retries: int | None, backoff_factor: float) -> Session:
     return http
 
 
-no_retry = make_retry_session(None, 0)
+no_retry = make_retry_session(0, 0)
 retry3 = make_retry_session(3, 2)
 retry5 = make_retry_session(5, 1)
 retry10 = make_retry_session(10, 0.1)


### PR DESCRIPTION
This fixes the following error:
```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```