### PR TITLE
feat: add job group details to qem-bot comments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -72,22 +72,22 @@ updates information about submissions and related openQA tests.
     │ --help                                           Show this message and exit. │
     ╰──────────────────────────────────────────────────────────────────────────────╯
     ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-    │ full-run            Full schedule for Maintenance Submissions in openQA.     │
-    │ submissions-run     Submissions only schedule for Maintenance Submissions in │
-    │                     openQA.                                                  │
-    │ updates-run         Aggregates only schedule for Maintenance Submissions in  │
-    │                     openQA.                                                  │
-    │ smelt-sync          Sync data from SMELT into QEM Dashboard.                 │
-    │ gitea-sync          Sync data from Gitea into QEM Dashboard.                 │
-    │ gitea-trigger       Trigger testing for PR(s) with certain label.            │
-    │ sub-approve         Approve submissions which passed tests.                  │
-    │ sub-comment         Comment submissions in BuildService.                     │
-    │ sub-sync-results    Sync results of openQA submission jobs to Dashboard.     │
-    │ aggr-sync-results   Sync results of openQA aggregate jobs to Dashboard.      │
-    │ increment-approve   Approve the most recent product increment for an OBS     │
-    │                     project if tests passed.                                 │
-    │ repo-diff           Computes the diff between two repositories.              │
-    │ amqp                AMQP listener daemon.                                    │
+    │ full-run           Full schedule for Maintenance Submissions in openQA.      │
+    │ submissions-run    Submissions only schedule for Maintenance Submissions in  │
+    │                    openQA.                                                   │
+    │ updates-run        Aggregates only schedule for Maintenance Submissions in   │
+    │                    openQA.                                                   │
+    │ smelt-sync         Sync data from SMELT into QEM Dashboard.                  │
+    │ gitea-sync         Sync data from Gitea into QEM Dashboard.                  │
+    │ gitea-trigger      Trigger testing for PR(s) with certain label.             │
+    │ sub-approve        Approve submissions which passed tests.                   │
+    │ sub-comment        Comment submissions in BuildService.                      │
+    │ sub-sync-results   Sync results of openQA submission jobs to Dashboard.      │
+    │ aggr-sync-results  Sync results of openQA aggregate jobs to Dashboard.       │
+    │ increment-approve  Approve the most recent product increment for an OBS      │
+    │                    project if tests passed.                                  │
+    │ repo-diff          Computes the diff between two repositories.               │
+    │ amqp               AMQP listener daemon.                                     │
     ╰──────────────────────────────────────────────────────────────────────────────╯
 
 

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -366,10 +366,57 @@ def sub_approve(
 
 
 @app.command("sub-comment")
-def sub_comment(ctx: typer.Context) -> None:
+def sub_comment(
+    ctx: typer.Context,
+    enable_detailed_comments: Annotated[
+        bool | None,
+        typer.Option(
+            "--enable-detailed-comments/--disable-detailed-comments",
+            envvar="QEM_ENABLE_DETAILED_COMMENTS",
+            help="Add job group contact details to comments",
+        ),
+    ] = None,
+    fallback_contact: Annotated[
+        str | None,
+        typer.Option(
+            "--fallback-contact",
+            envvar="QEM_FALLBACK_CONTACT",
+            help="Fallback contact when no maintainer found",
+        ),
+    ] = None,
+    generic_tool_issues_contact: Annotated[
+        str | None,
+        typer.Option(
+            "--generic-tool-issues-contact",
+            envvar="QEM_GENERIC_TOOL_ISSUES_CONTACT",
+            help="Contact for generic tool issues",
+        ),
+    ] = None,
+    max_detailed_comment_entries: Annotated[
+        int | None,
+        typer.Option(
+            "--max-detailed-comment-entries",
+            envvar="QEM_MAX_DETAILED_COMMENT_ENTRIES",
+            help="Max entries in job groups table",
+        ),
+    ] = None,
+) -> None:
     """Comment submissions in BuildService."""
     args = ctx.obj
     _require_token(args)
+
+    if enable_detailed_comments is not None:
+        args.enable_detailed_comments = enable_detailed_comments
+        config_module.settings.enable_detailed_comments = enable_detailed_comments
+    if fallback_contact is not None:
+        args.fallback_contact = fallback_contact
+        config_module.settings.fallback_contact = fallback_contact
+    if generic_tool_issues_contact is not None:
+        args.generic_tool_issues_contact = generic_tool_issues_contact
+        config_module.settings.generic_tool_issues_contact = generic_tool_issues_contact
+    if max_detailed_comment_entries is not None:
+        args.max_detailed_comment_entries = max_detailed_comment_entries
+        config_module.settings.max_detailed_comment_entries = max_detailed_comment_entries
 
     submissions = get_submissions()
     comment = Commenter(args, submissions)

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -55,6 +55,61 @@ comment_option = Annotated[
     ),
 ]
 
+enable_detailed_comments_option = Annotated[
+    bool | None,
+    typer.Option(
+        "--enable-detailed-comments/--disable-detailed-comments",
+        envvar="QEM_ENABLE_DETAILED_COMMENTS",
+        help="Add job group contact details to comments",
+    ),
+]
+
+fallback_contact_option = Annotated[
+    str | None,
+    typer.Option(
+        "--fallback-contact",
+        envvar="QEM_FALLBACK_CONTACT",
+        help="Fallback contact when no maintainer found",
+    ),
+]
+
+generic_tool_issues_contact_option = Annotated[
+    str | None,
+    typer.Option(
+        "--generic-tool-issues-contact",
+        envvar="QEM_GENERIC_TOOL_ISSUES_CONTACT",
+        help="Contact for generic tool issues",
+    ),
+]
+
+max_detailed_comment_entries_option = Annotated[
+    int | None,
+    typer.Option(
+        "--max-detailed-comment-entries",
+        envvar="QEM_MAX_DETAILED_COMMENT_ENTRIES",
+        help="Max entries in job groups table",
+    ),
+]
+
+
+def _apply_detailed_comment_options(
+    args: SimpleNamespace,
+    *,
+    enable_detailed_comments: bool | None,
+    fallback_contact: str | None,
+    generic_tool_issues_contact: str | None,
+    max_detailed_comment_entries: int | None,
+) -> None:
+    for k, v in {
+        "enable_detailed_comments": enable_detailed_comments,
+        "fallback_contact": fallback_contact,
+        "generic_tool_issues_contact": generic_tool_issues_contact,
+        "max_detailed_comment_entries": max_detailed_comment_entries,
+    }.items():
+        if v is not None:
+            setattr(args, k, v)
+            setattr(config_module.settings, k, v)
+
 
 def _require_token(args: SimpleNamespace) -> None:
     """Enforce that a qem-dashboard token is present before entering a command.
@@ -313,7 +368,7 @@ def gitea_sync(  # noqa: PLR0913
 
 
 @app.command("gitea-trigger")
-def gitea_trigger(
+def gitea_trigger(  # noqa: PLR0913
     ctx: typer.Context,
     *,
     gitea_repo: gitea_repo_arg = "products/SLFO",
@@ -323,6 +378,10 @@ def gitea_trigger(
     ] = "staging/In Progress",
     pr_number: pr_number_arg = None,
     comment: comment_option = True,
+    enable_detailed_comments: enable_detailed_comments_option = None,
+    fallback_contact: fallback_contact_option = None,
+    generic_tool_issues_contact: generic_tool_issues_contact_option = None,
+    max_detailed_comment_entries: max_detailed_comment_entries_option = None,
 ) -> None:
     """Trigger testing for PR(s) with certain label."""
     args = ctx.obj
@@ -331,12 +390,20 @@ def gitea_trigger(
     args.pr_label = pr_label
     args.comment = comment
 
+    _apply_detailed_comment_options(
+        args,
+        enable_detailed_comments=enable_detailed_comments,
+        fallback_contact=fallback_contact,
+        generic_tool_issues_contact=generic_tool_issues_contact,
+        max_detailed_comment_entries=max_detailed_comment_entries,
+    )
+
     syncer = GiteaTrigger(args)
     sys.exit(syncer())
 
 
 @app.command("sub-approve")
-def sub_approve(
+def sub_approve(  # noqa: PLR0913
     ctx: typer.Context,
     *,
     all_submissions: Annotated[
@@ -352,6 +419,10 @@ def sub_approve(
         ),
     ] = None,
     comment: comment_option = True,
+    enable_detailed_comments: enable_detailed_comments_option = None,
+    fallback_contact: fallback_contact_option = None,
+    generic_tool_issues_contact: generic_tool_issues_contact_option = None,
+    max_detailed_comment_entries: max_detailed_comment_entries_option = None,
 ) -> None:
     """Approve submissions which passed tests."""
     args = ctx.obj
@@ -361,6 +432,14 @@ def sub_approve(
     args.incident = submission
     args.comment = comment
 
+    _apply_detailed_comment_options(
+        args,
+        enable_detailed_comments=enable_detailed_comments,
+        fallback_contact=fallback_contact,
+        generic_tool_issues_contact=generic_tool_issues_contact,
+        max_detailed_comment_entries=max_detailed_comment_entries,
+    )
+
     approve = Approver(args)
     sys.exit(approve())
 
@@ -368,55 +447,22 @@ def sub_approve(
 @app.command("sub-comment")
 def sub_comment(
     ctx: typer.Context,
-    enable_detailed_comments: Annotated[
-        bool | None,
-        typer.Option(
-            "--enable-detailed-comments/--disable-detailed-comments",
-            envvar="QEM_ENABLE_DETAILED_COMMENTS",
-            help="Add job group contact details to comments",
-        ),
-    ] = None,
-    fallback_contact: Annotated[
-        str | None,
-        typer.Option(
-            "--fallback-contact",
-            envvar="QEM_FALLBACK_CONTACT",
-            help="Fallback contact when no maintainer found",
-        ),
-    ] = None,
-    generic_tool_issues_contact: Annotated[
-        str | None,
-        typer.Option(
-            "--generic-tool-issues-contact",
-            envvar="QEM_GENERIC_TOOL_ISSUES_CONTACT",
-            help="Contact for generic tool issues",
-        ),
-    ] = None,
-    max_detailed_comment_entries: Annotated[
-        int | None,
-        typer.Option(
-            "--max-detailed-comment-entries",
-            envvar="QEM_MAX_DETAILED_COMMENT_ENTRIES",
-            help="Max entries in job groups table",
-        ),
-    ] = None,
+    enable_detailed_comments: enable_detailed_comments_option = None,
+    fallback_contact: fallback_contact_option = None,
+    generic_tool_issues_contact: generic_tool_issues_contact_option = None,
+    max_detailed_comment_entries: max_detailed_comment_entries_option = None,
 ) -> None:
     """Comment submissions in BuildService."""
     args = ctx.obj
     _require_token(args)
 
-    if enable_detailed_comments is not None:
-        args.enable_detailed_comments = enable_detailed_comments
-        config_module.settings.enable_detailed_comments = enable_detailed_comments
-    if fallback_contact is not None:
-        args.fallback_contact = fallback_contact
-        config_module.settings.fallback_contact = fallback_contact
-    if generic_tool_issues_contact is not None:
-        args.generic_tool_issues_contact = generic_tool_issues_contact
-        config_module.settings.generic_tool_issues_contact = generic_tool_issues_contact
-    if max_detailed_comment_entries is not None:
-        args.max_detailed_comment_entries = max_detailed_comment_entries
-        config_module.settings.max_detailed_comment_entries = max_detailed_comment_entries
+    _apply_detailed_comment_options(
+        args,
+        enable_detailed_comments=enable_detailed_comments,
+        fallback_contact=fallback_contact,
+        generic_tool_issues_contact=generic_tool_issues_contact,
+        max_detailed_comment_entries=max_detailed_comment_entries,
+    )
 
     submissions = get_submissions()
     comment = Commenter(args, submissions)

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from logging import getLogger
 from pprint import pformat
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import osc.conf
 
@@ -18,7 +18,7 @@ from .loader import gitea
 from .loader.qem import get_aggregate_results, get_submission_results
 from .openqa import OpenQAInterface
 from .osclib.comments import CommentAPI
-from .utils import normalize_results
+from .utils import extract_contact_from_description, normalize_results
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -181,8 +181,81 @@ class Commenter:
         base_url = self.client.openqa.baseurl
         builds = sorted({j["build"] for j in jobs if "build" in j})
         suffix = "" if config.settings.allow_development_groups else "&not_group_glob=*Devel*%2C*Test*"
-        return "".join(
+        badge_msg = "".join(
             f"[![Test Results]({base_url}/tests/overview/badge?build={b}{suffix})]"
             f"({base_url}/tests/overview?build={b}{suffix})\n"
             for b in builds
         ).strip()
+
+        if not config.settings.enable_detailed_comments:
+            return badge_msg
+
+        job_groups = self.get_job_groups_with_failures(jobs)
+        if not job_groups:
+            return badge_msg
+
+        max_entries = config.settings.max_detailed_comment_entries
+        display_groups = job_groups[:max_entries]
+        excluded_count = len(job_groups) - max_entries
+
+        fallback = config.settings.fallback_contact
+        table_rows = [
+            f"| {g['name']}: [![openQA Test Results]({g['badge_url']})]({g['overview_url']}) | "
+            f"{g['contact'] or f'No contact provided: {fallback}'} |"
+            for g in display_groups
+        ]
+
+        detail_msg = "\n\n| *Job Group with blocking failures* | *Group Owner's contact information*\n| --- | --- |\n"
+        detail_msg += "\n".join(table_rows)
+
+        if excluded_count > 0:
+            first_build = builds[0] if builds else ""
+            overview_link = f"{base_url}/tests/overview?build={first_build}{suffix}"
+            detail_msg += (
+                f"\n\n*... and {excluded_count} more job groups. See [Test Results]({overview_link}) for details.*"
+            )
+
+        detail_msg += f"\n\nFor generic tool issues, contact {config.settings.generic_tool_issues_contact}."
+
+        return badge_msg + "\n\n" + detail_msg
+
+    def get_job_groups_with_failures(self, jobs: list[dict[str, Any]]) -> list[dict[str, str]]:
+        """Get job groups with blocking failures and their contact info."""
+        base_url = self.client.openqa.baseurl
+        suffix = "" if config.settings.allow_development_groups else "&not_group_glob=*Devel*%2C*Test*"
+
+        groups: dict[int, dict[str, Any]] = {}
+        for job in jobs:
+            status = job.get("status", "")
+            if status in {"passed", "softfailed"}:
+                continue
+            group_id = job.get("group_id")
+            if not group_id:
+                continue
+            if group_id not in groups:
+                group_info = self.client.get_job_group_info(group_id)
+                groups[group_id] = {
+                    "id": group_id,
+                    "name": group_info.get("name", "Unknown") if group_info else "Unknown",
+                    "description": group_info.get("description") if group_info else None,
+                    "contact": None,
+                    "build": job.get("build", ""),
+                    "status": status,
+                }
+                if group_info:
+                    groups[group_id]["contact"] = extract_contact_from_description(group_info.get("description"))
+
+        return [
+            {
+                "id": g["id"],
+                "name": (name := str(g["name"])),
+                "contact": g["contact"],
+                "build": g["build"],
+                "status": g["status"],
+                "overview_url": (
+                    u := f"{base_url}/tests/overview?build={g['build']}&group={quote(name, safe='')}{suffix}"
+                ),
+                "badge_url": u.replace("/tests/overview?", "/tests/overview/badge?"),
+            }
+            for g in groups.values()
+        ]

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -72,6 +72,13 @@ class Settings(BaseSettings):
     oldest_approval_job_days: int = 6
     # How long to wait for http(s) call in seconds
     url_timeout: int = 60
+    # Detailed comments settings
+    enable_detailed_comments: bool = Field(default=False, alias="QEM_ENABLE_DETAILED_COMMENTS")
+    fallback_contact: str = Field(default="Contact openQA test maintainers", alias="QEM_FALLBACK_CONTACT")
+    generic_tool_issues_contact: str = Field(
+        default="Contact qem-bot maintainers for generic questions", alias="QEM_GENERIC_TOOL_ISSUES_CONTACT"
+    )
+    max_detailed_comment_entries: int = Field(default=7, alias="QEM_MAX_DETAILED_COMMENT_ENTRIES")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -150,3 +150,14 @@ class OpenQAInterface:
     def get_scheduled_product_stats(self, params: dict[str, Any]) -> dict[str, Any]:
         """Fetch scheduling statistics for a product."""
         return self.openqa.openqa_request("GET", "isos/job_stats", params, retries=self.retries)
+
+    @lru_cache(maxsize=256)  # noqa: B019
+    def get_job_group_info(self, group_id: int) -> dict[str, Any] | None:
+        """Fetch job group details including description."""
+        try:
+            ret = self.openqa.openqa_request("GET", f"job_groups/{group_id}")
+            if ret and len(ret) > 0:
+                return ret[0]
+        except RequestError:
+            log.exception("openQA API error when fetching job group %s", group_id)
+        return None

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -142,7 +142,7 @@ CONTACT_PATTERN = re.compile(
 
 def extract_contact_from_description(description: str | None) -> str | None:
     """Extract contact information from job group description."""
-    if not description:
+    if not isinstance(description, str):
         return None
     match = CONTACT_PATTERN.search(description)
     return match.group(1).strip() if match else None

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -132,3 +132,17 @@ def make_retry_session(retries: int, backoff_factor: float) -> Session:
 retry3 = make_retry_session(3, 2)
 retry5 = make_retry_session(5, 1)
 retry10 = make_retry_session(10, 0.1)
+
+
+CONTACT_PATTERN = re.compile(
+    r"^\s*(?:[rR]esponsible(?:\s+(?:[pP]erson|[tT]eam|[mM]aintainer))?|(?:[pP]erson|[tT]eam|[mM]aintainer)):\s+(.*)",
+    re.MULTILINE,
+)
+
+
+def extract_contact_from_description(description: str | None) -> str | None:
+    """Extract contact information from job group description."""
+    if not description:
+        return None
+    match = CONTACT_PATTERN.search(description)
+    return match.group(1).strip() if match else None

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -111,6 +111,31 @@ def test_sub_comment(mocker: MockerFixture, tmp_path: Path) -> None:
     comment.assert_called_once()
 
 
+def test_sub_comment_with_detailed_args(mocker: MockerFixture, tmp_path: Path) -> None:
+    mocker.patch("openqabot.args.get_submissions", return_value=[])
+    comment = mocker.patch("openqabot.args.Commenter")
+    comment.return_value.return_value = 0
+    result = runner.invoke(
+        app,
+        [
+            "--token",
+            "foo",
+            "--configs",
+            str(tmp_path),
+            "sub-comment",
+            "--enable-detailed-comments",
+            "--fallback-contact",
+            "Test Contact",
+            "--generic-tool-issues-contact",
+            "@test",
+            "--max-detailed-comment-entries",
+            "5",
+        ],
+    )
+    assert result.exit_code == 0
+    comment.assert_called_once()
+
+
 def test_sub_sync_results(mocker: MockerFixture, tmp_path: Path) -> None:
     syncer = mocker.patch("openqabot.args.SubResultsSync")
     syncer.return_value.return_value = 0

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -652,3 +652,133 @@ def test_generate_comment_raw_openqa_jobs(mock_args: Namespace) -> None:
     msg, state = res
     assert state == "passed"
     assert "build=1" in msg
+
+
+@pytest.fixture
+def detailed_comment_mocks(
+    commenter_setup: dict[str, MagicMock],
+    mocker: MockerFixture,
+) -> dict[str, MagicMock]:
+    """Set up common mocks for detailed comments tests."""
+    commenter_setup["client"].return_value.openqa.baseurl = "https://openqa.opensuse.org"
+    mocker.patch("openqabot.config.settings.allow_development_groups", new=None)
+    mocker.patch("openqabot.config.settings.fallback_contact", new="Contact openQA test maintainer")
+    mocker.patch("openqabot.config.settings.generic_tool_issues_contact", new="our cool qem-bot admins")
+    mocker.patch("openqabot.config.settings.enable_detailed_comments", new=True)
+    mocker.patch("openqabot.config.settings.max_detailed_comment_entries", new=7)
+    return commenter_setup
+
+
+@pytest.mark.parametrize(
+    ("enabled", "jobs", "group_info", "expected_contains", "expected_not_contains"),
+    [
+        pytest.param(
+            False,
+            [{"build": "1.1", "status": "failed", "group_id": 42}],
+            {"id": 42, "name": "Functional", "description": "Responsible: qe@test.com"},
+            [],
+            ["Job Group with blocking failures", "generic tool issues"],
+            id="disabled",
+        ),
+        pytest.param(
+            True,
+            [{"build": "1.1", "status": "passed", "group_id": 42}],
+            {"id": 42, "name": "Functional", "description": "Responsible: qe@test.com"},
+            [],
+            ["Job Group with blocking failures"],
+            id="enabled_no_failures",
+        ),
+        pytest.param(
+            True,
+            [
+                {"build": "1.1", "status": "failed", "group_id": 42},
+                {"build": "1.1", "status": "passed", "group_id": 42},
+            ],
+            {"id": 42, "name": "Functional", "description": "Responsible: qe-functional@example.com"},
+            ["Job Group with blocking failures", "Functional", "qe-functional@example.com"],
+            [],
+            id="enabled_with_failures",
+        ),
+        pytest.param(
+            True,
+            [{"build": "1.1", "status": "failed", "group_id": 42}],
+            {"id": 42, "name": "Functional", "description": "Responsible: qe-functional@example.com"},
+            ["generic tool issues", "our cool qem-bot admins"],
+            [],
+            id="generic_contact",
+        ),
+        pytest.param(
+            True,
+            [{"build": "1.1", "status": "failed", "group_id": 42}],
+            {"id": 42, "name": "Kernel", "description": "No contact info here"},
+            ["Kernel", "No contact provided", "Contact openQA test maintainer"],
+            [],
+            id="fallback_contact",
+        ),
+        pytest.param(
+            True,
+            [{"build": "1.1", "status": "failed", "group_id": 42}],
+            None,
+            ["Job Group with blocking failures", "Unknown", "No contact provided"],
+            [],
+            id="api_error",
+        ),
+        pytest.param(
+            True,
+            [{"build": "1.1", "status": "failed"}],
+            {"id": 42, "name": "Functional", "description": "Responsible: qe@test.com"},
+            [],
+            ["Job Group with blocking failures"],
+            id="no_group_id",
+        ),
+        pytest.param(
+            True,
+            [{"build": "1.1", "status": "failed", "group_id": i} for i in range(10)],
+            {"id": 0, "name": "Group", "description": "Responsible: qe@test.com"},
+            ["... and 2 more job groups"],
+            [],
+            id="exceeds_max_entries",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("commenter_setup")
+def test_summarize_message_detailed_comments(
+    mock_args: Namespace,
+    detailed_comment_mocks: dict[str, MagicMock],
+    mocker: MockerFixture,
+    enabled: bool,  # noqa: FBT001
+    jobs: list[dict],
+    group_info: dict | None,
+    expected_contains: list[str],
+    expected_not_contains: list[str],
+) -> None:
+    """Test summarize_message with detailed comments in various scenarios."""
+    mocker.patch("openqabot.config.settings.enable_detailed_comments", new=enabled)
+    detailed_comment_mocks["client"].return_value.get_job_group_info.return_value = group_info
+    c = Commenter(mock_args, submissions=[])
+    result = c.summarize_message(jobs)
+    for text in expected_contains:
+        assert text in result
+    for text in expected_not_contains:
+        assert text not in result
+
+
+@pytest.mark.usefixtures("commenter_setup")
+def test_summarize_message_detailed_comments_duplicate_group(
+    mock_args: Namespace,
+    detailed_comment_mocks: dict[str, MagicMock],
+) -> None:
+    """Test summarize_message when multiple jobs have the same group_id."""
+    detailed_comment_mocks["client"].return_value.get_job_group_info.return_value = {
+        "id": 42,
+        "name": "Functional",
+        "description": "Responsible: qe-functional@example.com",
+    }
+    c = Commenter(mock_args, submissions=[])
+    jobs = [
+        {"build": "1.1", "status": "failed", "group_id": 42},
+        {"build": "1.1", "status": "failed", "group_id": 42},
+    ]
+    result = c.summarize_message(jobs)
+    assert "Functional" in result
+    assert result.count("| Functional:") == 1

--- a/tests/test_openqaclient.py
+++ b/tests/test_openqaclient.py
@@ -126,3 +126,43 @@ def test_is_in_devel_group_no_group_id() -> None:
         assert not client.is_in_devel_group({"group": "Production"})
         # No group_id but "Devel" in name -> should return True
         assert client.is_in_devel_group({"group": "Devel Group"})
+
+
+@responses.activate
+def test_get_job_group_info_success(fake_openqa_url: str) -> None:
+    """Test get_job_group_info returns group data on success."""
+    group_data = [{"id": 42, "name": "TestGroup", "description": "Test description"}]
+    responses.add(
+        responses.GET,
+        f"{fake_openqa_url}/api/v1/job_groups/42",
+        json=group_data,
+        status=200,
+    )
+    client = oQAI()
+    result = client.get_job_group_info(42)
+    assert result == {"id": 42, "name": "TestGroup", "description": "Test description"}
+
+
+@responses.activate
+def test_get_job_group_info_empty_response(fake_openqa_url: str) -> None:
+    """Test get_job_group_info returns None on empty response."""
+    responses.add(responses.GET, f"{fake_openqa_url}/api/v1/job_groups/42", json=[], status=200)
+    client = oQAI()
+    result = client.get_job_group_info(42)
+    assert result is None
+
+
+@responses.activate
+def test_get_job_group_info_error(fake_openqa_url: str, caplog: pytest.LogCaptureFixture) -> None:
+    """Test get_job_group_info returns None on API error."""
+    caplog.set_level(logging.ERROR, logger="bot.openqa")
+    responses.add(
+        responses.GET,
+        f"{fake_openqa_url}/api/v1/job_groups/42",
+        json={"error": "not found"},
+        status=404,
+    )
+    client = oQAI()
+    result = client.get_job_group_info(42)
+    assert result is None
+    assert "openQA API error when fetching job group 42" in caplog.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from openqabot.types.types import Data
 from openqabot.utils import (
     compare_submission_data,
     create_logger,
+    extract_contact_from_description,
     get_yml_list,
     make_retry_session,
     normalize_results,
@@ -182,3 +183,23 @@ def test_create_logger_duplicate_handlers() -> None:
     log2 = create_logger(name)
     assert log is log2
     assert len(log.handlers) == 1
+
+
+@pytest.mark.parametrize(
+    ("description", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("Some random text without contact info", None),
+        ("Responsible: qe-team@suse.de", "qe-team@suse.de"),
+        ("Person: test@suse.de", "test@suse.de"),
+        ("Team: #qe-team on Slack", "#qe-team on Slack"),
+        ("Maintainer: maintainer@suse.de", "maintainer@suse.de"),
+        ("responsible: lowercase@example.com", "lowercase@example.com"),
+        ("Multiple lines\nResponsible: contact@example.com\nOther text", "contact@example.com"),
+        ("Leading text\nPerson: middle@example.com\nTrailing text", "middle@example.com"),
+    ],
+)
+def test_extract_contact_from_description(description: str | None, expected: str | None) -> None:
+    """Test extraction of contact information from job group descriptions."""
+    assert extract_contact_from_description(description) == expected


### PR DESCRIPTION
 [feat: add job group details to qem-bot comments](https://github.com/openSUSE/qem-bot/pull/472/commits/6ed415be3deed3de94738b115f1f2685b18d5838)

Motivation:
The openQA team requested more context in qem-bot comments on
submissions, including job group details and contact information
for handling test failures.

Design Choices:
- Added configurable feature switch enable_detailed_comments that
  applies only to the sub-comment command (not global)
- Added fallback_contact and generic_tool_issues_contact settings
- Added get_job_group_info method with LRU caching to OpenQAInterface
- Added extract_contact_from_description utility function with regex
  pattern matching for Responsible/Person/Team/Maintainer
- Use urllib.parse.quote with safe='' to properly URL-encode group names
  when generating badge_url and overview_url in the commenter.

Benefits:
- Comments now include a table with job group names and contacts
- Falls back to configurable contact when group has no contact info
- Generic tool issues contact shown for infrastructure problems
- Feature is opt-in via configuration to maintain backwards compat

[feat: extend detailed comments to sub-approve and gitea-trigger](https://github.com/openSUSE/qem-bot/pull/472/commits/4c1783260efdffe5d54dcd81cb345ad2c814389e)

Motivation:
Detailed comments provide useful job group context and maintainer contacts
for failures. These need to be available when using the 'sub-approve'
and 'gitea-trigger' commands which already have commenting functionality.

Design Choices:
- Extract detailed comments typer options into reusable annotated types
- Add an _apply_detailed_comment_options helper function
- Apply the detailed comment options to sub-approve and gitea-trigger
  in args.py so they work with the same parameters as sub-comment

Benefits:
- Code duplication is minimized for typer options
- Detailed comments with contact information can now be generated when
  triggering tests or running approvals
- Maintains consistent command-line interface across commands

Example comment based on a SUSE customized preference for fallback and general comment as configurable:

---
[![Test Results](https://openqa.suse.de/tests/overview/badge?build=20260327-1&not_group_glob=*Devel*%2C*Test*)](https://openqa.suse.de/tests/overview?build=20260327-1&not_group_glob=*Devel*%2C*Test*)
[![Test Results](https://openqa.suse.de/tests/overview/badge?build=:smelt:43388:webkit2gtk3&not_group_glob=*Devel*%2C*Test*)](https://openqa.suse.de/tests/overview?build=:smelt:43388:webkit2gtk3&not_group_glob=*Devel*%2C*Test*)

| *Job Group with blocking failures* | *Group Owner's contact information*
| --- | --- |
| Core Maintenance Updates: [![openQA Test Results](https://openqa.suse.de/tests/overview/badge?build=20260327-1&group=Core%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*)](https://openqa.suse.de/tests/overview?build=20260327-1&group=Core%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*) | No contact provided: No contact provided in job group: Contact QE Prj Mgr |
| Security Maintenance Updates: [![openQA Test Results](https://openqa.suse.de/tests/overview/badge?build=20260327-1&group=Security%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*)](https://openqa.suse.de/tests/overview?build=20260327-1&group=Security%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*) | No contact provided: No contact provided in job group: Contact QE Prj Mgr |
| YaST Maintenance Updates: [![openQA Test Results](https://openqa.suse.de/tests/overview/badge?build=20260327-1&group=YaST%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*)](https://openqa.suse.de/tests/overview?build=20260327-1&group=YaST%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*) | QE Yam - <qe-yam@suse.de> |
| SAP/HA Maintenance Updates: [![openQA Test Results](https://openqa.suse.de/tests/overview/badge?build=20260327-1&group=SAP%2FHA%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*)](https://openqa.suse.de/tests/overview?build=20260327-1&group=SAP%2FHA%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*) | No contact provided: No contact provided in job group: Contact QE Prj Mgr |
| Public Cloud Maintenance Updates: [![openQA Test Results](https://openqa.suse.de/tests/overview/badge?build=20260327-1&group=Public%20Cloud%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*)](https://openqa.suse.de/tests/overview?build=20260327-1&group=Public%20Cloud%20Maintenance%20Updates&not_group_glob=*Devel*%2C*Test*) | No contact provided: No contact provided in job group: Contact QE Prj Mgr |

For generic tool issues, contact @qe-infra in SUSE Slack #eng-testing. This comment was posted by qem-bot.

---

^ Note that many job groups don't have a proper description yet and my proposal to provide consistent information has so far not been followed consistently. Hence this new feature should actually motivate for bringing those descriptions up-to-date so that more helpful information is presented.

Related issue: https://progress.opensuse.org/issues/198710