### PR TITLE
fix(aggregate): revert incidents payload to list of IDs

### DIFF
--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -177,9 +177,7 @@ class Aggregate(BaseConf):
         full_post["qem"]["build"] = full_post["openqa"]["BUILD"]
         full_post["qem"]["arch"] = full_post["openqa"]["ARCH"]
         full_post["qem"]["product"] = self.product
-        full_post["qem"]["incidents"] = [
-            {"incident": sub.id, "type": sub.type} for sub in full_post["qem"]["incidents"]
-        ]
+        full_post["qem"]["incidents"] = [sub.id for sub in full_post["qem"]["incidents"]]
 
         return full_post
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -359,4 +359,4 @@ def test_aggregate_duplicate_submissions() -> None:
     # Verify unique incidents
     assert res is not None
     assert len(res["qem"]["incidents"]) == 1
-    assert res["qem"]["incidents"][0]["incident"] == 123
+    assert res["qem"]["incidents"][0] == 123


### PR DESCRIPTION
Revert the structure of the 'incidents' field in the 'api/update_settings'
payload from a list of dictionaries to a list of integer IDs.

The dashboard currently does not support the disambiguated format for
aggregate jobs and returns a 500 error ("Cannot bind a reference").