### PR TITLE
feat: use custom badge labels for openQA test results

### DIFF
--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -204,14 +204,7 @@ class Commenter:
         base_url = self.client.openqa.baseurl
         badge_msg = ""
         for b in sorted(builds):
-            params = {"build": b.build}
-            if b.distri:
-                params["distri"] = b.distri
-            if b.version:
-                params["version"] = b.version
-            if not config.settings.allow_development_groups:
-                params["not_group_glob"] = "*Devel*,*Test*"
-
+            params = self._get_base_badge_params(b.build, b.distri, b.version)
             label = f"Build {b.build}"
             params["label"] = label
             query = urlencode(params, safe="*")
@@ -240,14 +233,7 @@ class Commenter:
 
         if excluded_count > 0:
             first_b = sorted_builds[0]
-            params = {"build": first_b.build}
-            if first_b.distri:
-                params["distri"] = first_b.distri
-            if first_b.version:
-                params["version"] = first_b.version
-            if not config.settings.allow_development_groups:
-                params["not_group_glob"] = "*Devel*,*Test*"
-
+            params = self._get_base_badge_params(first_b.build, first_b.distri, first_b.version)
             query = urlencode(params, safe="*")
             overview_link = f"{base_url}/tests/overview?{query}"
             detail_msg += (
@@ -256,6 +242,13 @@ class Commenter:
 
         detail_msg += f"\n\nFor generic tool issues, contact {config.settings.generic_tool_issues_contact}."
         return detail_msg.strip()
+
+    def _get_base_badge_params(self, build: str, distri: str, version: str) -> dict[str, str]:  # noqa: PLR6301
+        """Centralized openQA badge parameter construction."""
+        params = {k: v for k, v in [("build", build), ("distri", distri), ("version", version)] if v}
+        if not config.settings.allow_development_groups:
+            params["not_group_glob"] = "*Devel*,*Test*"
+        return params
 
     def get_job_groups_with_failures(self, jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Get job groups with blocking failures and their contact info."""
@@ -297,18 +290,12 @@ class Commenter:
             for g in groups.values()
         ]
 
-    @staticmethod
     def _generate_overview_url(
-        base_url: str, group: dict[str, Any], group_name: str, *, badge: bool = False, label: str | None = None
+        self, base_url: str, group: dict[str, Any], group_name: str, *, badge: bool = False, label: str | None = None
     ) -> str:
-        params = {"build": group["build"]}
-        if group.get("distri"):
-            params["distri"] = group["distri"]
-        if group.get("version"):
-            params["version"] = group["version"]
+        """Generate overview or badge URL for a specific job group."""
+        params = self._get_base_badge_params(group.get("build", ""), group.get("distri", ""), group.get("version", ""))
         params["group"] = group_name
-        if not config.settings.allow_development_groups:
-            params["not_group_glob"] = "*Devel*,*Test*"
         if label:
             params["label"] = label
 

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -212,10 +212,12 @@ class Commenter:
             if not config.settings.allow_development_groups:
                 params["not_group_glob"] = "*Devel*,*Test*"
 
+            label = f"Build {b.build}"
+            params["label"] = label
             query = urlencode(params, safe="*")
             badge_url = f"{base_url}/tests/overview/badge?{query}"
             link_url = f"{base_url}/tests/overview?{query}"
-            badge_msg += f"[![Test Results]({badge_url})]({link_url})\n"
+            badge_msg += f"[![{label} Results]({badge_url})]({link_url})\n"
         return badge_msg.strip()
 
     def _generate_detail_section(self, job_groups: list[dict[str, Any]], sorted_builds: list[BuildIdentifier]) -> str:
@@ -228,7 +230,7 @@ class Commenter:
         base_url = self.client.openqa.baseurl
 
         table_rows = [
-            f"| {g['name']}: [![openQA Test Results]({g['badge_url']})]({g['overview_url']}) | "
+            f"| [![{g['name']} Test Results]({g['badge_url']})]({g['overview_url']}) | "
             f"{g['contact'] or f'No contact provided: {fallback}'} |"
             for g in display_groups
         ]
@@ -290,21 +292,25 @@ class Commenter:
                 "build": g["build"],
                 "status": g["status"],
                 "overview_url": self._generate_overview_url(base_url, g, name),
-                "badge_url": self._generate_overview_url(base_url, g, name, badge=True),
+                "badge_url": self._generate_overview_url(base_url, g, name, badge=True, label=name),
             }
             for g in groups.values()
         ]
 
     @staticmethod
-    def _generate_overview_url(base_url: str, group: dict[str, Any], group_name: str, *, badge: bool = False) -> str:
+    def _generate_overview_url(
+        base_url: str, group: dict[str, Any], group_name: str, *, badge: bool = False, label: str | None = None
+    ) -> str:
         params = {"build": group["build"]}
-        if group["distri"]:
+        if group.get("distri"):
             params["distri"] = group["distri"]
-        if group["version"]:
+        if group.get("version"):
             params["version"] = group["version"]
         params["group"] = group_name
         if not config.settings.allow_development_groups:
             params["not_group_glob"] = "*Devel*,*Test*"
+        if label:
+            params["label"] = label
 
         query = urlencode(params, safe="*")
         path = "/tests/overview/badge" if badge else "/tests/overview"

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -204,7 +204,7 @@ class Commenter:
         base_url = self.client.openqa.baseurl
         badge_msg = ""
         for b in sorted(builds):
-            params = self._get_base_badge_params(b.build, b.distri, b.version)
+            params = b.get_base_badge_params()
             label = f"Build {b.build}"
             params["label"] = label
             query = urlencode(params, safe="*")
@@ -232,8 +232,7 @@ class Commenter:
         detail_msg += "\n".join(table_rows)
 
         if excluded_count > 0:
-            first_b = sorted_builds[0]
-            params = self._get_base_badge_params(first_b.build, first_b.distri, first_b.version)
+            params = sorted_builds[0].get_base_badge_params()
             query = urlencode(params, safe="*")
             overview_link = f"{base_url}/tests/overview?{query}"
             detail_msg += (
@@ -242,13 +241,6 @@ class Commenter:
 
         detail_msg += f"\n\nFor generic tool issues, contact {config.settings.generic_tool_issues_contact}."
         return detail_msg.strip()
-
-    def _get_base_badge_params(self, build: str, distri: str, version: str) -> dict[str, str]:  # noqa: PLR6301
-        """Centralized openQA badge parameter construction."""
-        params = {k: v for k, v in [("build", build), ("distri", distri), ("version", version)] if v}
-        if not config.settings.allow_development_groups:
-            params["not_group_glob"] = "*Devel*,*Test*"
-        return params
 
     def get_job_groups_with_failures(self, jobs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Get job groups with blocking failures and their contact info."""
@@ -290,11 +282,14 @@ class Commenter:
             for g in groups.values()
         ]
 
+    @staticmethod
     def _generate_overview_url(
-        self, base_url: str, group: dict[str, Any], group_name: str, *, badge: bool = False, label: str | None = None
+        base_url: str, group: dict[str, Any], group_name: str, *, badge: bool = False, label: str | None = None
     ) -> str:
         """Generate overview or badge URL for a specific job group."""
-        params = self._get_base_badge_params(group.get("build", ""), group.get("distri", ""), group.get("version", ""))
+        params = BuildIdentifier(
+            group.get("build", ""), group.get("distri", ""), group.get("version", "")
+        ).get_base_badge_params()
         params["group"] = group_name
         if label:
             params["label"] = label

--- a/openqabot/types/increment.py
+++ b/openqabot/types/increment.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from openqabot import config
+
 if TYPE_CHECKING:
     import osc.core
 
@@ -29,6 +31,13 @@ class BuildIdentifier(NamedTuple):
     def from_params(cls, params: dict[str, str]) -> BuildIdentifier:
         """Create a BuildIdentifier from scheduling parameters."""
         return cls(params["BUILD"], params["DISTRI"], params["VERSION"])
+
+    def get_base_badge_params(self) -> dict[str, str]:
+        """Centralized openQA badge parameter construction."""
+        params = {k: v for k, v in [("build", self.build), ("distri", self.distri), ("version", self.version)] if v}
+        if not config.settings.allow_development_groups:
+            params["not_group_glob"] = "*Devel*,*Test*"
+        return params
 
 
 class BuildInfo(NamedTuple):

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -337,13 +337,12 @@ def test_summarize_message(
     c = Commenter(mock_args, submissions=[])
     builds = [BuildIdentifier("1.1", "sle", "15"), BuildIdentifier("1.2", "", "")]
     result = c.summarize_message(set(builds), [])
-    suffix = "&not_group_glob=*Devel*%2C*Test*"
     assert (
-        "[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*)](https://openqa.opensuse.org/tests/overview?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*)"
+        "https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*&label=Build+1.1"
         in result
     )
     assert (
-        f"[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.2{suffix})](https://openqa.opensuse.org/tests/overview?build=1.2{suffix})"
+        "https://openqa.opensuse.org/tests/overview/badge?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2"
         in result
     )
 
@@ -361,7 +360,7 @@ def test_summarize_message_allow_devel(
     result = c.summarize_message({builds[0]}, [])
     assert "not_group_glob" not in result
     assert (
-        "[![Test Results](https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=opensuse&version=Tumbleweed)](https://openqa.opensuse.org/tests/overview?build=1.1&distri=opensuse&version=Tumbleweed)"
+        "https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=opensuse&version=Tumbleweed&label=Build+1.1"
         in result
     )
 
@@ -657,6 +656,7 @@ def test_generate_comment_raw_openqa_jobs(mock_args: Namespace) -> None:
     msg, state = res
     assert state == "passed"
     assert "build=1" in msg
+    assert "label=Build+1" in msg
 
 
 @pytest.fixture
@@ -816,4 +816,5 @@ def test_summarize_message_detailed_comments_duplicate_group(
     builds = {BuildIdentifier.from_job(j) for j in jobs if "build" in j}
     result = c.summarize_message(builds, jobs)
     assert "Functional" in result
-    assert result.count("| Functional:") == 1
+    assert result.count("![Functional Test Results]") == 1
+    assert "label=Functional" in result


### PR DESCRIPTION
Motivation:
With openQA PR #7203, test result badges can now display custom labels on the
left side instead of the generic "openQA" branding. Using this feature
allows qem-bot to provide cleaner comments by embedding job group names and
build numbers directly into the badges.

Design Choices:
- Added &label=Build%20{build} to the overall build status badges.
- Added &label={group_name} to individual job group badges in the detailed
  failures table.
- Removed the redundant text prefix of the job group name in the table
  since the information is now natively displayed in the badge.
- Updated the image alt text to maintain accessibility.

Benefits:
- Cleaner, more professional-looking comments.
- Better use of the available horizontal space in OBS/Gitea tables.
- Consistent branding for the specific builds being tested.

Related issue: https://progress.opensuse.org/issues/198710