### PR TITLE
fix: ignore unfinished jobs in development groups for product increments

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 log = getLogger("bot.increment_approver")
 ok_results = {"passed", "softfailed"}
 final_states = {"done", "cancelled"}
-default_flavor = "Online"
 
 
 OpenQAResult = dict[str, dict[str, dict[str, Any]]]
@@ -94,6 +93,23 @@ class IncrementApprover:
             )
         return match
 
+    def _filter_results(self, results: OpenQAResults) -> OpenQAResults:
+        """Remove jobs belonging to development groups from openQA results."""
+        return [
+            {
+                state: filtered
+                for state, jobs in res.items()
+                if (
+                    filtered := {
+                        name: {"job_ids": ids}
+                        for name, info in jobs.items()
+                        if (ids := [i for i in info["job_ids"] if not self.is_in_devel_group(i)])
+                    }
+                )
+            }
+            for res in results
+        ]
+
     def request_openqa_job_results(self, params: ScheduleParams, info_str: str) -> OpenQAResults:
         """Fetch results from openQA for the specified scheduling parameters."""
         log.debug("Checking openQA job results for %s", info_str)
@@ -136,14 +152,11 @@ class IncrementApprover:
         """Evaluate openQA job results and sort them into ok and not_ok sets."""
         all_items = chain.from_iterable(results.get(s, {}).items() for s in final_states)
         for result, info in all_items:
-            # Filter out jobs that belong to a development group
-            relevant_job_ids = [job_id for job_id in info["job_ids"] if not self.is_in_devel_group(job_id)]
-            if not relevant_job_ids:
-                continue
-
+            # Filtering is now done upfront in process_build_info
+            job_ids = info["job_ids"]
             destination = ok_jobs if result in ok_results else not_ok_jobs[result]
-            self.check_unique_jobid_request_pair(relevant_job_ids, request)
-            destination.update(relevant_job_ids)
+            self.check_unique_jobid_request_pair(job_ids, request)
+            destination.update(job_ids)
 
     def evaluate_list_of_openqa_job_results(
         self, list_of_results: OpenQAResults, request: osc.core.Request
@@ -426,6 +439,7 @@ class IncrementApprover:
             info_str,
         )
         res = self.request_openqa_job_results(params, info_str)
+        res = self._filter_results(res)
 
         if self.args.reschedule:
             approval_status.reasons_to_disapprove.append("Re-scheduling jobs for " + info_str)

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -93,22 +93,21 @@ class IncrementApprover:
             )
         return match
 
+    def _filter_jobs(self, jobs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        """Filter jobs within a state, removing those in devel groups."""
+        return {
+            name: {"job_ids": ids}
+            for name, info in jobs.items()
+            if (ids := [i for i in info["job_ids"] if not self.is_in_devel_group(i)])
+        }
+
+    def _filter_result(self, res: OpenQAResult) -> OpenQAResult:
+        """Filter a single OpenQAResult by state and job groups."""
+        return {state: filtered for state, jobs in res.items() if (filtered := self._filter_jobs(jobs))}
+
     def _filter_results(self, results: OpenQAResults) -> OpenQAResults:
         """Remove jobs belonging to development groups from openQA results."""
-        return [
-            {
-                state: filtered
-                for state, jobs in res.items()
-                if (
-                    filtered := {
-                        name: {"job_ids": ids}
-                        for name, info in jobs.items()
-                        if (ids := [i for i in info["job_ids"] if not self.is_in_devel_group(i)])
-                    }
-                )
-            }
-            for res in results
-        ]
+        return [self._filter_result(res) for res in results]
 
     def request_openqa_job_results(self, params: ScheduleParams, info_str: str) -> OpenQAResults:
         """Fetch results from openQA for the specified scheduling parameters."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,7 +228,11 @@ def fake_only_jobs_of_additional_builds_with_param_matching(
 
 @pytest.fixture
 def fake_pending_jobs(fake_openqa_url_job_stat: str) -> None:
-    responses.add(responses.GET, re.compile(f"{fake_openqa_url_job_stat}.*"), json={"scheduled": {}, "running": {}})
+    responses.add(
+        responses.GET,
+        re.compile(f"{fake_openqa_url_job_stat}.*"),
+        json={"scheduled": {"job1": {"job_ids": [1]}}, "running": {"job2": {"job_ids": [2]}}},
+    )
 
 
 @pytest.fixture

--- a/tests/test_incrementapprover_helpers.py
+++ b/tests/test_incrementapprover_helpers.py
@@ -80,3 +80,13 @@ def test_extra_builds_for_package_filtering(caplog: pytest.LogCaptureFixture) ->
     # nosrc architecture
     pkg5 = Package("kernel-livepatch", "0", "20240101", "1.1", "nosrc")
     assert approver.extra_builds_for_package(pkg5, config, build_info) is None
+
+
+def test_filter_results(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    approver = prepare_approver(caplog)
+    mocker.patch.object(approver.client, "is_in_devel_group", side_effect=lambda j: j.get("id") == 2)
+    mocker.patch.object(approver.client, "get_single_job", side_effect=lambda j: {"id": j})
+
+    results = [{"passed": {"j1": {"job_ids": [1]}, "j2": {"job_ids": [1, 2]}}, "failed": {"j3": {"job_ids": [2]}}}]
+    expected = [{"passed": {"j1": {"job_ids": [1]}, "j2": {"job_ids": [1]}}}]
+    assert approver._filter_results(results) == expected  # noqa: SLF001

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -468,10 +468,10 @@ def test_approval_if_failing_jobs_are_in_development_group(
 
     # 4. Verification:
     # Since the only job was in a development group, it should be ignored.
-    # The IncrementApprover should report "No openQA jobs were found/checked for this request"
-    # because the failed job was filtered out.
+    # The IncrementApprover should report "No jobs scheduled for ..."
+    # because the failed job was filtered out upfront.
     assert "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:" in caplog.text
-    assert "No openQA jobs were found/checked for this request." in caplog.text
+    assert "No jobs scheduled for" in caplog.text
 
 
 @responses.activate
@@ -514,3 +514,37 @@ def test_approval_with_mixed_jobs_development_ignored(
         "Approving OBS request https://build.suse.de/request/show/42: All 1 openQA jobs have passed/softfailed"
         in caplog.text
     )
+
+
+@responses.activate
+@pytest.mark.usefixtures("fake_product_repo", "mock_osc")
+def test_approval_if_running_jobs_are_in_development_group(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_openqa_url_job_stat: str
+) -> None:
+    # 1. Setup: a running job in devel group and a passed job in prod group
+    responses.add(
+        responses.GET,
+        fake_openqa_url_job_stat,
+        json={"running": {"some_job": {"job_ids": [123]}}, "done": {"passed": {"job_ids": [456]}}},
+    )
+
+    def mock_get_single_job(job_id: int) -> dict[str, Any]:
+        if job_id == 123:
+            return {"id": 123, "group": "Development", "group_id": 9, "state": "running"}
+        return {"id": 456, "group": "Production", "group_id": 1, "state": "done", "result": "passed"}
+
+    def mock_is_in_devel_group(job: dict[str, Any]) -> bool:
+        return "Development" in job.get("group", "")
+
+    mock_osc_approve = mocker.patch("osc.core.change_review_state")
+
+    increment_approver = prepare_approver(caplog)
+    increment_approver.client.get_single_job = mocker.Mock(side_effect=mock_get_single_job)
+    increment_approver.client.is_in_devel_group = mocker.Mock(side_effect=mock_is_in_devel_group)
+    increment_approver()
+
+    # 4. Verification:
+    # Job 123 (running) is ignored. Job 456 (passed) is counted.
+    # The request should be approved.
+    assert "All 1 openQA jobs have passed/softfailed" in caplog.text
+    mock_osc_approve.assert_called()


### PR DESCRIPTION
Motivation:
Jobs in development job groups were blocking product increment approvals as long
as they were running, because the readiness check happened before filtering out
irrelevant jobs.

Design Choices:
- Introduced a private method `_filter_results` to remove jobs in development
  groups from the `OpenQAResults` structure.
- Called `_filter_results` immediately after fetching results in
  `process_build_info`, ensuring both readiness check (`check_openqa_jobs`) and
  evaluation (`evaluate_list_of_openqa_job_results`) operate on filtered data.
- Simplified `evaluate_openqa_job_results` by removing now-redundant local
  filtering.
- Updated `fake_pending_jobs` test fixture to include actual job IDs, as the new
  upfront filtering removes state keys if they have no jobs.

Benefits:
- Product increment approvals are no longer blocked by irrelevant running jobs
  in development or testing groups.
- Consistent and robust handling of development groups throughout the entire
  approval logic.