### PR TITLE
fix(types/submissions): fallback to all matched channels for INCIDENT_REPO

### DIFF
--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -261,7 +261,8 @@ class Submissions(BaseConf):
         settings = self._get_base_settings(ctx, revs, cfg)
         for issue in matches:
             settings[issue] = str(sub.id)
-        repos = {c for matched in matches.values() for c in matched if c.product_version == version}
+        all_repos = {c for matched in matches.values() for c in matched}
+        repos = {c for c in all_repos if c.product_version == version} or all_repos
         settings["INCIDENT_REPO"] = ",".join(sorted(self._make_repo_url(sub, chan) for chan in repos))
         if prio := self._get_priority(ctx):
             settings["_PRIORITY"] = prio


### PR DESCRIPTION
If the version-filtered repos set is empty, fallback to all matched
channels to prevent scheduling jobs with an empty INCIDENT_REPO
variable.

This fixes a regression from commit 65866c63 where too restrictive
filtering led to empty incident repositories.

Related progress issue: https://progress.opensuse.org/issues/193828