### PR TITLE
feat: post openQA test results on product increment requests

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -592,6 +592,7 @@ def increment_approve(  # noqa: PLR0913
             help="Use configuration from the specified YAML document instead of arguments",
         ),
     ] = None,
+    comment: comment_option = False,
 ) -> None:
     """Approve the most recent product increment for an OBS project if tests passed."""
     args = ctx.obj
@@ -610,6 +611,7 @@ def increment_approve(  # noqa: PLR0913
     args.build_regex = build_regex
     args.product_regex = product_regex
     args.increment_config = increment_config
+    args.comment = comment
 
     approve = IncrementApprover(args)
     sys.exit(approve())

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from logging import getLogger
 from pprint import pformat
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, urlparse
+from urllib.parse import urlencode, urlparse
 
 import osc.conf
 
@@ -17,14 +17,15 @@ from openqabot.errors import EmptyCommentError, NoResultsError
 from .loader import gitea
 from .loader.qem import get_aggregate_results, get_submission_results
 from .openqa import OpenQAInterface
-from .osclib.comments import CommentAPI
+from .osclib.comments import CommentAPI, add_marker, truncate
+from .types.increment import BuildIdentifier
 from .utils import extract_contact_from_description, normalize_results
 
 if TYPE_CHECKING:
     from argparse import Namespace
     from collections.abc import Callable, Sequence
 
-    from .types.pullrequest import GiteaPullRequestProtocol
+    from .types.pullrequest import CommentableProtocol
     from .types.submission import Submission
 
 log = getLogger("bot.commenter")
@@ -73,7 +74,7 @@ class Commenter:
         """Calculate overall state of jobs."""
         return "passed" if all(j["status"] in {"passed", "softfailed"} for j in jobs) else "failed"
 
-    def generate_comment(self, sub: GiteaPullRequestProtocol, jobs: list[dict[str, Any]]) -> tuple[str, str] | None:
+    def generate_comment(self, sub: CommentableProtocol, jobs: list[dict[str, Any]]) -> tuple[str, str] | None:
         """Generate comment message and state for a set of jobs."""
         if not jobs:
             log.debug("No jobs found for submission %s", sub)
@@ -93,25 +94,25 @@ class Commenter:
         state = self.calculate_state(jobs)
         log.debug("Determined comment state for %s: %s", sub, state)
 
-        msg = self.summarize_message(jobs)
+        builds = {BuildIdentifier.from_job(j) for j in jobs if "build" in j}
+        msg = self.summarize_message(builds, jobs)
         if not msg:
             raise EmptyCommentError(sub)
 
         return msg, state
 
-    def osc_comment(self, sub: Submission, msg: str, state: str) -> None:
-        """Comment a submission in OBS."""
+    def osc_comment_on_request(
+        self, request_id: str, msg: str, state: str, revisions: dict[str, Any] | None = None
+    ) -> None:
+        """Comment on an OBS request."""
         osc.conf.get_config(override_apiurl=config.settings.obs_url)
-        if sub.rr is None:
-            log.debug("Comment skipped for submission %s: No release request defined", sub)
-            return
-
         bot_name = "openqa"
         info: dict[str, Any] = {"state": state}
-        info.update({f"revision_{k.version}_{k.arch}": v for k, v in sub.revisions.items()}) if sub.revisions else None
+        if revisions:
+            info.update(revisions)
 
-        msg = self.commentapi.truncate(self.commentapi.add_marker(msg, bot_name, info).strip())
-        comments = self.commentapi.get_comments(request_id=str(sub.rr))
+        msg = truncate(add_marker(msg, bot_name, info).strip())
+        comments = self.commentapi.get_comments(request_id=request_id)
         comment, _ = self.commentapi.comment_find(comments, bot_name, info)
 
         # To prevent spam, assume same state/result
@@ -132,12 +133,21 @@ class Commenter:
             log.info("Dry run: Would delete comment %s", comment["id"])
 
         if not self.dry:
-            self.commentapi.add_comment(comment=msg, request_id=str(sub.rr))
+            self.commentapi.add_comment(comment=msg, request_id=request_id)
         else:
-            log.info("Dry run: Would write comment to request %s", sub)
+            log.info("Dry run: Would write comment to request %s", request_id)
             log.debug(pformat(msg))
 
-    def gitea_comment(self, sub: GiteaPullRequestProtocol, msg: str, state: str) -> None:
+    def osc_comment(self, sub: Submission, msg: str, state: str) -> None:
+        """Comment a submission in OBS."""
+        if sub.rr is None:
+            log.debug("Comment skipped for submission %s: No release request defined", sub)
+            return
+
+        revisions = {f"revision_{k.version}_{k.arch}": v for k, v in sub.revisions.items()} if sub.revisions else None
+        self.osc_comment_on_request(str(sub.rr), msg, state, revisions=revisions)
+
+    def gitea_comment(self, sub: CommentableProtocol, msg: str, state: str) -> None:
         """Comment a submission in Gitea."""
         if not self.gitea_token:
             log.warning("Gitea token missing, skipping comment for %s", sub)
@@ -152,7 +162,7 @@ class Commenter:
         repo = "/".join(urlparse(sub.url).path.strip("/").split("/")[:2])
 
         # Add a marker so we can find our own comments later
-        msg = self.commentapi.add_marker(msg, "openqa", {"state": state})
+        msg = add_marker(msg, "openqa", {"state": state})
 
         comments = gitea.get_json_list(gitea.comments_url(repo, sub.id), self.gitea_token)
         formatted = {str(c["id"]): {"id": c["id"], "comment": c["body"]} for c in comments}
@@ -176,16 +186,9 @@ class Commenter:
         else:
             gitea.patch_json(f"repos/{repo}/issues/comments/{comment['id']}", self.gitea_token, {"body": msg})
 
-    def summarize_message(self, jobs: list[dict[str, Any]]) -> str:
+    def summarize_message(self, builds: set[BuildIdentifier], jobs: list[dict[str, Any]]) -> str:
         """Create markdown containing openQA badges."""
-        base_url = self.client.openqa.baseurl
-        builds = sorted({j["build"] for j in jobs if "build" in j})
-        suffix = "" if config.settings.allow_development_groups else "&not_group_glob=*Devel*%2C*Test*"
-        badge_msg = "".join(
-            f"[![Test Results]({base_url}/tests/overview/badge?build={b}{suffix})]"
-            f"({base_url}/tests/overview?build={b}{suffix})\n"
-            for b in builds
-        ).strip()
+        badge_msg = self._generate_badge_section(builds)
 
         if not config.settings.enable_detailed_comments:
             return badge_msg
@@ -194,11 +197,36 @@ class Commenter:
         if not job_groups:
             return badge_msg
 
+        return badge_msg + "\n\n" + self._generate_detail_section(job_groups, sorted(builds))
+
+    def _generate_badge_section(self, builds: set[BuildIdentifier]) -> str:
+        """Generate markdown for openQA badges."""
+        base_url = self.client.openqa.baseurl
+        badge_msg = ""
+        for b in sorted(builds):
+            params = {"build": b.build}
+            if b.distri:
+                params["distri"] = b.distri
+            if b.version:
+                params["version"] = b.version
+            if not config.settings.allow_development_groups:
+                params["not_group_glob"] = "*Devel*,*Test*"
+
+            query = urlencode(params, safe="*")
+            badge_url = f"{base_url}/tests/overview/badge?{query}"
+            link_url = f"{base_url}/tests/overview?{query}"
+            badge_msg += f"[![Test Results]({badge_url})]({link_url})\n"
+        return badge_msg.strip()
+
+    def _generate_detail_section(self, job_groups: list[dict[str, Any]], sorted_builds: list[BuildIdentifier]) -> str:
+        """Generate markdown for detailed failure information."""
         max_entries = config.settings.max_detailed_comment_entries
         display_groups = job_groups[:max_entries]
         excluded_count = len(job_groups) - max_entries
 
         fallback = config.settings.fallback_contact
+        base_url = self.client.openqa.baseurl
+
         table_rows = [
             f"| {g['name']}: [![openQA Test Results]({g['badge_url']})]({g['overview_url']}) | "
             f"{g['contact'] or f'No contact provided: {fallback}'} |"
@@ -209,20 +237,27 @@ class Commenter:
         detail_msg += "\n".join(table_rows)
 
         if excluded_count > 0:
-            first_build = builds[0] if builds else ""
-            overview_link = f"{base_url}/tests/overview?build={first_build}{suffix}"
+            first_b = sorted_builds[0]
+            params = {"build": first_b.build}
+            if first_b.distri:
+                params["distri"] = first_b.distri
+            if first_b.version:
+                params["version"] = first_b.version
+            if not config.settings.allow_development_groups:
+                params["not_group_glob"] = "*Devel*,*Test*"
+
+            query = urlencode(params, safe="*")
+            overview_link = f"{base_url}/tests/overview?{query}"
             detail_msg += (
                 f"\n\n*... and {excluded_count} more job groups. See [Test Results]({overview_link}) for details.*"
             )
 
         detail_msg += f"\n\nFor generic tool issues, contact {config.settings.generic_tool_issues_contact}."
+        return detail_msg.strip()
 
-        return badge_msg + "\n\n" + detail_msg
-
-    def get_job_groups_with_failures(self, jobs: list[dict[str, Any]]) -> list[dict[str, str]]:
+    def get_job_groups_with_failures(self, jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Get job groups with blocking failures and their contact info."""
         base_url = self.client.openqa.baseurl
-        suffix = "" if config.settings.allow_development_groups else "&not_group_glob=*Devel*%2C*Test*"
 
         groups: dict[int, dict[str, Any]] = {}
         for job in jobs:
@@ -240,6 +275,8 @@ class Commenter:
                     "description": group_info.get("description") if group_info else None,
                     "contact": None,
                     "build": job.get("build", ""),
+                    "distri": job.get("distri", ""),
+                    "version": job.get("version", ""),
                     "status": status,
                 }
                 if group_info:
@@ -252,10 +289,23 @@ class Commenter:
                 "contact": g["contact"],
                 "build": g["build"],
                 "status": g["status"],
-                "overview_url": (
-                    u := f"{base_url}/tests/overview?build={g['build']}&group={quote(name, safe='')}{suffix}"
-                ),
-                "badge_url": u.replace("/tests/overview?", "/tests/overview/badge?"),
+                "overview_url": self._generate_overview_url(base_url, g, name),
+                "badge_url": self._generate_overview_url(base_url, g, name, badge=True),
             }
             for g in groups.values()
         ]
+
+    @staticmethod
+    def _generate_overview_url(base_url: str, group: dict[str, Any], group_name: str, *, badge: bool = False) -> str:
+        params = {"build": group["build"]}
+        if group["distri"]:
+            params["distri"] = group["distri"]
+        if group["version"]:
+            params["version"] = group["version"]
+        params["group"] = group_name
+        if not config.settings.allow_development_groups:
+            params["not_group_glob"] = "*Devel*,*Test*"
+
+        query = urlencode(params, safe="*")
+        path = "/tests/overview/badge" if badge else "/tests/overview"
+        return f"{base_url}{path}?{query}"

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -7,6 +7,8 @@ from logging import getLogger
 from pprint import pformat
 from typing import Any
 
+import requests
+from openqa_client.exceptions import RequestError
 from osc import conf
 
 from openqabot import config
@@ -129,9 +131,7 @@ class GiteaTrigger:
 
         try:
             jobs = self.openqa.get_jobs(data)
-            for j in jobs:
-                j.setdefault("build", build)
-        except Exception:
+        except (requests.exceptions.RequestException, RequestError):
             log.exception("Failed to fetch jobs for PR %s", pullrequest.number)
             return
 

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -131,6 +131,8 @@ class GiteaTrigger:
 
         try:
             jobs = self.openqa.get_jobs(data)
+            for j in jobs:
+                j.setdefault("build", build)
         except (requests.exceptions.RequestException, RequestError):
             log.exception("Failed to fetch jobs for PR %s", pullrequest.number)
             return

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -99,7 +99,7 @@ class IncrementApprover:
     def _filter_jobs(self, jobs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
         """Filter jobs within a state, removing those in devel groups."""
         return {
-            name: {"job_ids": ids}
+            name: {**info, "job_ids": ids}
             for name, info in jobs.items()
             if (ids := [i for i in info["job_ids"] if not self.is_in_devel_group(i)])
         }
@@ -215,10 +215,7 @@ class IncrementApprover:
 
         if self.comment and approval_status.builds:
             state = "passed" if not reasons_to_disapprove else "failed"
-        if self.comment and approval_status.builds:
-            state = "passed" if not reasons_to_disapprove else "failed"
             msg = self.commenter.summarize_message(approval_status.builds, approval_status.jobs)
-            self.commenter.osc_comment_on_request(str(reqid), msg, state)
             self.commenter.osc_comment_on_request(str(reqid), msg, state)
 
         if not reasons_to_disapprove:

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -215,7 +215,10 @@ class IncrementApprover:
 
         if self.comment and approval_status.builds:
             state = "passed" if not reasons_to_disapprove else "failed"
+        if self.comment and approval_status.builds:
+            state = "passed" if not reasons_to_disapprove else "failed"
             msg = self.commenter.summarize_message(approval_status.builds, approval_status.jobs)
+            self.commenter.osc_comment_on_request(str(reqid), msg, state)
             self.commenter.osc_comment_on_request(str(reqid), msg, state)
 
         if not reasons_to_disapprove:

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -21,13 +21,14 @@ from openqabot.config import OBSOLETE_PARAMS
 from openqabot.openqa import OpenQAInterface
 from openqabot.pc_helper import apply_public_cloud_settings
 
+from .commenter import Commenter
 from .errors import AmbiguousApprovalStatusError, PostOpenQAError
 from .loader.buildinfo import load_build_info
-from .loader.incrementconfig import IncrementConfig
+from .loader.incrementconfig import IncrementConfig, from_args
 from .loader.sourcereport import compute_packages_of_request_from_source_report
 from .repodiff import Package, RepoDiff
 from .requests import find_request_on_obs
-from .types.increment import ApprovalStatus, BuildInfo
+from .types.increment import ApprovalStatus, BuildIdentifier, BuildInfo
 from .utils import merge_dicts, unique_dicts
 
 if TYPE_CHECKING:
@@ -53,7 +54,10 @@ class IncrementApprover:
         self.requests_to_approve = {}
         # safeguard us from using same job ID for 2 requests
         self.unique_jobid_request_pair = {}
-        self.config = IncrementConfig.from_args(args)
+        self.config = from_args(args)
+        self.comment = getattr(args, "comment", False)
+
+        self.commenter = Commenter(args, submissions=[])
         osc.conf.get_config(override_apiurl=config.settings.obs_url)
 
     def check_unique_jobid_request_pair(self, jobids: list[int], request: osc.core.Request) -> None:
@@ -144,32 +148,49 @@ class IncrementApprover:
         return self.client.is_in_devel_group(job) if job else False
 
     def evaluate_openqa_job_results(
-        self, results: OpenQAResult, ok_jobs: set[int], not_ok_jobs: dict[str, set[str]], request: osc.core.Request
+        self,
+        results: OpenQAResult,
+        ok_jobs: set[int],
+        not_ok_jobs: dict[str, set[str]],
+        jobs: list[dict[str, Any]],
+        request: osc.core.Request,
     ) -> None:
         """Evaluate openQA job results and sort them into ok and not_ok sets."""
         all_items = chain.from_iterable(results.get(s, {}).items() for s in final_states)
         for result, info in all_items:
             # Filtering is now done upfront in process_build_info
             job_ids = info["job_ids"]
+            jobs.extend(
+                {
+                    "id": job_id,
+                    "status": result,
+                    "group_id": info.get("group_id"),
+                    "build": info.get("build"),
+                    "distri": info.get("distri"),
+                    "version": info.get("version"),
+                }
+                for job_id in job_ids
+            )
             destination = ok_jobs if result in ok_results else not_ok_jobs[result]
             self.check_unique_jobid_request_pair(job_ids, request)
             destination.update(job_ids)
 
     def evaluate_list_of_openqa_job_results(
         self, list_of_results: OpenQAResults, request: osc.core.Request
-    ) -> tuple[set[int], list[str]]:
+    ) -> tuple[set[int], list[str], list[dict[str, Any]]]:
         """Evaluate a list of openQA job results."""
         ok_jobs = set()  # keep track of ok jobs
         not_ok_jobs = defaultdict(set)  # keep track of not ok jobs
+        jobs: list[dict[str, Any]] = []
         openqa_url = self.client.url.geturl()
         for results in list_of_results:
-            self.evaluate_openqa_job_results(results, ok_jobs, not_ok_jobs, request)
+            self.evaluate_openqa_job_results(results, ok_jobs, not_ok_jobs, jobs, request)
         reasons_to_disapprove = [
             f"The following openQA jobs ended up with result '{result}':\n"
             + "\n".join(f" - {openqa_url}/tests/{i}" for i in job_ids)
             for result, job_ids in not_ok_jobs.items()
         ]
-        return (ok_jobs, reasons_to_disapprove)
+        return (ok_jobs, reasons_to_disapprove, jobs)
 
     def approve_on_obs(self, reqid: str, msg: str) -> None:
         """Change the review state of a request on OBS to accepted."""
@@ -189,10 +210,15 @@ class IncrementApprover:
         reqid = approval_status.request.reqid
         id_msg = f"OBS request {config.settings.obs_web_url}/request/show/{reqid}"
 
-        if len(reasons_to_disapprove) == 0 and len(approval_status.ok_jobs) == 0:
+        if not reasons_to_disapprove and not approval_status.ok_jobs:
             reasons_to_disapprove.append("No openQA jobs were found/checked for this request.")
 
-        if len(reasons_to_disapprove) == 0:
+        if self.comment and approval_status.builds:
+            state = "passed" if not reasons_to_disapprove else "failed"
+            msg = self.commenter.summarize_message(approval_status.builds, approval_status.jobs)
+            self.commenter.osc_comment_on_request(str(reqid), msg, state)
+
+        if not reasons_to_disapprove:
             results_str = "/".join(sorted(ok_results))
             message = f"All {len(approval_status.ok_jobs)} openQA jobs have {results_str}"
             self.approve_on_obs(str(reqid), message)
@@ -461,7 +487,9 @@ class IncrementApprover:
 
         openqa_jobs_ready = self.check_openqa_jobs(res, build_info, params)
         if openqa_jobs_ready:
-            approval_status.add(*(self.evaluate_list_of_openqa_job_results(res, request)))
+            ok_jobs, reasons, jobs = self.evaluate_list_of_openqa_job_results(res, request)
+            builds = {BuildIdentifier.from_params(p) for p in params if "BUILD" in p}
+            approval_status.add(ok_jobs, reasons, builds, jobs)
             return 0
 
         return self._handle_not_ready_jobs(
@@ -474,7 +502,7 @@ class IncrementApprover:
         if request_id in self.requests_to_approve:
             return self.requests_to_approve[request_id]
 
-        status = ApprovalStatus(request, set(), [], set())
+        status = ApprovalStatus(request, set(), [], set(), set(), [])
         self.requests_to_approve[request_id] = status
         return status
 

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from itertools import chain
 from logging import getLogger
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import osc.conf
 import osc.core
@@ -24,7 +24,7 @@ from openqabot.pc_helper import apply_public_cloud_settings
 from .commenter import Commenter
 from .errors import AmbiguousApprovalStatusError, PostOpenQAError
 from .loader.buildinfo import load_build_info
-from .loader.incrementconfig import IncrementConfig, from_args
+from .loader.incrementconfig import IncrementConfig
 from .loader.sourcereport import compute_packages_of_request_from_source_report
 from .repodiff import Package, RepoDiff
 from .requests import find_request_on_obs
@@ -44,7 +44,13 @@ ScheduleParams = list[dict[str, str]]
 
 
 class IncrementApprover:
-    """Logic for approving product increments."""
+    """Logic for approving product increments.
+
+    This class handles the verification of product increment requests on OBS/IBS.
+    It fetches test results from openQA based on scheduling parameters,
+    filters out development jobs, and decides whether to approve or
+    disapprove the request.
+    """
 
     def __init__(self, args: Namespace) -> None:
         """Initialize the IncrementApprover class."""
@@ -54,7 +60,7 @@ class IncrementApprover:
         self.requests_to_approve = {}
         # safeguard us from using same job ID for 2 requests
         self.unique_jobid_request_pair = {}
-        self.config = from_args(args)
+        self.config = IncrementConfig.from_args(args)
         self.comment = getattr(args, "comment", False)
 
         self.commenter = Commenter(args, submissions=[])
@@ -104,13 +110,9 @@ class IncrementApprover:
             if (ids := [i for i in info["job_ids"] if not self.is_in_devel_group(i)])
         }
 
-    def _filter_result(self, res: OpenQAResult) -> OpenQAResult:
-        """Filter a single OpenQAResult by state and job groups."""
-        return {state: filtered for state, jobs in res.items() if (filtered := self._filter_jobs(jobs))}
-
     def _filter_results(self, results: OpenQAResults) -> OpenQAResults:
         """Remove jobs belonging to development groups from openQA results."""
-        return [self._filter_result(res) for res in results]
+        return [{s: f for s, j in res.items() if (f := self._filter_jobs(j))} for res in results]
 
     def request_openqa_job_results(self, params: ScheduleParams, info_str: str) -> OpenQAResults:
         """Fetch results from openQA for the specified scheduling parameters."""
@@ -156,24 +158,12 @@ class IncrementApprover:
         request: osc.core.Request,
     ) -> None:
         """Evaluate openQA job results and sort them into ok and not_ok sets."""
-        all_items = chain.from_iterable(results.get(s, {}).items() for s in final_states)
-        for result, info in all_items:
-            # Filtering is now done upfront in process_build_info
-            job_ids = info["job_ids"]
-            jobs.extend(
-                {
-                    "id": job_id,
-                    "status": result,
-                    "group_id": info.get("group_id"),
-                    "build": info.get("build"),
-                    "distri": info.get("distri"),
-                    "version": info.get("version"),
-                }
-                for job_id in job_ids
-            )
-            destination = ok_jobs if result in ok_results else not_ok_jobs[result]
-            self.check_unique_jobid_request_pair(job_ids, request)
-            destination.update(job_ids)
+        for result, info in chain.from_iterable(results.get(s, {}).items() for s in final_states):
+            ids = info["job_ids"]
+            common = {k: info.get(k) for k in ("group_id", "build", "distri", "version")}
+            jobs.extend({**common, "id": j, "status": result} for j in ids)
+            (ok_jobs if result in ok_results else not_ok_jobs[result]).update(ids)
+            self.check_unique_jobid_request_pair(ids, request)
 
     def evaluate_list_of_openqa_job_results(
         self, list_of_results: OpenQAResults, request: osc.core.Request
@@ -253,7 +243,7 @@ class IncrementApprover:
             extra_params["KERNEL_VERSION"] = kernel_version
 
         extra_params["BUILD"] = "-".join(extra_build)
-        extra_params.update(cast("dict[str, str]", additional_build["settings"]))
+        extra_params.update(additional_build["settings"])
         return extra_params
 
     def _match_package_name_and_version(self, package: Package, additional_build: dict[str, Any]) -> re.Match | None:

--- a/openqabot/osclib/comments.py
+++ b/openqabot/osclib/comments.py
@@ -28,6 +28,51 @@ def comment_as_dict(comment_element: etree.Element) -> dict[str, Any]:
     }
 
 
+def add_marker(comment: str, bot: str, info: dict[str, Any] | None = None) -> str:
+    """Add bot marker to comment that can be used to find comment."""
+    info_str = ""
+    if info:
+        infos = ["=".join((str(key), str(value))) for key, value in info.items()]
+        info_str = " " + " ".join(infos)
+
+    marker = f"<!-- {bot}{info_str} -->"
+    return marker + "\n\n" + comment
+
+
+def truncate(comment: str, suffix: str = "...", length: int = 65535) -> str:
+    """Truncate a comment to a specific length, preserving markdown pre tags."""
+    # Handle very short length by dropping suffix and just chopping comment.
+    if length <= len(suffix) + len("\n</pre>"):
+        return comment[:length]
+    if len(comment) <= length:
+        return comment
+
+    # Determine the point at which to end by leaving room for suffix.
+    end = length - len(suffix)
+    if comment.find("<pre>", 0, end) != -1:
+        # For the sake of simplicity leave space for closing pre tag even if
+        # after truncation it may no longer be necessary. Otherwise, it
+        # requires recursion with some fun edge cases.
+        end -= len("\n</pre>")
+
+    # Check for the end location landing inside a pre tag and correct by
+    # moving in front of the tag. Landing on the ends is a noop.
+    pre_index = max(
+        comment.rfind("<pre>", end - 4, end + 4),
+        comment.rfind("</pre>", end - 5, end + 5),
+    )
+    if pre_index != -1:
+        end = pre_index
+
+    comment = comment[:end]
+
+    # Check for unbalanced pre tag and add a closing tag.
+    if comment.count("<pre>") > comment.count("</pre>"):
+        suffix += "\n</pre>"
+
+    return comment + suffix
+
+
 class OscCommentsValueError(ValueError):
     """Raised when an invalid value is provided to OscComments."""
 
@@ -134,13 +179,7 @@ class CommentAPI:
     @staticmethod
     def add_marker(comment: str, bot: str, info: dict[str, Any] | None = None) -> str:
         """Add bot marker to comment that can be used to find comment."""
-        info_str = ""
-        if info:
-            infos = ["=".join((str(key), str(value))) for key, value in info.items()]
-            info_str = " " + " ".join(infos)
-
-        marker = f"<!-- {bot}{info_str} -->"
-        return marker + "\n\n" + comment
+        return add_marker(comment, bot, info)
 
     def add_comment(
         self,
@@ -170,36 +209,7 @@ class CommentAPI:
     @staticmethod
     def truncate(comment: str, suffix: str = "...", length: int = 65535) -> str:
         """Truncate a comment to a specific length, preserving markdown pre tags."""
-        # Handle very short length by dropping suffix and just chopping comment.
-        if length <= len(suffix) + len("\n</pre>"):
-            return comment[:length]
-        if len(comment) <= length:
-            return comment
-
-        # Determine the point at which to end by leaving room for suffix.
-        end = length - len(suffix)
-        if comment.find("<pre>", 0, end) != -1:
-            # For the sake of simplicity leave space for closing pre tag even if
-            # after truncation it may no longer be necessary. Otherwise, it
-            # requires recursion with some fun edge cases.
-            end -= len("\n</pre>")
-
-        # Check for the end location landing inside a pre tag and correct by
-        # moving in front of the tag. Landing on the ends is a noop.
-        pre_index = max(
-            comment.rfind("<pre>", end - 4, end + 4),
-            comment.rfind("</pre>", end - 5, end + 5),
-        )
-        if pre_index != -1:
-            end = pre_index
-
-        comment = comment[:end]
-
-        # Check for unbalanced pre tag and add a closing tag.
-        if comment.count("<pre>") > comment.count("</pre>"):
-            suffix += "\n</pre>"
-
-        return comment + suffix
+        return truncate(comment, suffix, length)
 
     def delete(self, comment_id: str | int) -> None:
         """Remove a comment object.

--- a/openqabot/types/increment.py
+++ b/openqabot/types/increment.py
@@ -5,12 +5,30 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 if TYPE_CHECKING:
     import osc.core
 
 log = getLogger("bot.increment_approver")
+
+
+class BuildIdentifier(NamedTuple):
+    """Identifier for a build."""
+
+    build: str
+    distri: str
+    version: str
+
+    @classmethod
+    def from_job(cls, job: dict[str, Any]) -> BuildIdentifier:
+        """Create a BuildIdentifier from an openQA job dictionary."""
+        return cls(job["build"], job.get("distri", ""), job.get("version", ""))
+
+    @classmethod
+    def from_params(cls, params: dict[str, str]) -> BuildIdentifier:
+        """Create a BuildIdentifier from scheduling parameters."""
+        return cls(params["BUILD"], params["DISTRI"], params["VERSION"])
 
 
 class BuildInfo(NamedTuple):
@@ -64,8 +82,18 @@ class ApprovalStatus(NamedTuple):
     ok_jobs: set[int]
     reasons_to_disapprove: list[str]
     processed_jobs: set[tuple[str, str, str, str, str, str]]
+    builds: set[BuildIdentifier]
+    jobs: list[dict[str, Any]]
 
-    def add(self, ok_jobs: set[int], reasons_to_disapprove: list[str]) -> None:
+    def add(
+        self,
+        ok_jobs: set[int],
+        reasons_to_disapprove: list[str],
+        builds: set[BuildIdentifier],
+        jobs: list[dict[str, Any]],
+    ) -> None:
         """Add jobs and reasons to the status."""
         self.ok_jobs.update(ok_jobs)
         self.reasons_to_disapprove.extend(reasons_to_disapprove)
+        self.builds.update(builds)
+        self.jobs.extend(jobs)

--- a/openqabot/types/pullrequest.py
+++ b/openqabot/types/pullrequest.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 
-class GiteaPullRequestProtocol(Protocol):
-    """Protocol for objects representing a Gitea pull request."""
+class CommentableProtocol(Protocol):
+    """Protocol for objects representing a commentable entity."""
 
     @property
     def id(self) -> int:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 from unittest.mock import MagicMock, patch
-from urllib.parse import urlparse
 
 import osc.core
 
@@ -224,7 +223,6 @@ def prepare_approver(
         dry=False,
         token="not-secret",
         gitea_token=None,
-        openqa_instance=urlparse("http://openqa-instance"),
         accepted=True,
         request_id=request_id,
         project_base="OBS:PROJECT",
@@ -346,7 +344,6 @@ def make_approver_args(**kwargs: Any) -> Namespace:
         "gitea_token": None,
         "token": "dummy_token",
         "dry": False,
-        "openqa_instance": urlparse("http://openqa.example.com"),
         "all_submissions": False,
     }
     defaults.update(kwargs)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -223,6 +223,8 @@ def prepare_approver(
     args = Namespace(
         dry=False,
         token="not-secret",
+        gitea_token=None,
+        openqa_instance=urlparse("http://openqa-instance"),
         accepted=True,
         request_id=request_id,
         project_base="OBS:PROJECT",

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -90,6 +90,10 @@ def commenter_setup(mocker: MockerFixture) -> dict[str, MagicMock]:
     mocker.patch("openqabot.commenter.osc.conf.get_config")
     mock_comment_api = mocker.patch("openqabot.commenter.CommentAPI")
     mock_gitea = mocker.patch("openqabot.commenter.gitea")
+    mocker.patch(
+        "openqabot.commenter.add_marker", side_effect=lambda comment, bot, _info=None: f"<!-- {bot} -->\n\n{comment}"
+    )
+    mocker.patch("openqabot.commenter.truncate", side_effect=lambda comment, **_kwargs: comment)
 
     # Common Gitea mock setup
     mock_gitea.make_token_header.return_value = {"Authorization": "token gitea_token"}
@@ -670,10 +674,11 @@ def detailed_comment_mocks(
 
 
 @pytest.mark.parametrize(
-    ("enabled", "jobs", "group_info", "expected_contains", "expected_not_contains"),
+    ("enabled", "allow_devel", "jobs", "group_info", "expected_contains", "expected_not_contains"),
     [
         pytest.param(
             False,
+            None,
             [{"build": "1.1", "status": "failed", "group_id": 42}],
             {"id": 42, "name": "Functional", "description": "Responsible: qe@test.com"},
             [],
@@ -682,6 +687,7 @@ def detailed_comment_mocks(
         ),
         pytest.param(
             True,
+            None,
             [{"build": "1.1", "status": "passed", "group_id": 42}],
             {"id": 42, "name": "Functional", "description": "Responsible: qe@test.com"},
             [],
@@ -690,6 +696,7 @@ def detailed_comment_mocks(
         ),
         pytest.param(
             True,
+            None,
             [
                 {"build": "1.1", "status": "failed", "group_id": 42},
                 {"build": "1.1", "status": "passed", "group_id": 42},
@@ -701,6 +708,16 @@ def detailed_comment_mocks(
         ),
         pytest.param(
             True,
+            "1",
+            [{"build": "1.1", "status": "failed", "group_id": 42}],
+            {"id": 42, "name": "Functional", "description": "Responsible: qe-functional@example.com"},
+            ["Functional"],
+            ["not_group_glob"],
+            id="enabled_allow_devel",
+        ),
+        pytest.param(
+            True,
+            None,
             [{"build": "1.1", "status": "failed", "group_id": 42}],
             {"id": 42, "name": "Functional", "description": "Responsible: qe-functional@example.com"},
             ["generic tool issues", "our cool qem-bot admins"],
@@ -709,6 +726,7 @@ def detailed_comment_mocks(
         ),
         pytest.param(
             True,
+            None,
             [{"build": "1.1", "status": "failed", "group_id": 42}],
             {"id": 42, "name": "Kernel", "description": "No contact info here"},
             ["Kernel", "No contact provided", "Contact openQA test maintainer"],
@@ -717,6 +735,7 @@ def detailed_comment_mocks(
         ),
         pytest.param(
             True,
+            None,
             [{"build": "1.1", "status": "failed", "group_id": 42}],
             None,
             ["Job Group with blocking failures", "Unknown", "No contact provided"],
@@ -725,6 +744,7 @@ def detailed_comment_mocks(
         ),
         pytest.param(
             True,
+            None,
             [{"build": "1.1", "status": "failed"}],
             {"id": 42, "name": "Functional", "description": "Responsible: qe@test.com"},
             [],
@@ -733,11 +753,21 @@ def detailed_comment_mocks(
         ),
         pytest.param(
             True,
+            "1",
+            [{"build": "1.1", "distri": "sle", "version": "15", "status": "failed", "group_id": i} for i in range(10)],
+            {"id": 0, "name": "Group", "description": "Responsible: qe@test.com"},
+            ["... and 2 more job groups", "distri=sle", "version=15"],
+            ["not_group_glob"],
+            id="exceeds_max_entries_allow_devel",
+        ),
+        pytest.param(
+            True,
+            None,
             [{"build": "1.1", "status": "failed", "group_id": i} for i in range(10)],
             {"id": 0, "name": "Group", "description": "Responsible: qe@test.com"},
-            ["... and 2 more job groups"],
-            [],
-            id="exceeds_max_entries",
+            ["... and 2 more job groups", "not_group_glob"],
+            ["distri=", "version="],
+            id="exceeds_max_entries_no_distri_version",
         ),
     ],
 )
@@ -747,6 +777,7 @@ def test_summarize_message_detailed_comments(
     detailed_comment_mocks: dict[str, MagicMock],
     mocker: MockerFixture,
     enabled: bool,  # noqa: FBT001
+    allow_devel: str | None,
     jobs: list[dict],
     group_info: dict | None,
     expected_contains: list[str],
@@ -754,9 +785,11 @@ def test_summarize_message_detailed_comments(
 ) -> None:
     """Test summarize_message with detailed comments in various scenarios."""
     mocker.patch("openqabot.config.settings.enable_detailed_comments", new=enabled)
+    mocker.patch("openqabot.config.settings.allow_development_groups", new=allow_devel)
     detailed_comment_mocks["client"].return_value.get_job_group_info.return_value = group_info
     c = Commenter(mock_args, submissions=[])
-    result = c.summarize_message(jobs)
+    builds = {BuildIdentifier.from_job(j) for j in jobs if "build" in j}
+    result = c.summarize_message(builds, jobs)
     for text in expected_contains:
         assert text in result
     for text in expected_not_contains:
@@ -779,6 +812,7 @@ def test_summarize_message_detailed_comments_duplicate_group(
         {"build": "1.1", "status": "failed", "group_id": 42},
         {"build": "1.1", "status": "failed", "group_id": 42},
     ]
-    result = c.summarize_message(jobs)
+    builds = {BuildIdentifier.from_job(j) for j in jobs if "build" in j}
+    result = c.summarize_message(builds, jobs)
     assert "Functional" in result
     assert result.count("| Functional:") == 1

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -13,6 +13,7 @@ import pytest
 
 from openqabot.commenter import Commenter
 from openqabot.errors import EmptyCommentError, NoResultsError
+from openqabot.types.increment import BuildIdentifier
 from openqabot.types.submission import Submission
 from openqabot.types.types import ArchVer
 
@@ -334,8 +335,8 @@ def test_summarize_message(
     commenter_setup["client"].return_value.openqa.baseurl = "https://openqa.opensuse.org"
     mocker.patch("openqabot.config.settings.allow_development_groups", new=None)
     c = Commenter(mock_args, submissions=[])
-    jobs = [{"build": "1.1", "distri": "sle", "version": "15"}, {"build": "1.2"}]
-    result = c.summarize_message(jobs)
+    builds = [BuildIdentifier("1.1", "sle", "15"), BuildIdentifier("1.2", "", "")]
+    result = c.summarize_message(set(builds), [])
     suffix = "&not_group_glob=*Devel*%2C*Test*"
     assert (
         f"[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1{suffix}&distri=sle&version=15)](https://openqa.opensuse.org/tests/overview?build=1.1{suffix}&distri=sle&version=15)"
@@ -356,8 +357,8 @@ def test_summarize_message_allow_devel(
     commenter_setup["client"].return_value.openqa.baseurl = "https://openqa.opensuse.org"
     mocker.patch("openqabot.config.settings.allow_development_groups", new="1")
     c = Commenter(mock_args, submissions=[])
-    jobs = [{"build": "1.1", "distri": "opensuse", "version": "Tumbleweed"}]
-    result = c.summarize_message(jobs)
+    builds = [BuildIdentifier("1.1", "opensuse", "Tumbleweed")]
+    result = c.summarize_message({builds[0]}, [])
     assert "not_group_glob" not in result
     assert (
         "[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=opensuse&version=Tumbleweed)](https://openqa.opensuse.org/tests/overview?build=1.1&distri=opensuse&version=Tumbleweed)"

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -334,11 +334,11 @@ def test_summarize_message(
     commenter_setup["client"].return_value.openqa.baseurl = "https://openqa.opensuse.org"
     mocker.patch("openqabot.config.settings.allow_development_groups", new=None)
     c = Commenter(mock_args, submissions=[])
-    jobs = [{"build": "1.1"}, {"build": "1.2"}]
+    jobs = [{"build": "1.1", "distri": "sle", "version": "15"}, {"build": "1.2"}]
     result = c.summarize_message(jobs)
     suffix = "&not_group_glob=*Devel*%2C*Test*"
     assert (
-        f"[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1{suffix})](https://openqa.opensuse.org/tests/overview?build=1.1{suffix})"
+        f"[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1{suffix}&distri=sle&version=15)](https://openqa.opensuse.org/tests/overview?build=1.1{suffix}&distri=sle&version=15)"
         in result
     )
     assert (
@@ -356,11 +356,11 @@ def test_summarize_message_allow_devel(
     commenter_setup["client"].return_value.openqa.baseurl = "https://openqa.opensuse.org"
     mocker.patch("openqabot.config.settings.allow_development_groups", new="1")
     c = Commenter(mock_args, submissions=[])
-    jobs = [{"build": "1.1"}]
+    jobs = [{"build": "1.1", "distri": "opensuse", "version": "Tumbleweed"}]
     result = c.summarize_message(jobs)
     assert "not_group_glob" not in result
     assert (
-        "[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1)](https://openqa.opensuse.org/tests/overview?build=1.1)"
+        "[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=opensuse&version=Tumbleweed)](https://openqa.opensuse.org/tests/overview?build=1.1&distri=opensuse&version=Tumbleweed)"
         in result
     )
 

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -339,7 +339,7 @@ def test_summarize_message(
     result = c.summarize_message(set(builds), [])
     suffix = "&not_group_glob=*Devel*%2C*Test*"
     assert (
-        f"[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1{suffix}&distri=sle&version=15)](https://openqa.opensuse.org/tests/overview?build=1.1{suffix}&distri=sle&version=15)"
+        "[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*)](https://openqa.opensuse.org/tests/overview?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*)"
         in result
     )
     assert (

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 from urllib.parse import urlparse
 
 import pytest
+import requests
 from pytest_mock import MockerFixture
 
 from openqabot.giteatrigger import GiteaTrigger
@@ -290,7 +291,7 @@ def test_comment_on_pr_no_jobs(trigger: GiteaTrigger) -> None:
 
 def test_comment_on_pr_exception(trigger: GiteaTrigger) -> None:
     """Tests comment_on_pr when fetching jobs fails."""
-    cast("MagicMock", trigger.openqa.get_jobs).side_effect = Exception("openQA Down")
+    cast("MagicMock", trigger.openqa.get_jobs).side_effect = requests.exceptions.RequestException("openQA Down")
 
     mock_pr = MagicMock(number=123)
     trigger.comment_on_pr(mock_pr, "product", "version", "arch", "build")

--- a/tests/test_incrementapprover_obs.py
+++ b/tests/test_incrementapprover_obs.py
@@ -8,14 +8,16 @@ import logging
 from argparse import Namespace
 from typing import TYPE_CHECKING
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import osc.core
 import pytest
 
 import responses
 from openqabot.config import BUILD_REGEX, OBS_GROUP, settings
-from openqabot.incrementapprover import ApprovalStatus, IncrementApprover
+from openqabot.incrementapprover import IncrementApprover
 from openqabot.requests import find_request_on_obs, get_obs_request_list
+from openqabot.types.increment import ApprovalStatus
 
 from .helpers import (
     ReviewState,
@@ -113,6 +115,9 @@ def testhandle_approval_dry(caplog: pytest.LogCaptureFixture, mocker: MockerFixt
     caplog.set_level(logging.INFO)
     args = Namespace(
         dry=True,
+        token="token",
+        gitea_token=None,
+        openqa_instance=urlparse("http://instance.qa"),
         accepted=True,
         request_id=None,
         project_base="BASE",
@@ -137,7 +142,7 @@ def testhandle_approval_dry(caplog: pytest.LogCaptureFixture, mocker: MockerFixt
         approver = IncrementApprover(args)
         req = mocker.Mock(spec=osc.core.Request)
         req.reqid = 123
-        status = ApprovalStatus(req, ok_jobs={1}, reasons_to_disapprove=[], processed_jobs=set())
+        status = ApprovalStatus(req, ok_jobs={1}, reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[])
         mock_osc_change = mocker.patch("osc.core.change_review_state")
 
         approver.handle_approval(status)
@@ -160,7 +165,7 @@ def testhandle_approval_no_jobs_safeguard(caplog: pytest.LogCaptureFixture, mock
     approver = prepare_approver(caplog)
     req = mocker.Mock(spec=osc.core.Request)
     req.reqid = 123
-    status = ApprovalStatus(req, ok_jobs=set(), reasons_to_disapprove=[], processed_jobs=set())
+    status = ApprovalStatus(req, ok_jobs=set(), reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[])
 
     approver.handle_approval(status)
     assert "No openQA jobs were found/checked for this request." in caplog.text

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -19,8 +19,8 @@ from pytest_mock import MockerFixture
 import responses
 from openqabot.errors import AmbiguousApprovalStatusError
 from openqabot.incrementapprover import IncrementApprover
-from openqabot.loader.incrementconfig import IncrementConfig
-from openqabot.types.increment import ApprovalStatus, BuildInfo
+from openqabot.loader.incrementconfig import IncrementConfig, from_config_file
+from openqabot.types.increment import ApprovalStatus, BuildIdentifier, BuildInfo
 
 from .helpers import (
     Action,
@@ -183,7 +183,7 @@ def test_scheduling_extra_livepatching_builds_with_no_openqa_jobs(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     path = Path("tests/fixtures/config-increment-approver/increment-definitions.yaml")
-    configs = IncrementConfig.from_config_file(path, load_defaults=False)
+    configs = from_config_file(path, load_defaults=False)
     (errors, jobs) = run_approver(
         mocker, caplog, schedule=True, diff_project_suffix="PUBLISH/product", config=next(configs)
     )
@@ -202,7 +202,7 @@ def test_scheduling_extra_livepatching_builds_based_on_source_report(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     path = Path("tests/fixtures/config-increment-approver/increment-definitions.yaml")
-    configs = IncrementConfig.from_config_file(path, load_defaults=False)
+    configs = from_config_file(path, load_defaults=False)
     mocker.patch("osc.core.get_repos_of_project", side_effect=fake_get_repos_of_project)
     mocker.patch("osc.core.get_binarylist", side_effect=fake_get_binarylist)
     mocker.patch("osc.core.get_binary_file", side_effect=fake_get_binary_file)
@@ -240,7 +240,7 @@ def test_evaluate_list_of_openqa_job_results(
         {"done": {"passed": {"job_ids": [1]}, "failed": {"job_ids": [2]}}},
         {"done": {"softfailed": {"job_ids": [3]}, "incomplete": {"job_ids": [4]}}},
     ]
-    ok_jobs, reasons = approver.evaluate_list_of_openqa_job_results(results, fake_osc_request)
+    ok_jobs, reasons, jobs = approver.evaluate_list_of_openqa_job_results(results, fake_osc_request)
     assert ok_jobs == {1, 3}
     assert any(f"result 'failed':\n - {fake_openqa_url}/tests/2" in r for r in reasons)
     assert any(f"result 'incomplete':\n - {fake_openqa_url}/tests/4" in r for r in reasons)
@@ -266,7 +266,9 @@ def test_check_unique_jobid_request_pair_ambiguity_found(
 
 def test_handle_approval_valid_request_id(caplog: pytest.LogCaptureFixture, fake_osc_request: osc.core.Request) -> None:
     approver = prepare_approver(caplog)
-    status = ApprovalStatus(fake_osc_request, ok_jobs={1, 2}, reasons_to_disapprove=[], processed_jobs=set())
+    status = ApprovalStatus(
+        fake_osc_request, ok_jobs={1, 2}, reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[]
+    )
     approver.handle_approval(status)
     assert (
         "Approving OBS request https://build.suse.de/request/show/42: All 2 openQA jobs have passed/softfailed"
@@ -277,7 +279,12 @@ def test_handle_approval_valid_request_id(caplog: pytest.LogCaptureFixture, fake
 def test_handle_approval_disapprove(caplog: pytest.LogCaptureFixture, fake_osc_request: osc.core.Request) -> None:
     approver = prepare_approver(caplog)
     status = ApprovalStatus(
-        fake_osc_request, ok_jobs=set(), reasons_to_disapprove=["failed jobs"], processed_jobs=set()
+        fake_osc_request,
+        ok_jobs=set(),
+        reasons_to_disapprove=["failed jobs"],
+        processed_jobs=set(),
+        builds=set(),
+        jobs=[],
     )
     approver.handle_approval(status)
     assert "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:" in caplog.text
@@ -587,3 +594,29 @@ def test_approval_if_running_jobs_are_in_development_group(
     # The request should be approved.
     assert "All 1 openQA jobs have passed/softfailed" in caplog.text
     mock_osc_approve.assert_called()
+
+
+def test_handle_approval_with_comment_flag(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_osc_request: osc.core.Request
+) -> None:
+    approver = prepare_approver(caplog)
+    approver.comment = True
+    approver.args.dry = False
+    mock_replace = mocker.patch.object(approver.commenter, "osc_comment_on_request")
+    mocker.patch.object(approver, "approve_on_obs")
+    status = ApprovalStatus(
+        fake_osc_request,
+        ok_jobs={1, 2},
+        reasons_to_disapprove=[],
+        processed_jobs=set(),
+        builds={BuildIdentifier("fake_build", "", "")},
+        jobs=[],
+    )
+
+    approver.handle_approval(status)
+
+    mock_replace.assert_called_once()
+    args = mock_replace.call_args[0]
+    assert args[0] == "42"
+    assert args[2] == "passed"
+    assert "fake_build" in args[1]

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -19,7 +19,7 @@ from pytest_mock import MockerFixture
 import responses
 from openqabot.errors import AmbiguousApprovalStatusError
 from openqabot.incrementapprover import IncrementApprover
-from openqabot.loader.incrementconfig import IncrementConfig, from_config_file
+from openqabot.loader.incrementconfig import IncrementConfig
 from openqabot.types.increment import ApprovalStatus, BuildIdentifier, BuildInfo
 
 from .helpers import (
@@ -183,7 +183,7 @@ def test_scheduling_extra_livepatching_builds_with_no_openqa_jobs(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     path = Path("tests/fixtures/config-increment-approver/increment-definitions.yaml")
-    configs = from_config_file(path, load_defaults=False)
+    configs = IncrementConfig.from_config_file(path, load_defaults=False)
     (errors, jobs) = run_approver(
         mocker, caplog, schedule=True, diff_project_suffix="PUBLISH/product", config=next(configs)
     )
@@ -202,7 +202,7 @@ def test_scheduling_extra_livepatching_builds_based_on_source_report(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     path = Path("tests/fixtures/config-increment-approver/increment-definitions.yaml")
-    configs = from_config_file(path, load_defaults=False)
+    configs = IncrementConfig.from_config_file(path, load_defaults=False)
     mocker.patch("osc.core.get_repos_of_project", side_effect=fake_get_repos_of_project)
     mocker.patch("osc.core.get_binarylist", side_effect=fake_get_binarylist)
     mocker.patch("osc.core.get_binary_file", side_effect=fake_get_binary_file)
@@ -326,6 +326,8 @@ def test_skipping_with_mismatching_package(mocker: MockerFixture, caplog: pytest
         approver = IncrementApprover(
             Namespace(
                 dry=True,
+                token="token",
+                gitea_token=None,
                 accepted=True,
                 request_id=None,
                 fake_data=True,

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -242,6 +242,7 @@ def test_evaluate_list_of_openqa_job_results(
     ]
     ok_jobs, reasons, jobs = approver.evaluate_list_of_openqa_job_results(results, fake_osc_request)
     assert ok_jobs == {1, 3}
+    assert len(jobs) == 4
     assert any(f"result 'failed':\n - {fake_openqa_url}/tests/2" in r for r in reasons)
     assert any(f"result 'incomplete':\n - {fake_openqa_url}/tests/4" in r for r in reasons)
 
@@ -269,6 +270,7 @@ def test_handle_approval_valid_request_id(caplog: pytest.LogCaptureFixture, fake
     status = ApprovalStatus(
         fake_osc_request, ok_jobs={1, 2}, reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[]
     )
+
     approver.handle_approval(status)
     assert (
         "Approving OBS request https://build.suse.de/request/show/42: All 2 openQA jobs have passed/softfailed"
@@ -286,6 +288,7 @@ def test_handle_approval_disapprove(caplog: pytest.LogCaptureFixture, fake_osc_r
         builds=set(),
         jobs=[],
     )
+
     approver.handle_approval(status)
     assert "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:" in caplog.text
     assert "failed jobs" in caplog.text
@@ -610,7 +613,7 @@ def test_handle_approval_with_comment_flag(
         reasons_to_disapprove=[],
         processed_jobs=set(),
         builds={BuildIdentifier("fake_build", "fake_distri", "fake_version")},
-        jobs=[],
+        jobs=[{"build": "fake_build", "distri": "fake_distri", "version": "fake_version", "status": "passed"}],
     )
 
     approver.handle_approval(status)

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -609,7 +609,7 @@ def test_handle_approval_with_comment_flag(
         ok_jobs={1, 2},
         reasons_to_disapprove=[],
         processed_jobs=set(),
-        builds={BuildIdentifier("fake_build", "", "")},
+        builds={BuildIdentifier("fake_build", "fake_distri", "fake_version")},
         jobs=[],
     )
 


### PR DESCRIPTION
Motivation
After adding comments to maintenance submissions and Gitea staging
PRs, we need to ensure that openQA test results are posted as comments
in product increment requests on OBS/IBS as well.

Design Choices
Extended `IncrementApprover` and `ApprovalStatus` to track
verified builds. Reused the general commenting logic from
`Commenter` by extracting `osc_comment_on_request`.
Added a `--comment` parameter to `increment-approve` CLI.

Benefits
Provides immediate feedback directly inside product increment
requests on OBS/IBS without needing to consult the qem-dashboard.

Related issue: https://progress.opensuse.org/issues/198287

Example dry-run:

```
Dry run: Would write comment to request 404363
Dry run: Comment content:
<!-- openqa state=failed -->

[![Test Results](https://openqa.suse.de/tests/overview/badge?build=205.35&not_group_glob=*Devel*%2C*Test*&distri=sle&version=16.0)](https://openqa.suse.de/tests/overview?build=205.35&not_group_glob=*Devel*%2C*Test*&distri=sle&version=16.0)
```

Before:
* #463