### PR TITLE
feat(repodiff): Allow computing diff of production SL Micro repo

### DIFF
--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -10,8 +10,8 @@ from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+import pyzstd
 import requests
-import zstandard
 from lxml import etree  # type: ignore[unresolved-import]
 
 from .config import OBS_DOWNLOAD_URL
@@ -53,7 +53,7 @@ class RepoDiff:
         if repo_data_file.endswith(".gz"):
             return gzip.decompress(repo_data_raw)
         if repo_data_file.endswith(".zst"):
-            return zstandard.decompress(repo_data_raw)
+            return pyzstd.decompress(repo_data_raw)
         return repo_data_raw
 
     def _request_and_dump(self, url: str, name: str, *, as_json: bool = False) -> bytes | dict[str, Any] | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "osc",
     "openqa-client",
     "pika",
-    "zstandard",
+    "pyzstd",
     "requests",
     "ruamel.yaml",
     "jsonschema",


### PR DESCRIPTION
The zstandard module does not seem to be capable of decompressing the XML files used in production. To support this we need to use pystd after all. This effectively reverts 5e2bf52fae60c40efd7d3e4a59844ee1c933b3ce.

Related ticket: https://progress.opensuse.org/issues/190542