### PR TITLE
fix(gitea): prevent scheduling on not-supported architectures

### DIFF
--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import osc.conf
 from pydantic import Field, field_validator
@@ -98,6 +98,15 @@ class Settings(BaseSettings):
     )
     max_detailed_comment_entries: int = Field(default=7, alias="QEM_MAX_DETAILED_COMMENT_ENTRIES")
 
+    @field_validator("obs_download_url")
+    @classmethod
+    def validate_obs_download_url(cls, v: str) -> str:
+        """Validate that obs_download_url has a valid hostname."""
+        if not urlparse(v).netloc:
+            msg = f"OBS_DOWNLOAD_URL '{v}' does not contain a valid hostname"
+            raise ValueError(msg)
+        return v
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
@@ -134,6 +143,11 @@ class Settings(BaseSettings):
         if self.git_review_bot is not None:
             return self.git_review_bot
         return self.obs_group + "-review"
+
+    @property
+    def repo_mirror_host(self) -> str:
+        """Extract the repository mirror host from obs_download_url."""
+        return urlparse(self.obs_download_url).netloc
 
     @property
     def obs_products_set(self) -> set[str]:

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -29,7 +29,8 @@ from osc.core import MultibuildFlavorResolver
 from openqabot import config
 from openqabot.errors import NoRepoFoundError
 from openqabot.types.pullrequest import PullRequest
-from openqabot.utils import BuildTarget, RepoConfig, get_repo_url
+from openqabot.types.gitea import BuildTarget, RepoConfig
+from openqabot.utils import get_repo_url
 from openqabot.utils import retry10 as retried_requests
 
 if TYPE_CHECKING:

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -17,7 +17,6 @@ from io import BytesIO
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import urlparse
 
 import osc.conf as osc_conf
 import osc.core as osc_core
@@ -30,6 +29,7 @@ from osc.core import MultibuildFlavorResolver
 from openqabot import config
 from openqabot.errors import NoRepoFoundError
 from openqabot.types.pullrequest import PullRequest
+from openqabot.utils import get_repo_url
 from openqabot.utils import retry10 as retried_requests
 
 if TYPE_CHECKING:
@@ -375,16 +375,17 @@ def verify_repo_exists(project: str, product_name: str, product_version: str, ar
     """Check if the repository actually exists for the given architecture via HTTP HEAD request."""
     if not product_version:
         return True
-    download_base = config.settings.download_base_url
-    obs_download = config.settings.obs_download_url
-    if not download_base or not obs_download:
+    repo_url = get_repo_url(
+        project,
+        product_name,
+        product_version,
+        arch,
+        repo_type=config.settings.obs_repo_type or "product",
+        download_base_url=config.settings.download_base_url,
+        obs_download_url=config.settings.obs_download_url,
+    )
+    if not repo_url:
         return True
-    host = urlparse(obs_download).netloc
-    if not host:
-        return True
-    base = download_base.replace("%REPO_MIRROR_HOST%", host)
-    project_path = project.replace(":", ":/")
-    repo_url = f"{base}/{project_path}/{config.OBS_REPO_TYPE}/repo/{product_name}-{product_version}-{arch}/{arch}/"
     with suppress(requests.exceptions.RequestException):
         response = retried_requests.head(repo_url, allow_redirects=True)
         if response.status_code == HTTPStatus.NOT_FOUND:

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -5,17 +5,13 @@
 from __future__ import annotations
 
 import json
-import re
 import urllib.error
-from collections import Counter
 from concurrent import futures
 from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import lru_cache
 from http import HTTPStatus
-from io import BytesIO
 from logging import getLogger
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import osc.conf as osc_conf
@@ -37,9 +33,63 @@ from openqabot.utils import retry10 as retried_requests
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-ARCHS = {"x86_64", "aarch64", "ppc64le", "s390x"}
 
-JsonType = dict[str, Any] | list[Any]
+from openqabot.loader.gitea_utils import (
+    ARCHS,
+    OBS_PROJECT_SHOW_REGEX,
+    URL_FINDALL_REGEX,
+    _approval_identifiers,
+    _extract_version,
+    _is_bot_approval_comment,
+    changed_files_url,
+    comments_url,
+    get_json,
+    get_product_name,
+    get_product_name_and_version_from_scmsync,
+    iter_gitea_items,
+    make_token_header,
+    patch_json,
+    post_json,
+    read_json_file,
+    read_json_file_list,
+    read_utf8,
+    read_xml,
+    reviews_url,
+)
+
+# Re-exporting for other modules
+__all__ = [
+    "BuildResults",
+    "add_build_results",
+    "add_channel_for_build_result",
+    "add_comments_and_referenced_build_results",
+    "add_packages_from_files",
+    "add_packages_from_patchinfo",
+    "add_reviews",
+    "approve_pr",
+    "compute_repo_url_for_job_setting",
+    "determine_relevant_archs_from_multibuild_info",
+    "generate_repo_url",
+    "get_gitea_staging_config",
+    "get_multibuild_data",
+    "get_name",
+    "get_open_prs",
+    "get_product_version_from_repo_listing",
+    "get_submissions_from_open_prs",
+    "is_build_acceptable_and_log_if_not",
+    "is_build_result_relevant",
+    "is_review_requested_by",
+    "make_submission_from_gitea_pr",
+    "make_token_header",
+    "patch_json",
+    "post_json",
+    "read_json_file",
+    "read_utf8",
+    "read_xml",
+    "review_pr",
+    "reviews_url",
+    "verify_repo_exists",
+]
 
 log = getLogger("bot.loader.gitea")
 
@@ -54,134 +104,24 @@ class BuildResults:
     failed: set[str] = field(default_factory=set)
     unavailable: set[str] = field(default_factory=set)
 
+    def update_submission(self, submission: dict[str, Any]) -> None:
+        """Update submission with aggregated build results."""
+        submission.update({
+            "failed_or_unpublished_packages": sorted(self.failed | self.unpublished | self.unavailable),
+            "successful_packages": sorted(self.successful),
+        })
 
-PROJECT_PRODUCT_REGEX = re.compile(r".*:PullRequest:\d+:(.*)")
-SCMSYNC_REGEX = re.compile(r".*/products/(.*)#([\d\.]{2,6})$")
-VERSION_EXTRACT_REGEX = re.compile(r"[.\d]+")
-OBS_PROJECT_SHOW_REGEX = re.compile(r".*/project/show/([^/\s\?\#\)]+)")
-# Regex to find all HTTPS URLs, excluding common trailing punctuation like dots or parentheses
-# that are likely part of the surrounding text (e.g. at the end of a sentence or in Markdown).
-URL_FINDALL_REGEX = re.compile(r"https?://[^\s\?\#\)]*[^\s\?\#\)\.]")
+        if "channels" not in submission:
+            submission["channels"] = []
 
+        for result in sorted(self.projects):
+            if result not in submission["channels"]:
+                submission["channels"].append(result)
 
-def make_token_header(token: str) -> dict[str, str]:
-    """Create the Authorization header for Gitea API requests."""
-    return {} if token is None else {"Authorization": "token " + token}
-
-
-def get_json(
-    query: str,
-    token: dict[str, str],
-    host: str | None = None,
-    params: dict[str, Any] | None = None,
-) -> JsonType:
-    """Fetch JSON data from Gitea API."""
-    host = host or config.settings.gitea_url
-    url = f"{host}/api/v1/{query}"
-    response = retried_requests.get(url, verify=not config.settings.insecure, headers=token, params=params)
-    response.raise_for_status()
-    return response.json()
-
-
-def iter_gitea_items(query: str, token: dict[str, str], host: str | None = None) -> Iterator[Any]:
-    """Fetch a list of JSON data from Gitea API with pagination support.
-
-    Yields:
-        JSON items from the paginated response.
-
-    """
-    host = host or config.settings.gitea_url
-    url = f"{host}/api/v1/{query}"
-
-    while url:
-        response = retried_requests.get(url, verify=not config.settings.insecure, headers=token)
-        response.raise_for_status()
-        res = response.json()
-
-        if not isinstance(res, list):
-            msg = f"Gitea API returned {type(res).__name__} instead of list for query: {query}"
-            raise TypeError(msg)
-
-        yield from res
-        url = response.links.get("next", {}).get("url")
-
-
-def _request_json(method: str, query: str, token: dict[str, str], post_data: JsonType, host: str | None = None) -> None:
-    """Send a JSON request to Gitea API."""
-    host = host or config.settings.gitea_url
-    url = f"{host}/api/v1/{query}"
-    res = getattr(retried_requests, method.lower())(
-        url, verify=not config.settings.insecure, headers=token, json=post_data
-    )
-    if not res.ok:
-        log.error("Gitea API error: %s to %s failed: %s", method.upper(), url, res.text)
-
-
-def post_json(query: str, token: dict[str, str], post_data: JsonType, host: str | None = None) -> None:
-    """Post JSON data to Gitea API."""
-    _request_json("POST", query, token, post_data, host)
-
-
-def patch_json(query: str, token: dict[str, str], post_data: JsonType, host: str | None = None) -> None:
-    """Patch JSON data in Gitea API."""
-    _request_json("PATCH", query, token, post_data, host)
-
-
-@lru_cache(maxsize=128)
-def read_utf8(name: str) -> str:
-    """Read a UTF-8 encoded response file."""
-    return Path(f"tests/fixtures/responses/{name}").read_text(encoding="utf8")
-
-
-@lru_cache(maxsize=128)
-def read_json_file(name: str) -> JsonType:
-    """Read a JSON response file."""
-    return json.loads(read_utf8(name + ".json"))
-
-
-def read_json_file_list(name: str) -> list[Any]:
-    """Read a list from a JSON response file."""
-    res = read_json_file(name)
-    if not isinstance(res, list):
-        msg = f"JSON response file '{name}' returned {type(res).__name__} instead of list"
-        raise TypeError(msg)
-    return res
-
-
-@lru_cache(maxsize=128)
-def read_xml(name: str) -> etree.ElementTree:
-    """Read an XML response file."""
-    return etree.parse(BytesIO(read_utf8(name + ".xml").encode("utf-8")))
-
-
-def reviews_url(repo_name: str, number: int) -> str:
-    """Construct the URL for PR reviews."""
-    # https://docs.gitea.com/api/1.25/#tag/repository/operation/repolistPullReviews
-    return f"repos/{repo_name}/pulls/{number}/reviews"
-
-
-def changed_files_url(project: str, number: int) -> str:
-    """Construct the URL for PR changed files."""
-    # https://docs.gitea.com/api/1.25/#tag/repository/operation/repoGetPullRequestFiles
-    return f"repos/{project}/pulls/{number}/files"
-
-
-def comments_url(repo_name: str, number: int) -> str:
-    """Construct the URL for PR comments."""
-    # https://docs.gitea.com/api/1.25/#tag/issue/operation/issueCreateComment
-    return f"repos/{repo_name}/issues/{number}/comments"
-
-
-def get_product_name(obs_project: str) -> str:
-    """Extract product name from an OBS project name."""
-    product_match = PROJECT_PRODUCT_REGEX.search(obs_project)
-    return product_match.group(1) if product_match else ""
-
-
-def get_product_name_and_version_from_scmsync(scmsync_url: str) -> tuple[str, str]:
-    """Extract product name and version from an scmsync URL."""
-    m = SCMSYNC_REGEX.search(scmsync_url)
-    return (m.group(1), m.group(2)) if m else ("", "")
+        # fallback scminfo if only one product is configured
+        obs_products = config.settings.obs_products_set
+        if "scminfo" not in submission and len(obs_products) == 1 and "all" not in obs_products:
+            submission["scminfo"] = submission.get(f"scminfo_{next(iter(obs_products))}", "")
 
 
 def compute_repo_url_for_job_setting(
@@ -226,20 +166,6 @@ def _get_single_pr(token: dict[str, str], project: str, number: int) -> list[Pul
     except (requests.exceptions.RequestException, json.JSONDecodeError) as ex:
         log.error("PR git:%s ignored: %s", number, ex, exc_info=True)  # noqa: G201
     return []
-
-
-def _approval_identifiers(bot_user: str, commit_id: str, *, approve: bool = True) -> tuple[str, str]:
-    action = "approved" if approve else "decline"
-    return f"@{bot_user}: {action}", f"Tested commit: {commit_id}"
-
-
-def _is_bot_approval_comment(comment: dict[str, Any], bot_user: str, commit_id: str) -> bool:
-    """Check if a comment is an authentic approval from the bot."""
-    body = comment.get("body", "")
-    allowed_authors = {bot_user, config.settings.obs_group}
-    is_author = comment.get("user", {}).get("login") in allowed_authors
-    review_cmd, commit_str = _approval_identifiers(bot_user, commit_id)
-    return is_author and review_cmd in body and commit_str in body
 
 
 def review_pr(  # noqa: PLR0913
@@ -323,28 +249,40 @@ def is_review_requested_by(
 
 
 def add_reviews(submission: dict[str, Any], reviews: list[Any]) -> int:
-    """Process PR reviews and update submission status.
+    """Process PR reviews and update submission status."""
+    qam_pending, qam_blocking, qam_approved = 0, 0, 0
 
-    Returns number of reviews by us that have been requested.
-    """
-    pending_states = {"PENDING", "REQUEST_REVIEW"}
-    open_reviews = [r for r in reviews if not r.get("dismissed", True)]
-    qam_states = [r.get("state", "") for r in open_reviews if is_review_requested_by(r)]
-    has_other_pending = any(r.get("state", "") in pending_states for r in open_reviews if not is_review_requested_by(r))
+    qam_reviews = [r for r in open_reviews if is_review_requested_by(r)]
+    for r in qam_reviews:
+        state = r.get("state", "")
+        qam_pending += state in {"PENDING", "REQUEST_REVIEW"}
+        qam_blocking += state in {"REQUEST_CHANGES", "REQUEST_REVIEW"}
+        qam_approved += state == "APPROVED"
 
-    counts = Counter(qam_states)
-    qam_pending = counts["PENDING"] + counts["REQUEST_REVIEW"]
-    qam_blocking = counts["REQUEST_CHANGES"] + counts["REQUEST_REVIEW"]
-    submission["approved"] = (counts["APPROVED"] > 0) and (qam_blocking == 0)
-    submission["inReviewQAM"] = qam_pending > 0
-    submission["inReview"] = has_other_pending or (qam_pending > 0)
-    return len(qam_states)
+    other_reviews = [r for r in open_reviews if not is_review_requested_by(r)]
+    other_pending = any(r.get("state", "") in {"PENDING", "REQUEST_REVIEW"} for r in other_reviews)
+
+    submission.update({
+        "approved": qam_approved > 0 and qam_blocking == 0,
+        "inReviewQAM": qam_pending > 0,
+        "inReview": other_pending or qam_pending > 0,
+    })
+    return len(qam_reviews)
 
 
-def _extract_version(name: str, prefix: str) -> str:
-    """Extract version number from a package name string."""
-    remainder = name.removeprefix(prefix)
-    return next((part for part in remainder.split("-") if VERSION_EXTRACT_REGEX.search(part)), "")
+def _fetch_repo_data(url: str) -> list[dict[str, Any]]:
+    """Fetch repository listing data from OBS."""
+    try:
+        r = retried_requests.get(url, params={"jsontable": 1})
+        r.raise_for_status()
+        return cast("list[dict[str, Any]]", r.json()["data"])
+    except requests.exceptions.HTTPError as e:
+        log.warning("Repo ignored: Could not query repository '%s': %s", url, e)
+    except (json.JSONDecodeError, requests.exceptions.JSONDecodeError) as e:
+        log.info("Invalid JSON document at '%s', ignoring: %s", url, e)
+    except requests.exceptions.RequestException as e:
+        log.warning("Product version unresolved: Could not read from '%s': %s", url, e)
+    return []
 
 
 @lru_cache(maxsize=512)
@@ -355,22 +293,9 @@ def get_product_version_from_repo_listing(
     project_path = project.replace(":", ":/")
     url = f"{obs_download_url}/{project_path}/{repository}/repo"
     start = f"{product_name}-"
-    try:
-        r = retried_requests.get(url, params={"jsontable": 1})
-        r.raise_for_status()
-        data = r.json()["data"]
-    except requests.exceptions.HTTPError as e:
-        log.warning("Repo ignored: Could not query repository '%s' (%s->%s): %s", repository, product_name, project, e)
-        return ""
-    # Catching both because requests' JSONDecodeError might not inherit from json's
-    except (json.JSONDecodeError, requests.exceptions.JSONDecodeError) as e:
-        log.info("Invalid JSON document at '%s', ignoring: %s", url, e)
-        return ""
-    except requests.exceptions.RequestException as e:
-        log.warning("Product version unresolved: Could not read from '%s': %s", url, e)
-        return ""
+    data = _fetch_repo_data(url)
     versions = (_extract_version(entry["name"], start) for entry in data if entry["name"].startswith(start))
-    return next((v for v in versions if len(v) > 0), "")
+    return next((v for v in versions if v), "")
 
 
 def verify_repo_exists(
@@ -393,19 +318,22 @@ def verify_repo_exists(
     return True
 
 
+def _get_scmsync_version(res: etree._Element) -> str:
+    """Extract product version from scmsync element."""
+    for text in (e.text for e in res.findall("scmsync") if e.text):
+        _, pv = get_product_name_and_version_from_scmsync(text)
+        if pv:
+            return pv
+    return ""
+
+
 def _get_product_version(
     res: etree._Element,
     target: Repos,
     config: RepoConfig,
 ) -> str:
     """Extract product version from scmsync element or repository listing."""
-    # read product version from scmsync element if possible, e.g. 15.99
-    product_version = ""
-    for e in res.findall("scmsync"):
-        _, pv = get_product_name_and_version_from_scmsync(e.text)
-        if pv:
-            product_version = pv
-            break
+    product_version = _get_scmsync_version(res)
 
     # read product version from directory listing if the project is for a concrete product
     if (
@@ -454,14 +382,17 @@ def add_channel_for_build_result(
 def _update_scminfo(submission: dict[str, Any], res: etree._Element, project: str, product: str) -> None:
     """Update SCM info in the submission dict."""
     scm_key = f"scminfo_{product}" if product else "scminfo"
-    for e in res.findall("scminfo"):
-        found = e.text
-        if found:
-            existing = submission.get(scm_key)
-            if existing and found != existing:
-                msg = "PR git:%s: Inconsistent SCM info for project %s: found '%s' vs '%s'"
-                log.warning(msg, submission["number"], project, found, existing)
-                continue
+    for found in {e.text for e in res.findall("scminfo") if e.text}:
+        existing = submission.get(scm_key)
+        if existing and found != existing:
+            log.warning(
+                "PR git:%s: Inconsistent SCM info for project %s: found '%s' vs '%s'",
+                submission["number"],
+                project,
+                found,
+                existing,
+            )
+        else:
             submission[scm_key] = found
 
 
@@ -508,29 +439,29 @@ def get_multibuild_data(obs_project: str) -> str:
     return cast("str", r.get_multibuild_data())
 
 
+def _get_multibuild_xml(obs_project: str, *, dry: bool) -> str | None:
+    """Fetch multibuild XML data."""
+    if dry:
+        return read_utf8(f"_multibuild-124-{obs_project}.xml")
+    try:
+        return get_multibuild_data(obs_project)
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        log.warning("Could not determine relevant architectures for %s: %s", obs_project, e)
+    return None
+
+
 def determine_relevant_archs_from_multibuild_info(obs_project: str, *, dry: bool) -> set[str] | None:
     """Determine which architectures are relevant for a product based on multibuild data."""
-    # retrieve the _multibuild info like `osc cat SUSE:SLFO:1.1.99:PullRequest:124:SLES 000productcompose _multibuild`
     product_name = get_product_name(obs_project)
     if not product_name:
         return None
     product_prefix = product_name.replace("SL-", "sle_").replace(":", "_").lower() + "_"
     prefix_len = len(product_prefix)
-    if dry:
-        multibuild_data = read_utf8("_multibuild-124-" + obs_project + ".xml")
-    else:
-        try:
-            multibuild_data = get_multibuild_data(obs_project)
-        except (urllib.error.HTTPError, urllib.error.URLError) as e:
-            log.warning("Could not determine relevant architectures for %s: %s", obs_project, e)
-            return None
+    multibuild_data = _get_multibuild_xml(obs_project, dry=dry)
+    if not multibuild_data:
+        return None
 
     # determine from the flavors we got what architectures are actually expected to be present
-
-    # note: The build info will contain result elements for archs like `local` and `ppc64le` that and the published
-    # flag set even though no repos for those products are actually present. Considering these would lead to problems
-    # later on (e.g. when computing the repohash) so it makes sense to reduce the archs we are considering to actually
-    # relevant ones.
     flavors = MultibuildFlavorResolver.parse_multibuild_data(multibuild_data)
     relevant_archs = {
         flavor[prefix_len:] for flavor in flavors if flavor.startswith(product_prefix) and flavor[prefix_len:] in ARCHS
@@ -595,19 +526,7 @@ def add_build_results(submission: dict[str, Any], obs_urls: list[str], *, dry: b
     if results.failed:
         log.info("PR git:%i: Some packages failed: %s", submission["number"], ", ".join(results.failed))
 
-    submission.update({
-        "failed_or_unpublished_packages": sorted(results.failed | results.unpublished | results.unavailable),
-        "successful_packages": sorted(results.successful),
-    })
-
-    channels = submission.setdefault("channels", [])
-    channels.extend(result for result in sorted(results.projects) if result not in channels)
-
-    if "scminfo" not in submission and (
-        len(config.settings.obs_products_set),
-        "all" in config.settings.obs_products_set,
-    ) == (1, False):
-        submission["scminfo"] = submission.get("scminfo_" + next(iter(config.settings.obs_products_set)), "")
+    results.update_submission(submission)
 
 
 def add_comments_and_referenced_build_results(
@@ -781,7 +700,6 @@ def _validate_submission(
         return False
     return not (only_successful_builds and not is_build_acceptable_and_log_if_not(submission, number))
 
-
 def _build_submission_record(
     pr: PullRequest,
     token: dict[str, str],
@@ -858,3 +776,4 @@ def get_submissions_from_open_prs(
         ]
         submissions = (future.result() for future in futures.as_completed(future_sub))
         return [sub for sub in submissions if sub]
+

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -382,8 +382,6 @@ def verify_repo_exists(
     if not product_version:
         return True
     repo_url = get_repo_url(target, product_version, config)
-    if not repo_url:
-        return True
     with suppress(requests.exceptions.RequestException):
         response = retried_requests.head(repo_url, allow_redirects=True)
         if response.status_code == HTTPStatus.NOT_FOUND:
@@ -489,6 +487,7 @@ def add_build_result(
         repo_type=config.settings.obs_repo_type or "product",
         download_base_url=config.settings.download_base_url,
         obs_download_url=config.settings.obs_download_url,
+        repo_mirror_host=config.settings.repo_mirror_host,
         obs_products=config.settings.obs_products_set,
     )
     target = Repos(product=project, version=product, arch=res.get("arch"))

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -9,8 +9,10 @@ import re
 import urllib.error
 from collections import Counter
 from concurrent import futures
+from contextlib import suppress
 from dataclasses import dataclass, field
 from functools import lru_cache
+from http import HTTPStatus
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
@@ -368,6 +370,32 @@ def get_product_version_from_repo_listing(project: str, product_name: str, repos
     return next((v for v in versions if len(v) > 0), "")
 
 
+def verify_repo_exists(project: str, product_name: str, product_version: str, arch: str) -> bool:
+    """Check if the repository actually exists for the given architecture via HTTP HEAD request."""
+    if not product_version:
+        return True
+    download_base = config.settings.download_base_url
+    obs_download = config.settings.obs_download_url
+    if not download_base or not obs_download:
+        return True
+    try:
+        host = obs_download.split("/")[2]
+    except IndexError:
+        return True
+    base = download_base.replace("%REPO_MIRROR_HOST%", host)
+    project_path = project.replace(":", ":/")
+    repo_url = f"{base}/{project_path}/{config.OBS_REPO_TYPE}/repo/{product_name}-{product_version}-{arch}/{arch}/"
+    with suppress(requests.exceptions.RequestException):
+        response = retried_requests.head(repo_url, allow_redirects=True)
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            log.debug("Repo %s not found (404), skipping channel", repo_url)
+            return False
+        log.debug("Repo %s returned %s, allowing channel", repo_url, response.status_code)
+        return response.ok
+    log.debug("HTTP check failed for repo %s, allowing channel", repo_url)
+    return True
+
+
 def _get_product_version(res: etree._Element, project: str, product_name: str) -> str:
     """Extract product version from scmsync element or repository listing."""
     # read product version from scmsync element if possible, e.g. 15.99
@@ -409,7 +437,9 @@ def add_channel_for_build_result(
     elif len(product_name) > 0:
         log.debug("Channel skipped: Product version for build result %s:%s could not be determined", project, arch)
         return channel
-
+    if product_name and not verify_repo_exists(project, product_name, product_version, arch):
+        log.debug("Skipping %s:%s: repository not found for architecture %s", project, arch, arch)
+        return channel
     projects.add(channel)
     return channel
 

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -348,10 +348,12 @@ def _extract_version(name: str, prefix: str) -> str:
 
 
 @lru_cache(maxsize=512)
-def get_product_version_from_repo_listing(project: str, product_name: str, repository: str) -> str:
+def get_product_version_from_repo_listing(
+    project: str, product_name: str, repository: str, obs_download_url: str
+) -> str:
     """Determine the product version by inspecting an OBS repository listing."""
     project_path = project.replace(":", ":/")
-    url = f"{config.settings.obs_download_url}/{project_path}/{repository}/repo"
+    url = f"{obs_download_url}/{project_path}/{repository}/repo"
     start = f"{product_name}-"
     try:
         r = retried_requests.get(url, params={"jsontable": 1})
@@ -371,7 +373,16 @@ def get_product_version_from_repo_listing(project: str, product_name: str, repos
     return next((v for v in versions if len(v) > 0), "")
 
 
-def verify_repo_exists(project: str, product_name: str, product_version: str, arch: str) -> bool:
+def verify_repo_exists(  # noqa: PLR0913
+    project: str,
+    product_name: str,
+    product_version: str,
+    arch: str,
+    *,
+    repo_type: str,
+    download_base_url: str,
+    obs_download_url: str,
+) -> bool:
     """Check if the repository actually exists for the given architecture via HTTP HEAD request."""
     if not product_version:
         return True
@@ -380,9 +391,9 @@ def verify_repo_exists(project: str, product_name: str, product_version: str, ar
         product_name,
         product_version,
         arch,
-        repo_type=config.settings.obs_repo_type or "product",
-        download_base_url=config.settings.download_base_url,
-        obs_download_url=config.settings.obs_download_url,
+        repo_type=repo_type,
+        download_base_url=download_base_url,
+        obs_download_url=obs_download_url,
     )
     if not repo_url:
         return True
@@ -397,7 +408,13 @@ def verify_repo_exists(project: str, product_name: str, product_version: str, ar
     return True
 
 
-def _get_product_version(res: etree._Element, project: str, product_name: str) -> str:
+def _get_product_version(
+    res: etree._Element,
+    project: str,
+    product_name: str,
+    obs_download_url: str,
+    obs_products: set[str],
+) -> str:
     """Extract product version from scmsync element or repository listing."""
     # read product version from scmsync element if possible, e.g. 15.99
     product_version = ""
@@ -408,37 +425,48 @@ def _get_product_version(res: etree._Element, project: str, product_name: str) -
             break
 
     # read product version from directory listing if the project is for a concrete product
-    if (
-        len(product_name) != 0
-        and len(product_version) == 0
-        and ("all" in config.settings.obs_products_set or product_name in config.settings.obs_products_set)
-    ):
-        product_version = get_product_version_from_repo_listing(project, product_name, res.get("repository"))
+    if not product_version and product_name and ("all" in obs_products or product_name in obs_products):
+        product_version = get_product_version_from_repo_listing(
+            project, product_name, res.get("repository"), obs_download_url
+        )
 
     return product_version
 
 
-def add_channel_for_build_result(
+def add_channel_for_build_result(  # noqa: PLR0913
     project: str,
     arch: str,
     product_name: str,
     res: etree._Element,
     projects: set[str],
+    *,
+    repo_type: str,
+    download_base_url: str,
+    obs_download_url: str,
+    obs_products: set[str],
 ) -> str:
     """Construct a channel string for a build result and add it to the project set."""
     channel = f"{project}:{arch}"
     if arch == "local":
         return channel
 
-    product_version = _get_product_version(res, project, product_name)
+    product_version = _get_product_version(res, project, product_name, obs_download_url, obs_products)
 
     # append product version to channel if known; otherwise skip channel if this is for a concrete product
-    if len(product_version) > 0:
-        channel = f"{channel}#{product_version}"
+    if product_version:
+        channel += f"#{product_version}"
     elif len(product_name) > 0:
         log.debug("Channel skipped: Product version for build result %s:%s could not be determined", project, arch)
         return channel
-    if product_name and not verify_repo_exists(project, product_name, product_version, arch):
+    if product_name and not verify_repo_exists(
+        project,
+        product_name,
+        product_version,
+        arch,
+        repo_type=repo_type,
+        download_base_url=download_base_url,
+        obs_download_url=obs_download_url,
+    ):
         log.debug("Skipping %s:%s: repository not found for architecture %s", project, arch, arch)
         return channel
     projects.add(channel)
@@ -477,7 +505,17 @@ def add_build_result(
 
     _update_scminfo(submission, res, project, product)
 
-    channel = add_channel_for_build_result(project, res.get("arch"), product, res, results.projects)
+    channel = add_channel_for_build_result(
+        project,
+        res.get("arch"),
+        product,
+        res,
+        results.projects,
+        repo_type=config.settings.obs_repo_type or "product",
+        download_base_url=config.settings.download_base_url,
+        obs_download_url=config.settings.obs_download_url,
+        obs_products=config.settings.obs_products_set,
+    )
 
     if "all" not in config.settings.obs_products_set and product not in config.settings.obs_products_set:
         return

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -29,7 +29,7 @@ from osc.core import MultibuildFlavorResolver
 from openqabot import config
 from openqabot.errors import NoRepoFoundError
 from openqabot.types.pullrequest import PullRequest
-from openqabot.utils import get_repo_url
+from openqabot.utils import BuildTarget, RepoConfig, get_repo_url
 from openqabot.utils import retry10 as retried_requests
 
 if TYPE_CHECKING:
@@ -373,28 +373,15 @@ def get_product_version_from_repo_listing(
     return next((v for v in versions if len(v) > 0), "")
 
 
-def verify_repo_exists(  # noqa: PLR0913
-    project: str,
-    product_name: str,
+def verify_repo_exists(
+    target: BuildTarget,
     product_version: str,
-    arch: str,
-    *,
-    repo_type: str,
-    download_base_url: str,
-    obs_download_url: str,
+    config: RepoConfig,
 ) -> bool:
     """Check if the repository actually exists for the given architecture via HTTP HEAD request."""
     if not product_version:
         return True
-    repo_url = get_repo_url(
-        project,
-        product_name,
-        product_version,
-        arch,
-        repo_type=repo_type,
-        download_base_url=download_base_url,
-        obs_download_url=obs_download_url,
-    )
+    repo_url = get_repo_url(target, product_version, config)
     if not repo_url:
         return True
     with suppress(requests.exceptions.RequestException):
@@ -410,10 +397,8 @@ def verify_repo_exists(  # noqa: PLR0913
 
 def _get_product_version(
     res: etree._Element,
-    project: str,
-    product_name: str,
-    obs_download_url: str,
-    obs_products: set[str],
+    target: BuildTarget,
+    config: RepoConfig,
 ) -> str:
     """Extract product version from scmsync element or repository listing."""
     # read product version from scmsync element if possible, e.g. 15.99
@@ -425,48 +410,45 @@ def _get_product_version(
             break
 
     # read product version from directory listing if the project is for a concrete product
-    if not product_version and product_name and ("all" in obs_products or product_name in obs_products):
+    if (
+        not product_version
+        and target.product_name
+        and config.obs_products
+        and ("all" in config.obs_products or target.product_name in config.obs_products)
+    ):
         product_version = get_product_version_from_repo_listing(
-            project, product_name, res.get("repository"), obs_download_url
+            target.project, target.product_name, res.get("repository"), config.obs_download_url
         )
 
     return product_version
 
 
-def add_channel_for_build_result(  # noqa: PLR0913
-    project: str,
-    arch: str,
-    product_name: str,
+def add_channel_for_build_result(
+    target: BuildTarget,
     res: etree._Element,
     projects: set[str],
     *,
-    repo_type: str,
-    download_base_url: str,
-    obs_download_url: str,
-    obs_products: set[str],
+    config: RepoConfig,
 ) -> str:
     """Construct a channel string for a build result and add it to the project set."""
-    channel = f"{project}:{arch}"
-    if arch == "local":
+    channel = f"{target.project}:{target.arch}"
+    if target.arch == "local":
         return channel
 
-    product_version = _get_product_version(res, project, product_name, obs_download_url, obs_products)
+    product_version = _get_product_version(res, target, config)
 
     # append product version to channel if known; otherwise skip channel if this is for a concrete product
     if product_version:
         channel += f"#{product_version}"
-    elif len(product_name) > 0:
-        log.debug("Channel skipped: Product version for build result %s:%s could not be determined", project, arch)
+    elif len(target.product_name) > 0:
+        log.debug(
+            "Channel skipped: Product version for build result %s:%s could not be determined",
+            target.project,
+            target.arch,
+        )
         return channel
-    if product_name and not verify_repo_exists(
-        project,
-        product_name,
-        product_version,
-        arch,
-        repo_type=repo_type,
-        download_base_url=download_base_url,
-        obs_download_url=obs_download_url,
-    ):
+    if target.product_name and not verify_repo_exists(target, product_version, config):
+        log.debug("Skipping %s:%s: repository not found for architecture %s", target.project, target.arch, target.arch)
         return channel
     projects.add(channel)
     return channel
@@ -504,18 +486,14 @@ def add_build_result(
 
     _update_scminfo(submission, res, project, product)
 
-    channel = add_channel_for_build_result(
-        project,
-        res.get("arch"),
-        product,
-        res,
-        results.projects,
+    repo_config = RepoConfig(
         repo_type=config.settings.obs_repo_type or "product",
         download_base_url=config.settings.download_base_url,
         obs_download_url=config.settings.obs_download_url,
         obs_products=config.settings.obs_products_set,
     )
-
+    target = BuildTarget(project, res.get("arch"), product)
+    channel = add_channel_for_build_result(target, res, results.projects, config=repo_config)
     if "all" not in config.settings.obs_products_set and product not in config.settings.obs_products_set:
         return
 

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -29,14 +29,13 @@ from osc.core import MultibuildFlavorResolver
 from openqabot import config
 from openqabot.errors import NoRepoFoundError
 from openqabot.types.pullrequest import PullRequest
-from openqabot.types.gitea import BuildTarget, RepoConfig
+from openqabot.types.gitea import RepoConfig
+from openqabot.types.types import Repos
 from openqabot.utils import get_repo_url
 from openqabot.utils import retry10 as retried_requests
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-    from openqabot.types.types import Repos
 
 ARCHS = {"x86_64", "aarch64", "ppc64le", "s390x"}
 
@@ -375,7 +374,7 @@ def get_product_version_from_repo_listing(
 
 
 def verify_repo_exists(
-    target: BuildTarget,
+    target: Repos,
     product_version: str,
     config: RepoConfig,
 ) -> bool:
@@ -398,7 +397,7 @@ def verify_repo_exists(
 
 def _get_product_version(
     res: etree._Element,
-    target: BuildTarget,
+    target: Repos,
     config: RepoConfig,
 ) -> str:
     """Extract product version from scmsync element or repository listing."""
@@ -413,26 +412,26 @@ def _get_product_version(
     # read product version from directory listing if the project is for a concrete product
     if (
         not product_version
-        and target.product_name
+        and target.version
         and config.obs_products
-        and ("all" in config.obs_products or target.product_name in config.obs_products)
+        and ("all" in config.obs_products or target.version in config.obs_products)
     ):
         product_version = get_product_version_from_repo_listing(
-            target.project, target.product_name, res.get("repository"), config.obs_download_url
+            target.product, target.version, res.get("repository"), config.obs_download_url
         )
 
     return product_version
 
 
 def add_channel_for_build_result(
-    target: BuildTarget,
+    target: Repos,
     res: etree._Element,
     projects: set[str],
     *,
     config: RepoConfig,
 ) -> str:
     """Construct a channel string for a build result and add it to the project set."""
-    channel = f"{target.project}:{target.arch}"
+    channel = f"{target.product}:{target.arch}"
     if target.arch == "local":
         return channel
 
@@ -441,17 +440,16 @@ def add_channel_for_build_result(
     # append product version to channel if known; otherwise skip channel if this is for a concrete product
     if product_version:
         channel += f"#{product_version}"
-    elif len(target.product_name) > 0:
+    elif target.version:
         log.debug(
             "Channel skipped: Product version for build result %s:%s could not be determined",
-            target.project,
+            target.product,
             target.arch,
         )
         return channel
-    if target.product_name and not verify_repo_exists(target, product_version, config):
-        log.debug("Skipping %s:%s: repository not found for architecture %s", target.project, target.arch, target.arch)
-        return channel
-    projects.add(channel)
+
+    if not product_version or verify_repo_exists(target, product_version, config):
+        projects.add(channel)
     return channel
 
 
@@ -493,7 +491,7 @@ def add_build_result(
         obs_download_url=config.settings.obs_download_url,
         obs_products=config.settings.obs_products_set,
     )
-    target = BuildTarget(project, res.get("arch"), product)
+    target = Repos(product=project, version=product, arch=res.get("arch"))
     channel = add_channel_for_build_result(target, res, results.projects, config=repo_config)
     if "all" not in config.settings.obs_products_set and product not in config.settings.obs_products_set:
         return

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -400,11 +400,11 @@ def verify_repo_exists(  # noqa: PLR0913
     with suppress(requests.exceptions.RequestException):
         response = retried_requests.head(repo_url, allow_redirects=True)
         if response.status_code == HTTPStatus.NOT_FOUND:
-            log.debug("Repo %s not found (404), skipping channel", repo_url)
+            log.debug("Repo %s not found, skipping channel", repo_url)
             return False
         log.debug("Repo %s returned %s, allowing channel", repo_url, response.status_code)
         return response.ok
-    log.debug("HTTP check failed for repo %s, allowing channel", repo_url)
+    log.info("HTTP check failed for repo %s, allowing channel", repo_url)
     return True
 
 
@@ -467,7 +467,6 @@ def add_channel_for_build_result(  # noqa: PLR0913
         download_base_url=download_base_url,
         obs_download_url=obs_download_url,
     ):
-        log.debug("Skipping %s:%s: repository not found for architecture %s", project, arch, arch)
         return channel
     projects.add(channel)
     return channel

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -17,10 +17,11 @@ from io import BytesIO
 from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import urlparse
 
-import osc.conf
-import osc.core
-import osc.util.xml
+import osc.conf as osc_conf
+import osc.core as osc_core
+import osc.util.xml as osc_xml
 import requests
 from lxml import etree  # ty: ignore[unresolved-import]
 from osc.connection import http_GET
@@ -378,9 +379,8 @@ def verify_repo_exists(project: str, product_name: str, product_version: str, ar
     obs_download = config.settings.obs_download_url
     if not download_base or not obs_download:
         return True
-    try:
-        host = obs_download.split("/")[2]
-    except IndexError:
+    host = urlparse(obs_download).netloc
+    if not host:
         return True
     base = download_base.replace("%REPO_MIRROR_HOST%", host)
     project_path = project.replace(":", ":/")
@@ -535,11 +535,11 @@ def is_build_result_relevant(res: etree._Element, relevant_archs: set[str] | Non
 
 def _get_project_results(obs_project: str, *, dry: bool, results: BuildResults) -> list[etree._Element]:
     """Fetch build results for an OBS project."""
-    build_info_url = osc.core.makeurl(config.settings.obs_url, ["build", obs_project, "_result"])
+    build_info_url = osc_core.makeurl(config.settings.obs_url, ["build", obs_project, "_result"])
     if dry:
         return read_xml("build-results-124-" + obs_project).getroot().findall("result")
     try:
-        return osc.util.xml.xml_parse(http_GET(build_info_url)).getroot().findall("result")
+        return osc_xml.xml_parse(http_GET(build_info_url)).getroot().findall("result")
     except urllib.error.HTTPError:
         results.unavailable.add(obs_project)
         log.info("Build results for project %s unreadable, skipping: %s", obs_project, build_info_url)
@@ -828,7 +828,7 @@ def get_submissions_from_open_prs(
     submissions = []
 
     # configure osc to be able to request build info from OBS
-    osc.conf.get_config(override_apiurl=config.settings.obs_url)
+    osc_conf.get_config(override_apiurl=config.settings.obs_url)
 
     with futures.ThreadPoolExecutor() as executor:
         future_sub = [

--- a/openqabot/loader/gitea_utils.py
+++ b/openqabot/loader/gitea_utils.py
@@ -1,0 +1,174 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: MIT
+"""Gitea loader utilities."""
+
+from __future__ import annotations
+
+import json
+import re
+from functools import lru_cache
+from io import BytesIO
+from logging import getLogger
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lxml import etree  # ty: ignore[unresolved-import]
+
+from openqabot import config
+from openqabot.utils import retry10 as retried_requests
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+log = getLogger("bot.loader.gitea_utils")
+
+JsonType = dict[str, Any] | list[Any]
+
+
+ARCHS = {"x86_64", "aarch64", "ppc64le", "s390x"}
+
+
+PROJECT_PRODUCT_REGEX = re.compile(r".*:PullRequest:\d+:(.*)")
+SCMSYNC_REGEX = re.compile(r".*/products/(.*)#([\d\.]{2,6})$")
+VERSION_EXTRACT_REGEX = re.compile(r"[.\d]+")
+OBS_PROJECT_SHOW_REGEX = re.compile(r".*/project/show/([^/\s\?\#\)]+)")
+# Regex to find all HTTPS URLs, excluding common trailing punctuation like dots or parentheses
+# that are likely part of the surrounding text (e.g. at the end of a sentence or in Markdown).
+URL_FINDALL_REGEX = re.compile(r"https?://[^\s\?\#\)]*[^\s\?\#\)\.]")
+
+
+def get_product_name(obs_project: str) -> str:
+    """Extract product name from an OBS project name."""
+    product_match = PROJECT_PRODUCT_REGEX.search(obs_project)
+    return product_match.group(1) if product_match else ""
+
+
+def get_product_name_and_version_from_scmsync(scmsync_url: str) -> tuple[str, str]:
+    """Extract product name and version from an scmsync URL."""
+    m = SCMSYNC_REGEX.search(scmsync_url)
+    return (m.group(1), m.group(2)) if m else ("", "")
+
+
+def _extract_version(name: str, prefix: str) -> str:
+    """Extract version number from a package name string."""
+    remainder = name.removeprefix(prefix)
+    return next((part for part in remainder.split("-") if VERSION_EXTRACT_REGEX.search(part)), "")
+
+
+def _approval_identifiers(bot_user: str, commit_id: str, *, approve: bool = True) -> tuple[str, str]:
+    action = "approved" if approve else "decline"
+    return f"@{bot_user}: {action}", f"Tested commit: {commit_id}"
+
+
+def _is_bot_approval_comment(comment: dict[str, Any], bot_user: str, commit_id: str) -> bool:
+    """Check if a comment is an authentic approval from the bot."""
+    body = comment.get("body", "")
+    allowed_authors = {bot_user, config.settings.obs_group}
+    is_author = comment.get("user", {}).get("login") in allowed_authors
+    review_cmd, commit_str = _approval_identifiers(bot_user, commit_id)
+    return is_author and review_cmd in body and commit_str in body
+
+
+def make_token_header(token: str) -> dict[str, str]:
+    """Create the Authorization header for Gitea API requests."""
+    return {} if token is None else {"Authorization": "token " + token}
+
+
+def get_json(
+    query: str,
+    token: dict[str, str],
+    host: str | None = None,
+    params: dict[str, Any] | None = None,
+) -> JsonType:
+    """Fetch JSON data from Gitea API."""
+    host = host or config.settings.gitea_url
+    url = f"{host}/api/v1/{query}"
+    response = retried_requests.get(url, verify=not config.settings.insecure, headers=token, params=params)
+    response.raise_for_status()
+    return response.json()
+
+
+def iter_gitea_items(query: str, token: dict[str, str], host: str | None = None) -> Iterator[Any]:
+    """Fetch a list of JSON data from Gitea API with pagination support.
+
+    Yields:
+        JSON items from the paginated response.
+
+    """
+    host = host or config.settings.gitea_url
+    url = f"{host}/api/v1/{query}"
+
+    while url:
+        response = retried_requests.get(url, verify=not config.settings.insecure, headers=token)
+        response.raise_for_status()
+        res = response.json()
+
+        if not isinstance(res, list):
+            msg = f"Gitea API returned {type(res).__name__} instead of list for query: {query}"
+            raise TypeError(msg)
+
+        yield from res
+        url = response.links.get("next", {}).get("url")
+
+
+def _request_json(method: str, query: str, token: dict[str, str], post_data: JsonType, host: str | None = None) -> None:
+    """Send a JSON request to Gitea API."""
+    host = host or config.settings.gitea_url
+    url = f"{host}/api/v1/{query}"
+    res = getattr(retried_requests, method.lower())(
+        url, verify=not config.settings.insecure, headers=token, json=post_data
+    )
+    if not res.ok:
+        log.error("Gitea API error: %s to %s failed: %s", method.upper(), url, res.text)
+
+
+def post_json(query: str, token: dict[str, str], post_data: JsonType, host: str | None = None) -> None:
+    """Post JSON data to Gitea API."""
+    _request_json("POST", query, token, post_data, host)
+
+
+def patch_json(query: str, token: dict[str, str], post_data: JsonType, host: str | None = None) -> None:
+    """Patch JSON data in Gitea API."""
+    _request_json("PATCH", query, token, post_data, host)
+
+
+@lru_cache(maxsize=128)
+def read_utf8(name: str) -> str:
+    """Read a UTF-8 encoded response file."""
+    return Path(f"tests/fixtures/responses/{name}").read_text(encoding="utf8")
+
+
+@lru_cache(maxsize=128)
+def read_json_file(name: str) -> JsonType:
+    """Read a JSON response file."""
+    return json.loads(read_utf8(name + ".json"))
+
+
+def read_json_file_list(name: str) -> list[Any]:
+    """Read a list from a JSON response file."""
+    res = read_json_file(name)
+    if not isinstance(res, list):
+        msg = f"JSON response file '{name}' returned {type(res).__name__} instead of list"
+        raise TypeError(msg)
+    return res
+
+
+@lru_cache(maxsize=128)
+def read_xml(name: str) -> etree.ElementTree:
+    """Read an XML response file."""
+    return etree.parse(BytesIO(read_utf8(name + ".xml").encode("utf-8")))
+
+
+def reviews_url(repo_name: str, number: int) -> str:
+    """Construct the URL for PR reviews."""
+    return f"repos/{repo_name}/pulls/{number}/reviews"
+
+
+def changed_files_url(repo_name: str, number: int) -> str:
+    """Construct the URL for PR changed files."""
+    return f"repos/{repo_name}/pulls/{number}/files"
+
+
+def comments_url(repo_name: str, number: int) -> str:
+    """Construct the URL for PR comments."""
+    return f"repos/{repo_name}/issues/{number}/comments"

--- a/openqabot/types/gitea.py
+++ b/openqabot/types/gitea.py
@@ -8,15 +8,6 @@ from dataclasses import dataclass
 
 
 @dataclass
-class BuildTarget:
-    """OBS build target information including project, architecture, and product name."""
-
-    project: str
-    arch: str
-    product_name: str
-
-
-@dataclass
 class RepoConfig:
     """Configuration for OBS repository mirrors and product sets."""
 

--- a/openqabot/types/gitea.py
+++ b/openqabot/types/gitea.py
@@ -14,4 +14,5 @@ class RepoConfig:
     repo_type: str
     download_base_url: str
     obs_download_url: str
+    repo_mirror_host: str
     obs_products: set[str] | None = None

--- a/openqabot/types/gitea.py
+++ b/openqabot/types/gitea.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 @dataclass
 class BuildTarget:
-    """Build target information."""
+    """OBS build target information including project, architecture, and product name."""
 
     project: str
     arch: str
@@ -18,7 +18,7 @@ class BuildTarget:
 
 @dataclass
 class RepoConfig:
-    """Repository configuration parameters."""
+    """Configuration for OBS repository mirrors and product sets."""
 
     repo_type: str
     download_base_url: str

--- a/openqabot/types/gitea.py
+++ b/openqabot/types/gitea.py
@@ -1,0 +1,26 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: MIT
+"""Gitea loader specific type definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class BuildTarget:
+    """Build target information."""
+
+    project: str
+    arch: str
+    product_name: str
+
+
+@dataclass
+class RepoConfig:
+    """Repository configuration parameters."""
+
+    repo_type: str
+    download_base_url: str
+    obs_download_url: str
+    obs_products: set[str] | None = None

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -16,8 +16,8 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 if TYPE_CHECKING:
-    from .types.gitea import BuildTarget, RepoConfig
-    from .types.types import Data
+    from .types.gitea import RepoConfig
+    from .types.types import Data, Repos
 
 
 ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
@@ -131,7 +131,7 @@ def unique_dicts(dicts: list[dict[Any, Any]]) -> list[dict[Any, Any]]:
 
 
 def get_repo_url(
-    target: BuildTarget,
+    target: Repos,
     product_version: str,
     config: RepoConfig,
 ) -> str:
@@ -140,10 +140,9 @@ def get_repo_url(
     if not host:
         return ""
     base = config.download_base_url.replace("%REPO_MIRROR_HOST%", host)
-    project_path = target.project.replace(":", ":/")
+    project_path = target.product.replace(":", ":/")
     return (
-        f"{base}/{project_path}/{config.repo_type}/repo/"
-        f"{target.product_name}-{product_version}-{target.arch}/{target.arch}/"
+        f"{base}/{project_path}/{config.repo_type}/repo/{target.version}-{product_version}-{target.arch}/{target.arch}/"
     )
 
 

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -129,23 +130,40 @@ def unique_dicts(dicts: list[dict[Any, Any]]) -> list[dict[Any, Any]]:
     return unique
 
 
-def get_repo_url(  # noqa: PLR0913
-    project: str,
-    product_name: str,
+@dataclass
+class BuildTarget:
+    """Build target information."""
+
+    project: str
+    arch: str
+    product_name: str
+
+
+@dataclass
+class RepoConfig:
+    """Repository configuration parameters."""
+
+    repo_type: str
+    download_base_url: str
+    obs_download_url: str
+    obs_products: set[str] | None = None
+
+
+def get_repo_url(
+    target: BuildTarget,
     product_version: str,
-    arch: str,
-    *,
-    repo_type: str,
-    download_base_url: str,
-    obs_download_url: str,
+    config: RepoConfig,
 ) -> str:
     """Construct the repository URL for a given project and architecture."""
-    host = urlparse(obs_download_url).netloc
+    host = urlparse(config.obs_download_url).netloc
     if not host:
         return ""
-    base = download_base_url.replace("%REPO_MIRROR_HOST%", host)
-    project_path = project.replace(":", ":/")
-    return f"{base}/{project_path}/{repo_type}/repo/{product_name}-{product_version}-{arch}/{arch}/"
+    base = config.download_base_url.replace("%REPO_MIRROR_HOST%", host)
+    project_path = target.project.replace(":", ":/")
+    return (
+        f"{base}/{project_path}/{config.repo_type}/repo/"
+        f"{target.product_name}-{product_version}-{target.arch}/{target.arch}/"
+    )
 
 
 def number_of_retries(fallback: int = 3) -> int:

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 from copy import deepcopy
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
@@ -17,6 +16,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 if TYPE_CHECKING:
+    from .types.gitea import BuildTarget, RepoConfig
     from .types.types import Data
 
 
@@ -128,25 +128,6 @@ def unique_dicts(dicts: list[dict[Any, Any]]) -> list[dict[Any, Any]]:
             seen.add(items)
             unique.append(d)
     return unique
-
-
-@dataclass
-class BuildTarget:
-    """Build target information."""
-
-    project: str
-    arch: str
-    product_name: str
-
-
-@dataclass
-class RepoConfig:
-    """Repository configuration parameters."""
-
-    repo_type: str
-    download_base_url: str
-    obs_download_url: str
-    obs_products: set[str] | None = None
 
 
 def get_repo_url(

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -9,7 +9,6 @@ import os
 import re
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -136,10 +135,7 @@ def get_repo_url(
     config: RepoConfig,
 ) -> str:
     """Construct the repository URL for a given project and architecture."""
-    host = urlparse(config.obs_download_url).netloc
-    if not host:
-        return ""
-    base = config.download_base_url.replace("%REPO_MIRROR_HOST%", host)
+    base = config.download_base_url.replace("%REPO_MIRROR_HOST%", config.repo_mirror_host)
     project_path = target.product.replace(":", ":/")
     return (
         f"{base}/{project_path}/{config.repo_type}/repo/{target.version}-{product_version}-{target.arch}/{target.arch}/"

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -9,6 +9,7 @@ import os
 import re
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -126,6 +127,25 @@ def unique_dicts(dicts: list[dict[Any, Any]]) -> list[dict[Any, Any]]:
             seen.add(items)
             unique.append(d)
     return unique
+
+
+def get_repo_url(  # noqa: PLR0913
+    project: str,
+    product_name: str,
+    product_version: str,
+    arch: str,
+    *,
+    repo_type: str,
+    download_base_url: str,
+    obs_download_url: str,
+) -> str:
+    """Construct the repository URL for a given project and architecture."""
+    host = urlparse(obs_download_url).netloc
+    if not host:
+        return ""
+    base = download_base_url.replace("%REPO_MIRROR_HOST%", host)
+    project_path = project.replace(":", ":/")
+    return f"{base}/{project_path}/{repo_type}/repo/{product_name}-{product_version}-{arch}/{arch}/"
 
 
 def number_of_retries(fallback: int = 3) -> int:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
+from pydantic import ValidationError
 from openqabot.config import Settings, get_default_obs_url
 
 
@@ -104,3 +104,23 @@ def test_insecure_setting() -> None:
 
     settings = Settings(QEM_BOT_INSECURE=False)
     assert settings.insecure is False
+
+
+def test_obs_download_url_validation() -> None:
+    """Test validation of obs_download_url."""
+    # Valid URL
+    settings = Settings(obs_download_url="http://download.suse.de/ibs")
+    assert settings.obs_download_url == "http://download.suse.de/ibs"
+
+    # Invalid URL (no hostname)
+    with pytest.raises(ValidationError, match="OBS_DOWNLOAD_URL 'invalid-url' does not contain a valid hostname"):
+        Settings(obs_download_url="invalid-url")
+
+
+def test_repo_mirror_host_property() -> None:
+    """Test the repo_mirror_host property."""
+    settings = Settings(obs_download_url="http://download.suse.de/ibs")
+    assert settings.repo_mirror_host == "download.suse.de"
+
+    settings = Settings(obs_download_url="https://mirror.example.com/path")
+    assert settings.repo_mirror_host == "mirror.example.com"

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -168,6 +168,7 @@ def test_gitea_sync_on_dry_run_does_not_sync(args: Namespace, caplog: pytest.Log
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
 def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
     mocker.patch("openqabot.config.settings.obs_products", "SLES")
+    mocker.patch("openqabot.loader.gitea.verify_repo_exists", return_value=True)
     run_gitea_sync(mocker, caplog, args)
     expected_repo = "SUSE:SLFO:1.1.99:PullRequest:124:SLES"
     assert "Relevant archs for " + expected_repo + ": ['aarch64', 'x86_64']" in caplog.messages
@@ -207,6 +208,7 @@ def test_sync_with_product_version_from_repo_listing(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     mocker.patch("openqabot.config.settings.obs_repo_type", "standard")  # has no scmsync so repo listing is used
+    mocker.patch("openqabot.loader.gitea.verify_repo_exists", return_value=True)
     run_gitea_sync(mocker, caplog, args)
 
     expected_repo = "SUSE:SLFO:1.1.99:PullRequest:124:SLES"

--- a/tests/test_loader_gitea_build_results.py
+++ b/tests/test_loader_gitea_build_results.py
@@ -13,7 +13,7 @@ import pytest
 
 from openqabot.loader import gitea
 from openqabot.loader.gitea import BuildResults, verify_repo_exists
-from openqabot.utils import BuildTarget, RepoConfig
+from openqabot.types.gitea import BuildTarget, RepoConfig
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture

--- a/tests/test_loader_gitea_build_results.py
+++ b/tests/test_loader_gitea_build_results.py
@@ -2,16 +2,36 @@
 # SPDX-License-Identifier: MIT
 """Test loader Gitea build results."""
 
+from __future__ import annotations
+
 import logging
 import urllib.error
 from io import BytesIO
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
-from pytest_mock import MockerFixture
 
 from openqabot.loader import gitea
-from openqabot.loader.gitea import BuildResults
+from openqabot.loader.gitea import BuildResults, verify_repo_exists
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def mock_product_setup(mocker: MockerFixture) -> None:
+    """Set up common mocks for add_build_result tests with product."""
+    mocker.patch("openqabot.loader.gitea.get_product_name", return_value="SLES")
+    mocker.patch("openqabot.config.settings.obs_products", "all")
+    mocker.patch("openqabot.loader.gitea.get_product_version_from_repo_listing", return_value="16.0")
+
+
+@pytest.fixture
+def mock_repo_check_setup(mocker: MockerFixture) -> None:
+    """Set up common mocks for verify_repo_exists tests."""
+    mocker.patch("openqabot.config.settings.download_base_url", "http://example.com")
+    mocker.patch("openqabot.config.settings.obs_download_url", "http://download.suse.de/ibs")
+    mocker.patch("openqabot.config.settings.obs_repo_type", "product")
 
 
 def test_add_build_result_inconsistent_scminfo(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
@@ -215,3 +235,115 @@ def test_add_comments_bot_comments_no_urls(mocker: MockerFixture, caplog: pytest
     gitea.add_comments_and_referenced_build_results(submission, comments, dry=True)
     mock_add_build_results.assert_not_called()
     assert "PR git:123: No OBS URLs found in comments from autogits_obs_staging_bot" in caplog.text
+
+
+@pytest.mark.usefixtures("mock_product_setup")
+@pytest.mark.parametrize(
+    ("arch", "verify_result", "expected_in_projects", "expected_log"),
+    [
+        (
+            "ppc64le",
+            False,
+            False,
+            "Skipping SUSE:SLFO:1.2:PullRequest:2702:SLES:ppc64le: repository not found for architecture",
+        ),
+        ("x86_64", True, True, None),
+        ("aarch64", True, True, None),
+    ],
+)
+def test_add_build_result_channel_handling(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    *,
+    arch: str,
+    verify_result: bool,
+    expected_in_projects: bool,
+    expected_log: str | None,
+) -> None:
+    """Verify channel is handled based on verify_repo_exists result."""
+    if expected_log:
+        caplog.set_level(logging.DEBUG, logger="bot.loader.gitea")
+    mocker.patch("openqabot.loader.gitea.verify_repo_exists", return_value=verify_result)
+
+    incident = {"number": 123}
+    res = mocker.Mock()
+    base_data = {
+        "project": "SUSE:SLFO:1.2:PullRequest:2702:SLES",
+        "arch": arch,
+        "repository": "product",
+    }
+    if arch == "aarch64":
+        base_data["state"] = "published"
+    res.get.side_effect = lambda k: base_data.get(k, "")
+    res.findall.return_value = []
+
+    results = BuildResults()
+    gitea.add_build_result(incident, res, results)
+
+    channel = f"SUSE:SLFO:1.2:PullRequest:2702:SLES:{arch}#16.0"
+    assert (channel in results.projects) == expected_in_projects
+    if expected_log:
+        assert expected_log in caplog.text
+
+
+@pytest.mark.usefixtures("mock_repo_check_setup")
+@pytest.mark.parametrize(
+    ("status_code", "ok", "expected"),
+    [
+        (404, False, False),
+        (200, True, True),
+    ],
+)
+def test_verify_repo_exists_status_codes(
+    mocker: MockerFixture,
+    *,
+    status_code: int,
+    ok: bool,
+    expected: bool,
+) -> None:
+    """Verify verify_repo_exists returns correct result for HTTP status codes."""
+    mock_head = mocker.patch("openqabot.loader.gitea.retried_requests.head")
+    mock_head.return_value.status_code = status_code
+    mock_head.return_value.ok = ok
+
+    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "16.0", "x86_64")
+
+    assert result is expected
+
+
+def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
+    """Verify verify_repo_exists returns True when no product version."""
+    mock_head = mocker.patch("openqabot.loader.gitea.retried_requests.head")
+
+    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "", "x86_64")
+
+    assert result is True
+    mock_head.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("download_base", "obs_download"),
+    [
+        ("", "http://download.suse.de/ibs"),
+        ("http://example.com", ""),
+        ("", ""),
+    ],
+)
+def test_verify_repo_exists_missing_urls(mocker: MockerFixture, download_base: str, obs_download: str) -> None:
+    """Verify verify_repo_exists returns True when configuration URLs are missing."""
+    mocker.patch("openqabot.config.settings.download_base_url", download_base)
+    mocker.patch("openqabot.config.settings.obs_download_url", obs_download)
+
+    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "16.0", "x86_64")
+
+    assert result is True
+
+
+def test_verify_repo_exists_invalid_obs_url(mocker: MockerFixture) -> None:
+    """Verify verify_repo_exists returns True when obs_download_url is invalid."""
+    mocker.patch("openqabot.config.settings.download_base_url", "http://example.com")
+    mocker.patch("openqabot.config.settings.obs_download_url", "invalid-url-no-slashes")
+
+    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "16.0", "x86_64")
+
+    assert result is True

--- a/tests/test_loader_gitea_build_results.py
+++ b/tests/test_loader_gitea_build_results.py
@@ -147,7 +147,14 @@ def test_add_build_results_duplicate_channels(mocker: MockerFixture) -> None:
     mocker.patch("openqabot.loader.gitea.determine_relevant_archs_from_multibuild_info", return_value=None)
     mocker.patch("openqabot.loader.gitea.get_product_name", return_value="SLES")
 
-    def mock_add_channel(_project: str, _arch: str, _product: str, _res: Any, projects: set[str]) -> str:
+    def mock_add_channel(
+        _project: str,
+        _arch: str,
+        _product: str,
+        _res: Any,
+        projects: set[str],
+        **kwargs: Any,
+    ) -> str:
         projects.add("chan")
         return "chan"
 
@@ -306,7 +313,15 @@ def test_verify_repo_exists_status_codes(
     mock_head.return_value.status_code = status_code
     mock_head.return_value.ok = ok
 
-    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "16.0", "x86_64")
+    result = verify_repo_exists(
+        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
+        "SLES",
+        "16.0",
+        "x86_64",
+        repo_type="product",
+        download_base_url="http://example.com",
+        obs_download_url="http://download.suse.de/ibs",
+    )
 
     assert result is expected
 
@@ -315,7 +330,15 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
     """Verify verify_repo_exists returns True when no product version."""
     mock_head = mocker.patch("openqabot.loader.gitea.retried_requests.head")
 
-    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "", "x86_64")
+    result = verify_repo_exists(
+        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
+        "SLES",
+        "",
+        "x86_64",
+        repo_type="product",
+        download_base_url="http://example.com",
+        obs_download_url="http://download.suse.de/ibs",
+    )
 
     assert result is True
     mock_head.assert_not_called()
@@ -331,19 +354,29 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
 )
 def test_verify_repo_exists_missing_urls(mocker: MockerFixture, download_base: str, obs_download: str) -> None:
     """Verify verify_repo_exists returns True when configuration URLs are missing."""
-    mocker.patch("openqabot.config.settings.download_base_url", download_base)
-    mocker.patch("openqabot.config.settings.obs_download_url", obs_download)
-
-    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "16.0", "x86_64")
+    result = verify_repo_exists(
+        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
+        "SLES",
+        "16.0",
+        "x86_64",
+        repo_type="product",
+        download_base_url=download_base,
+        obs_download_url=obs_download,
+    )
 
     assert result is True
 
 
 def test_verify_repo_exists_invalid_obs_url(mocker: MockerFixture) -> None:
     """Verify verify_repo_exists returns True when obs_download_url is invalid."""
-    mocker.patch("openqabot.config.settings.download_base_url", "http://example.com")
-    mocker.patch("openqabot.config.settings.obs_download_url", "invalid-url-no-slashes")
-
-    result = verify_repo_exists("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "16.0", "x86_64")
+    result = verify_repo_exists(
+        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
+        "SLES",
+        "16.0",
+        "x86_64",
+        repo_type="product",
+        download_base_url="http://example.com",
+        obs_download_url="invalid-url-no-slashes",
+    )
 
     assert result is True

--- a/tests/test_loader_gitea_build_results.py
+++ b/tests/test_loader_gitea_build_results.py
@@ -13,7 +13,8 @@ import pytest
 
 from openqabot.loader import gitea
 from openqabot.loader.gitea import BuildResults, verify_repo_exists
-from openqabot.types.gitea import BuildTarget, RepoConfig
+from openqabot.types.gitea import RepoConfig
+from openqabot.types.types import Repos
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -149,7 +150,7 @@ def test_add_build_results_duplicate_channels(mocker: MockerFixture) -> None:
     mocker.patch("openqabot.loader.gitea.get_product_name", return_value="SLES")
 
     def mock_add_channel(
-        _target: BuildTarget,
+        _target: Repos,
         _res: Any,
         projects: set[str],
         *,
@@ -301,7 +302,7 @@ def test_verify_repo_exists_status_codes(
     mock_head.return_value.ok = ok
 
     result = verify_repo_exists(
-        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
+        Repos("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "x86_64"),
         "16.0",
         config=RepoConfig(
             repo_type="product",
@@ -318,7 +319,7 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
     mock_head = mocker.patch("openqabot.loader.gitea.retried_requests.head")
 
     result = verify_repo_exists(
-        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
+        Repos("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "x86_64"),
         "",
         config=RepoConfig(
             repo_type="product",
@@ -342,7 +343,7 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
 def test_verify_repo_exists_missing_urls(download_base: str, obs_download: str) -> None:
     """Verify verify_repo_exists returns True when configuration URLs are missing."""
     result = verify_repo_exists(
-        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
+        Repos("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "x86_64"),
         "16.0",
         config=RepoConfig(
             repo_type="product",
@@ -357,7 +358,7 @@ def test_verify_repo_exists_missing_urls(download_base: str, obs_download: str) 
 def test_verify_repo_exists_invalid_obs_url() -> None:
     """Verify verify_repo_exists returns True when obs_download_url is invalid."""
     result = verify_repo_exists(
-        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
+        Repos("SUSE:SLFO:1.2:PullRequest:2702:SLES", "SLES", "x86_64"),
         "16.0",
         config=RepoConfig(
             repo_type="product",

--- a/tests/test_loader_gitea_build_results.py
+++ b/tests/test_loader_gitea_build_results.py
@@ -13,6 +13,7 @@ import pytest
 
 from openqabot.loader import gitea
 from openqabot.loader.gitea import BuildResults, verify_repo_exists
+from openqabot.utils import BuildTarget, RepoConfig
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -148,12 +149,11 @@ def test_add_build_results_duplicate_channels(mocker: MockerFixture) -> None:
     mocker.patch("openqabot.loader.gitea.get_product_name", return_value="SLES")
 
     def mock_add_channel(
-        _project: str,
-        _arch: str,
-        _product: str,
+        _target: BuildTarget,
         _res: Any,
         projects: set[str],
-        **_kwargs: Any,
+        *,
+        config: RepoConfig,  # noqa: ARG001
     ) -> str:
         projects.add("chan")
         return "chan"
@@ -301,13 +301,13 @@ def test_verify_repo_exists_status_codes(
     mock_head.return_value.ok = ok
 
     result = verify_repo_exists(
-        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
-        "SLES",
+        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
         "16.0",
-        "x86_64",
-        repo_type="product",
-        download_base_url="http://example.com",
-        obs_download_url="http://download.suse.de/ibs",
+        config=RepoConfig(
+            repo_type="product",
+            download_base_url="http://example.com",
+            obs_download_url="http://download.suse.de/ibs",
+        ),
     )
 
     assert result is expected
@@ -318,13 +318,13 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
     mock_head = mocker.patch("openqabot.loader.gitea.retried_requests.head")
 
     result = verify_repo_exists(
-        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
-        "SLES",
+        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
         "",
-        "x86_64",
-        repo_type="product",
-        download_base_url="http://example.com",
-        obs_download_url="http://download.suse.de/ibs",
+        config=RepoConfig(
+            repo_type="product",
+            download_base_url="http://example.com",
+            obs_download_url="http://download.suse.de/ibs",
+        ),
     )
 
     assert result is True
@@ -342,13 +342,13 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
 def test_verify_repo_exists_missing_urls(download_base: str, obs_download: str) -> None:
     """Verify verify_repo_exists returns True when configuration URLs are missing."""
     result = verify_repo_exists(
-        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
-        "SLES",
+        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
         "16.0",
-        "x86_64",
-        repo_type="product",
-        download_base_url=download_base,
-        obs_download_url=obs_download,
+        config=RepoConfig(
+            repo_type="product",
+            download_base_url=download_base,
+            obs_download_url=obs_download,
+        ),
     )
 
     assert result is True
@@ -357,13 +357,13 @@ def test_verify_repo_exists_missing_urls(download_base: str, obs_download: str) 
 def test_verify_repo_exists_invalid_obs_url() -> None:
     """Verify verify_repo_exists returns True when obs_download_url is invalid."""
     result = verify_repo_exists(
-        "SUSE:SLFO:1.2:PullRequest:2702:SLES",
-        "SLES",
+        BuildTarget("SUSE:SLFO:1.2:PullRequest:2702:SLES", "x86_64", "SLES"),
         "16.0",
-        "x86_64",
-        repo_type="product",
-        download_base_url="http://example.com",
-        obs_download_url="invalid-url-no-slashes",
+        config=RepoConfig(
+            repo_type="product",
+            download_base_url="http://example.com",
+            obs_download_url="invalid-url-no-slashes",
+        ),
     )
 
     assert result is True

--- a/tests/test_loader_gitea_build_results.py
+++ b/tests/test_loader_gitea_build_results.py
@@ -308,6 +308,7 @@ def test_verify_repo_exists_status_codes(
             repo_type="product",
             download_base_url="http://example.com",
             obs_download_url="http://download.suse.de/ibs",
+            repo_mirror_host="download.suse.de",
         ),
     )
 
@@ -325,6 +326,7 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
             repo_type="product",
             download_base_url="http://example.com",
             obs_download_url="http://download.suse.de/ibs",
+            repo_mirror_host="download.suse.de",
         ),
     )
 
@@ -349,6 +351,7 @@ def test_verify_repo_exists_missing_urls(download_base: str, obs_download: str) 
             repo_type="product",
             download_base_url=download_base,
             obs_download_url=obs_download,
+            repo_mirror_host="example.com",
         ),
     )
 
@@ -364,6 +367,7 @@ def test_verify_repo_exists_invalid_obs_url() -> None:
             repo_type="product",
             download_base_url="http://example.com",
             obs_download_url="invalid-url-no-slashes",
+            repo_mirror_host="",
         ),
     )
 

--- a/tests/test_loader_gitea_build_results.py
+++ b/tests/test_loader_gitea_build_results.py
@@ -153,7 +153,7 @@ def test_add_build_results_duplicate_channels(mocker: MockerFixture) -> None:
         _product: str,
         _res: Any,
         projects: set[str],
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> str:
         projects.add("chan")
         return "chan"
@@ -246,30 +246,21 @@ def test_add_comments_bot_comments_no_urls(mocker: MockerFixture, caplog: pytest
 
 @pytest.mark.usefixtures("mock_product_setup")
 @pytest.mark.parametrize(
-    ("arch", "verify_result", "expected_in_projects", "expected_log"),
+    ("arch", "verify_result", "expected_in_projects"),
     [
-        (
-            "ppc64le",
-            False,
-            False,
-            "Skipping SUSE:SLFO:1.2:PullRequest:2702:SLES:ppc64le: repository not found for architecture",
-        ),
-        ("x86_64", True, True, None),
-        ("aarch64", True, True, None),
+        ("ppc64le", False, False),
+        ("x86_64", True, True),
+        ("aarch64", True, True),
     ],
 )
 def test_add_build_result_channel_handling(
     mocker: MockerFixture,
-    caplog: pytest.LogCaptureFixture,
     *,
     arch: str,
     verify_result: bool,
     expected_in_projects: bool,
-    expected_log: str | None,
 ) -> None:
     """Verify channel is handled based on verify_repo_exists result."""
-    if expected_log:
-        caplog.set_level(logging.DEBUG, logger="bot.loader.gitea")
     mocker.patch("openqabot.loader.gitea.verify_repo_exists", return_value=verify_result)
 
     incident = {"number": 123}
@@ -279,8 +270,6 @@ def test_add_build_result_channel_handling(
         "arch": arch,
         "repository": "product",
     }
-    if arch == "aarch64":
-        base_data["state"] = "published"
     res.get.side_effect = lambda k: base_data.get(k, "")
     res.findall.return_value = []
 
@@ -289,8 +278,6 @@ def test_add_build_result_channel_handling(
 
     channel = f"SUSE:SLFO:1.2:PullRequest:2702:SLES:{arch}#16.0"
     assert (channel in results.projects) == expected_in_projects
-    if expected_log:
-        assert expected_log in caplog.text
 
 
 @pytest.mark.usefixtures("mock_repo_check_setup")
@@ -352,7 +339,7 @@ def test_verify_repo_exists_no_product_version(mocker: MockerFixture) -> None:
         ("", ""),
     ],
 )
-def test_verify_repo_exists_missing_urls(mocker: MockerFixture, download_base: str, obs_download: str) -> None:
+def test_verify_repo_exists_missing_urls(download_base: str, obs_download: str) -> None:
     """Verify verify_repo_exists returns True when configuration URLs are missing."""
     result = verify_repo_exists(
         "SUSE:SLFO:1.2:PullRequest:2702:SLES",
@@ -367,7 +354,7 @@ def test_verify_repo_exists_missing_urls(mocker: MockerFixture, download_base: s
     assert result is True
 
 
-def test_verify_repo_exists_invalid_obs_url(mocker: MockerFixture) -> None:
+def test_verify_repo_exists_invalid_obs_url() -> None:
     """Verify verify_repo_exists returns True when obs_download_url is invalid."""
     result = verify_repo_exists(
         "SUSE:SLFO:1.2:PullRequest:2702:SLES",

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -14,7 +14,7 @@ from pytest_mock import MockerFixture
 from openqabot.errors import NoRepoFoundError
 from openqabot.loader import gitea
 from openqabot.types.pullrequest import PullRequest
-from openqabot.utils import BuildTarget, RepoConfig
+from openqabot.types.gitea import BuildTarget, RepoConfig
 
 
 @pytest.fixture

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -74,7 +74,7 @@ def test_get_product_version_from_repo_listing_json_error(mocker: MockerFixture)
     mock_response = MagicMock()
     mock_response.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
     mocker.patch.object(gitea.retried_requests, "get", return_value=mock_response)
-    res = gitea.get_product_version_from_repo_listing("project", "product", "repo")
+    res = gitea.get_product_version_from_repo_listing("project", "product", "repo", "http://obs.url")
     assert not res
     assert mock_log.info.called
 
@@ -85,7 +85,7 @@ def test_get_product_version_from_repo_listing_http_error(mocker: MockerFixture)
     mock_response = MagicMock()
     mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("error")
     mocker.patch.object(gitea.retried_requests, "get", return_value=mock_response)
-    res = gitea.get_product_version_from_repo_listing("project", "product", "repo")
+    res = gitea.get_product_version_from_repo_listing("project", "product", "repo", "http://obs.url")
     assert not res
     assert mock_log.warning.called
 
@@ -96,7 +96,7 @@ def test_get_product_version_from_repo_listing_request_exception(
     gitea.get_product_version_from_repo_listing.cache_clear()
     caplog.set_level(logging.WARNING, logger="bot.loader.gitea")
     mocker.patch("openqabot.loader.gitea.retried_requests.get", side_effect=requests.RequestException("error"))
-    res = gitea.get_product_version_from_repo_listing("project", "product", "repo")
+    res = gitea.get_product_version_from_repo_listing("project", "product", "repo", "http://obs.url")
     assert not res
     assert "Product version unresolved" in caplog.text
 
@@ -132,7 +132,7 @@ def test_get_product_version_from_repo_listing_success(mocker: MockerFixture) ->
     # product name 'SLES', prefix 'SLES-'
     # _extract_version will be called with name 'SLES-15-SP4-x86_64' and prefix 'SLES-'
     # remainder '15-SP4-x86_64', next(...) returns '15'
-    res = gitea.get_product_version_from_repo_listing("project", "SLES", "repo")
+    res = gitea.get_product_version_from_repo_listing("project", "SLES", "repo", "http://obs.url")
     assert res == "15"
 
 
@@ -146,14 +146,24 @@ def test_get_product_version_from_repo_listing_requests_json_error(
     # but requests.exceptions.JSONDecodeError should work.
     mock_response.json.side_effect = requests.exceptions.JSONDecodeError("msg", "doc", 0)
     mocker.patch("openqabot.loader.gitea.retried_requests.get", return_value=mock_response)
-    res = gitea.get_product_version_from_repo_listing("project_json", "product_json", "repo_json")
+    res = gitea.get_product_version_from_repo_listing("project_json", "product_json", "repo_json", "http://obs.url")
     assert not res
     assert "Invalid JSON document" in caplog.text
 
 
 def test_add_channel_for_build_result_local() -> None:
     projects: set[str] = set()
-    res = gitea.add_channel_for_build_result("myproj", "local", "myprod", None, projects)
+    res = gitea.add_channel_for_build_result(
+        "myproj",
+        "local",
+        "myprod",
+        None,
+        projects,
+        repo_type="product",
+        download_base_url="http://base.url",
+        obs_download_url="http://obs.url",
+        obs_products={"all"},
+    )
     assert res == "myproj:local"
     assert len(projects) == 0
 

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -13,8 +13,9 @@ from pytest_mock import MockerFixture
 
 from openqabot.errors import NoRepoFoundError
 from openqabot.loader import gitea
+from openqabot.types.gitea import RepoConfig
 from openqabot.types.pullrequest import PullRequest
-from openqabot.types.gitea import BuildTarget, RepoConfig
+from openqabot.types.types import Repos
 
 
 @pytest.fixture
@@ -155,7 +156,7 @@ def test_get_product_version_from_repo_listing_requests_json_error(
 def test_add_channel_for_build_result_local() -> None:
     projects: set[str] = set()
     res = gitea.add_channel_for_build_result(
-        BuildTarget("myproj", "local", "myprod"),
+        Repos("myproj", "myprod", "local"),
         None,
         projects,
         config=RepoConfig(

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -213,13 +213,13 @@ def test_iter_gitea_items_throws_on_dict(mocker: MockerFixture) -> None:
 
 
 def test_read_json_file_list_success(mocker: MockerFixture) -> None:
-    mocker.patch("openqabot.loader.gitea.read_json_file", return_value=[{"id": 1}])
+    mocker.patch("openqabot.loader.gitea_utils.read_json_file", return_value=[{"id": 1}])
     res = gitea.read_json_file_list("some_file")
     assert res == [{"id": 1}]
 
 
 def test_read_json_file_list_throws_on_dict(mocker: MockerFixture) -> None:
-    mocker.patch("openqabot.loader.gitea.read_json_file", return_value={"message": "Not Found"})
+    mocker.patch("openqabot.loader.gitea_utils.read_json_file", return_value={"message": "Not Found"})
     with pytest.raises(TypeError, match="JSON response file 'some_file' returned dict instead of list"):
         gitea.read_json_file_list("some_file")
 

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -163,6 +163,7 @@ def test_add_channel_for_build_result_local() -> None:
             repo_type="product",
             download_base_url="http://base.url",
             obs_download_url="http://obs.url",
+            repo_mirror_host="obs.url",
             obs_products={"all"},
         ),
     )

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -14,6 +14,7 @@ from pytest_mock import MockerFixture
 from openqabot.errors import NoRepoFoundError
 from openqabot.loader import gitea
 from openqabot.types.pullrequest import PullRequest
+from openqabot.utils import BuildTarget, RepoConfig
 
 
 @pytest.fixture
@@ -154,15 +155,15 @@ def test_get_product_version_from_repo_listing_requests_json_error(
 def test_add_channel_for_build_result_local() -> None:
     projects: set[str] = set()
     res = gitea.add_channel_for_build_result(
-        "myproj",
-        "local",
-        "myprod",
+        BuildTarget("myproj", "local", "myprod"),
         None,
         projects,
-        repo_type="product",
-        download_base_url="http://base.url",
-        obs_download_url="http://obs.url",
-        obs_products={"all"},
+        config=RepoConfig(
+            repo_type="product",
+            download_base_url="http://base.url",
+            obs_download_url="http://obs.url",
+            obs_products={"all"},
+        ),
     )
     assert res == "myproj:local"
     assert len(projects) == 0


### PR DESCRIPTION
Motivation:
OBS returns state='published' with code='excluded' for packages on
architectures where no builds exist. This caused qem-bot to create
channels for unsupported architectures (e.g., ppc64le, s390x for
SLES 16.0), leading to openQA job failures when the repo subfolder
doesn't actually exist.

This change verifies that actual repository content exists via HTTP
requests before creating channel.

Design Choices:
- Added _verify_repo_exists() function that performs an HTTP HEAD
  request to check if the architecture-specific repo folder exists
- Check happens in add_channel_for_build_result() before adding to
  the projects set
- If HTTP returns 404, the channel is skipped
- Uses download.suse.de (replacing %REPO_MIRROR_HOST% placeholder)
  to check actual repo availability
- Fails open: if HTTP check fails for any reason, allow the channel

User Benefits:
- Prevents scheduling of tests on non-supported architectures
- Based on actual repo existence, not OBS package status
- Maintains backward compatibility for existing valid channels

For a specific example of SUSE internal PR "git:2702" a run of `qem-bot
gitea-sync` looks like this showing how channels for all architectures
are considered even the ones for which repository arch specific
subfolders are empty:

```
INFO  Loaded 1 active PRs from products/SLFO
DEBUG Fetching info for PR git:2702 from Gitea
DEBUG Checking OBS project SUSE:SLFO:1.2:PullRequest:2702
DEBUG Checking OBS project SUSE:SLFO:1.2:PullRequest:2702:SL-Micro
DEBUG Relevant archs for SUSE:SLFO:1.2:PullRequest:2702:SL-Micro: \
  ['aarch64', 'ppc64le', 's390x', 'x86_64']
DEBUG Checking OBS project SUSE:SLFO:1.2:PullRequest:2702:SLES
DEBUG Relevant archs for SUSE:SLFO:1.2:PullRequest:2702:SLES: \
  ['aarch64', 'ppc64le', 's390x', 'x86_64']
DEBUG Data for 1 submissions: [{'approved': True,
  'channels': ['SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:aarch64#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:ppc64le#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:s390x#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:x86_64#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:aarch64#16.0',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:ppc64le#16.0',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:s390x#16.0',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:x86_64#16.0'],
…
  'type': 'git',
  'url': 'https://src.suse.de/products/SLFO/pulls/2702'}]
INFO  Dry run: Would update QEM Dashboard data for 1 submissions
```

so also invalid channels like
SUSE:SLFO:1.2:PullRequest:2702:SLES:ppc64le#16.0 where the patch does
not exist are added.

With this commit repository folders are probed and channels adjusted
accordingly:

```
INFO  Loaded 1 active PRs from products/SLFO
DEBUG Fetching info for PR git:2702 from Gitea                                                                                                                             DEBUG Checking OBS project SUSE:SLFO:1.2:PullRequest:2702
DEBUG Checking OBS project SUSE:SLFO:1.2:PullRequest:2702:SL-Micro                                                                                                         DEBUG Relevant archs for SUSE:SLFO:1.2:PullRequest:2702:SL-Micro: \
  ['aarch64', 'ppc64le', 's390x', 'x86_64']
DEBUG Repo http://…/SL-Micro-6.2-x86_64/x86_64/ returned 200, allowing channel                                                                                             DEBUG Repo http://…/SL-Micro-6.2-aarch64/aarch64/ returned 200, allowing channel                                                                                           DEBUG Repo http://…-ppc64le/ppc64le/ not found (404), skipping channel
DEBUG Skipping …:SL-Micro:ppc64le: repository not found for architecture ppc64le
DEBUG Repo http://…-s390x/s390x/ not found (404), skipping channel                                                                                                         DEBUG Skipping …:SL-Micro:s390x: repository not found for architecture s390x
DEBUG Checking OBS project SUSE:SLFO:1.2:PullRequest:2702:SLES                                                                                                             DEBUG Relevant archs for SUSE:SLFO:1.2:PullRequest:2702:SLES: \
  ['aarch64', 'ppc64le', 's390x', 'x86_64']
DEBUG Repo http://…/SLES-16.0-aarch64/aarch64/ returned 200, allowing channel
DEBUG Repo http://…/SLES-16.0-ppc64le/ppc64le/ not found (404), skipping channel                                                                                           DEBUG Skipping …:SLES:ppc64le: repository not found for architecture ppc64le
DEBUG Repo http://…/SLES-16.0-s390x/s390x/ not found (404), skipping channel
DEBUG Skipping …:SLES:s390x: repository not found for architecture s390x                                                                                                   DEBUG Repo http://…/SLES-16.0-x86_64/x86_64/ returned 200, allowing channel
DEBUG Data for 1 submissions: [{'approved': True,
  'channels': ['SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:aarch64#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:x86_64#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:aarch64#16.0',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:x86_64#16.0'],
  'type': 'git',
  'url': 'https://src.suse.de/products/SLFO/pulls/2702'}]
INFO  Dry run: Would update QEM Dashboard data for 1 submissions
```

with the relevant part being

```
  'channels': ['SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:aarch64#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SL-Micro:x86_64#6.2',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:aarch64#16.0',
               'SUSE:SLFO:1.2:PullRequest:2702:SLES:x86_64#16.0'],
```

so only aarch64+x86_64 channels are included as expected.

Related progress issue: https://progress.opensuse.org/issues/197270