### PR TITLE
feat(incrementapprover): add PI- prefix to scheduled openQA jobs

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -231,7 +231,7 @@ class IncrementApprover:
             return None
 
         groups = package_name_match.groupdict()
-        extra_build = [build_info.build, additional_build["build_suffix"]]
+        extra_build = [f"PI-{build_info.build}", additional_build["build_suffix"]]
         extra_params: dict[str, str] = {}
 
         if kind := groups.get("kind"):
@@ -384,7 +384,7 @@ class IncrementApprover:
             "VERSION": build_info.version,
             "FLAVOR": build_info.flavor,
             "ARCH": build_info.arch,
-            "BUILD": build_info.build,
+            "BUILD": f"PI-{build_info.build}",
             "PRODUCT": build_info.product,
             "INCREMENT_REPO": config_inc.build_project_url(config.settings.download_base_url) + repo_sub_path,
             **OBSOLETE_PARAMS,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -319,13 +319,18 @@ def fake_openqa_responses_with_param_matching(
     additional_builds_json: dict, fake_openqa_url_job_stat: str
 ) -> list[responses.BaseResponse]:
     list_of_params = []
-    base_params = {"distri": "sle", "version": "16.0", "build": "139.1", "product": "SLES"}
+    base_params = {"distri": "sle", "version": "16.0", "build": "PI-139.1", "product": "SLES"}
     json_by_arch = {"aarch64": {}, "x86_64": {}, "s390x": {}, "ppc64le": {}}
     for flavor in ("Online-Increments", "Foo-Increments"):
         for arch, json in json_by_arch.items():
             list_of_params.append(({"arch": arch, "flavor": flavor}, json))
     list_of_params.append((
-        {"arch": "x86_64", "flavor": "Additional-Foo-Increments", "build": "139.1-additional-build", "product": "SLES"},
+        {
+            "arch": "x86_64",
+            "flavor": "Additional-Foo-Increments",
+            "build": "PI-139.1-additional-build",
+            "product": "SLES",
+        },
         additional_builds_json,
     ))
     return [

--- a/tests/test_incrementapprover_helpers.py
+++ b/tests/test_incrementapprover_helpers.py
@@ -67,7 +67,7 @@ def test_extra_builds_for_package_filtering(caplog: pytest.LogCaptureFixture) ->
     pkg2 = Package("kernel-livepatch-6.4.0-150600.10", "0", "20240101", "1.1", "x86_64")
     res = approver.extra_builds_for_package(pkg2, config, build_info)
     assert res is not None
-    assert res["BUILD"] == "1.1-test-build"
+    assert res["BUILD"] == "PI-1.1-test-build"
 
     # debuginfo package
     pkg3 = Package("kernel-livepatch-debuginfo", "0", "20240101", "1.1", "x86_64")

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -89,13 +89,13 @@ def test_skipping_with_no_openqa_jobs_verifying_that_expected_scheduled_products
 
     for arch in ("aarch64", "x86_64", "ppc64le", "s390x"):
         assert re.search(
-            f"Skipping approval.*no relevant jobs.*SLESv16.0.*139.1@{arch}.*Online-Increments", caplog.text
+            f"Skipping approval.*no relevant jobs.*SLESv16.0.*PI-139.1@{arch}.*Online-Increments", caplog.text
         )
     expected_log_message = R"Skipping approval.*no relevant jobs"
-    expected_log_message += ".*SLESv16.0.*139.1@x86_64.*Foo-Increments"
-    expected_log_message += ".*SLESv16.0.*139.1-additional-build@x86_64.*Additional-Foo-Increments"
+    expected_log_message += ".*SLESv16.0.*PI-139.1@x86_64.*Foo-Increments"
+    expected_log_message += ".*SLESv16.0.*PI-139.1-additional-build@x86_64.*Additional-Foo-Increments"
     assert re.search(expected_log_message, caplog.text, re.DOTALL)
-    assert re.search(r"Skipping approval.*no relevant jobs.*SLESv16.0.*139.1@s390x.*Foo-Increments", caplog.text)
+    assert re.search(r"Skipping approval.*no relevant jobs.*SLESv16.0.*PI-139.1@s390x.*Foo-Increments", caplog.text)
     assert (
         "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:"
         in caplog.messages[-1]
@@ -113,8 +113,8 @@ def test_skipping_with_only_jobs_of_additional_builds_present(
     for resp in fake_only_jobs_of_additional_builds_with_param_matching:
         assert resp.call_count == 1
 
-    assert re.search(r"Skipping approval.*no relevant jobs.*SLESv16.0.*139.1@x86_64.*Online-Increments", caplog.text)
-    assert re.search(r"Skipping approval.*no relevant jobs.*SLESv16.0.*139.1@ppc64le.*Foo-Increments", caplog.text)
+    assert re.search(r"Skipping approval.*no relevant jobs.*SLESv16.0.*PI-139.1@x86_64.*Online-Increments", caplog.text)
+    assert re.search(r"Skipping approval.*no relevant jobs.*SLESv16.0.*PI-139.1@ppc64le.*Foo-Increments", caplog.text)
     assert (
         "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:"
         in caplog.messages[-1]
@@ -134,7 +134,7 @@ def test_scheduling_with_no_openqa_jobs(mocker: MockerFixture, caplog: pytest.Lo
             "DISTRI": "sle",
             "VERSION": "16.0",
             "FLAVOR": "Online-Increments",
-            "BUILD": "139.1",
+            "BUILD": "PI-139.1",
             "ARCH": arch,
             "PRODUCT": "SLES",
             "INCREMENT_REPO": "http://%REPO_MIRROR_HOST%/ibs/OBS:/PROJECT:/TEST/product",
@@ -152,7 +152,7 @@ def assert_run_with_extra_livepatching(errors: int, jobs: list, messages: list) 
         "DISTRI": "sle",
         "VERSION": "16.0",
         "FLAVOR": "Online-Increments",
-        "BUILD": "139.1",
+        "BUILD": "PI-139.1",
         "PRODUCT": "SLES",
         "INCREMENT_REPO": "http://%REPO_MIRROR_HOST%/ibs/OBS:/PROJECT:/TEST/product",
         "FOO": "bar",
@@ -166,7 +166,7 @@ def assert_run_with_extra_livepatching(errors: int, jobs: list, messages: list) 
     def assert_livepatch(flavor: str, build_suffix: str, kernel_version: str) -> None:
         expected_params = base_params | {
             "FLAVOR": flavor,
-            "BUILD": f"139.1-{build_suffix}",
+            "BUILD": f"PI-139.1-{build_suffix}",
             "KERNEL_VERSION": kernel_version,
             "KGRAFT": "1",
         }


### PR DESCRIPTION
Motivation:
Product increment test builds use bare build numbers like `139.1`,
which are not uniquely identifiable on openQA instances when
searching across jobs.

Design Choices:
Updated `make_scheduling_parameters` and `_match_additional_build`
in `IncrementApprover` to inject the prefix `"PI-"` into the `BUILD`
parameter. Tests were updated to reflect this new prefix.

Benefits:
Build numbers submitted to openQA for product increments are now
explicitly prefixed as `"PI-139.1"` (for instance), avoiding
ambiguity with regular release builds.