### PR TITLE
feat(approver): distinguish between failed, waiting, and stopped jobs

### DIFF
--- a/tests/test_approve_helpers.py
+++ b/tests/test_approve_helpers.py
@@ -11,7 +11,7 @@ import pytest
 from openqa_client.exceptions import RequestError
 from pytest_mock import MockerFixture
 
-from openqabot.approver import Approver
+from openqabot.approver import Approver, JobStatus
 from openqabot.utc import UTC
 
 from .helpers import args
@@ -94,4 +94,4 @@ def test_was_ok_before_no_suitable_older_jobs(
 
 def test_get_submission_result_empty_jobs() -> None:
     approver_instance = Approver(args)
-    assert approver_instance.get_submission_result([], "api/", 1) is False
+    assert approver_instance.get_submission_result([], "api/", 1) == JobStatus.FAILED

--- a/tests/test_approve_scenarios.py
+++ b/tests/test_approve_scenarios.py
@@ -270,3 +270,43 @@ def test_one_aggr_failed(caplog: pytest.LogCaptureFixture, mocker: MockerFixture
         "Submission approval process finished",
     ]
     assert_log_messages(caplog.messages, expected)
+
+
+@responses.activate
+@with_fake_qem("NoResultsError isn't raised")
+@pytest.mark.usefixtures("fake_single_submission_mocks")
+def test_single_submission_waiting(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    caplog.set_level(logging.DEBUG, logger="bot.approver")
+
+    def mock_get_json(_url: str, **_kwargs: Any) -> Any:
+        return [{"submission_settings": 1000, "job_id": 100001, "status": "waiting"}]
+
+    mocker.patch("openqabot.approver.get_json", side_effect=mock_get_json)
+
+    approver(submission=1)
+    assert_submission_not_approved(
+        caplog.messages,
+        "SUSE:Maintenance:1:100",
+        "SUSE:Maintenance:1:100 has tests still in progress in submission tests",
+    )
+    assert "Found unfinished job http://instance.qa/t100001 for submission smelt:1" in caplog.messages
+
+
+@responses.activate
+@with_fake_qem("NoResultsError isn't raised")
+@pytest.mark.usefixtures("fake_single_submission_mocks")
+def test_single_submission_stopped(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    caplog.set_level(logging.DEBUG, logger="bot.approver")
+
+    def mock_get_json(_url: str, **_kwargs: Any) -> Any:
+        return [{"submission_settings": 1000, "job_id": 100001, "status": "stopped"}]
+
+    mocker.patch("openqabot.approver.get_json", side_effect=mock_get_json)
+
+    approver(submission=1)
+    assert_submission_not_approved(
+        caplog.messages,
+        "SUSE:Maintenance:1:100",
+        "SUSE:Maintenance:1:100 has stopped jobs in submission tests",
+    )
+    assert "Found stopped job http://instance.qa/t100001 for submission smelt:1" in caplog.messages


### PR DESCRIPTION
Introduce JobStatus enum to provide more accurate feedback when a
submission is not approved. This allows the bot to distinguish
between actual test failures, tests still in progress, and tests
that were stopped.

Detailed logging has been added to identify specific unfinished or
stopped jobs, and tests have been updated to verify this behavior.

Before:
* #368