### PR TITLE
fix(types/incidents): prevent non-sensible product+version combinations

### DIFF
--- a/openqabot/types/incidents.py
+++ b/openqabot/types/incidents.py
@@ -232,11 +232,11 @@ class Incidents(BaseConf):
         for issue in matches:
             full_post["openqa"][issue] = str(inc.id)
 
-        channels_set = {c for matched in matches.values() for c in matched}
+        version = self.product_version or self.settings["VERSION"]
+        channels_set = {c for matched in matches.values() for c in matched if c.product_version == version}
         full_post["openqa"]["INCIDENT_REPO"] = ",".join(
             sorted(self._make_repo_url(inc, chan) for chan in channels_set),
         )  # sorted for testability
-
         full_post["qem"]["withAggregate"] = True
         aggregate_job = data.get("aggregate_job", True)
 


### PR DESCRIPTION
When OBS_PRODUCTS includes more than one product then wrong combinations of
channels and incident settings are created triggering openQA jobs with
wrong INCIDENT_REPO settings like

```
…/1604:/SL-Micro/product/repo/SLES-HA-6.2-x86_64/
```

combining the product name "SLES-HA" which in this case would have
version 16.0 with the "SL-Micro" version "6.2" which is invalid.

This commit filters out those combinations before creating the
"INCIDENT_REPO" schedule variable.

Note that the overall design is still error prone and inefficient as also
in other places wrong repo URLs are actually computed like for the repohash
calculation.

Related progress issues:
* https://progress.opensuse.org/issues/194453
* https://progress.opensuse.org/issues/193828