### PR TITLE
feat: auto-approve staging PRs on ok openQA tests

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -13,7 +13,6 @@ from http import HTTPStatus
 from logging import getLogger
 from typing import TYPE_CHECKING
 from urllib.error import HTTPError
-from urllib.parse import urlparse
 
 import osc.conf
 import osc.core
@@ -25,7 +24,7 @@ from openqabot.errors import JobNotFoundError, NoResultsError
 from openqabot.openqa import OpenQAInterface
 
 from .commenter import Commenter
-from .loader.gitea import make_token_header, review_pr
+from .loader.gitea import approve_pr, make_token_header
 from .loader.qem import (
     JobAggr,
     SubReq,
@@ -441,19 +440,7 @@ class Approver:
 
     def git_approve(self, sub: SubReq, msg: str) -> bool:
         """Approve a submission in Gitea."""
-        if not sub.url:
-            log.error("Gitea API error: PR %s has no URL", sub.sub)
+        if not sub.submission or not getattr(sub.submission, "project", None):
+            log.error("Gitea API error: PR %s has no project (repo_name)", sub.sub)
             return False
-        try:
-            path_parts = urlparse(sub.url).path.split("/")
-            review_pr(
-                self.gitea_token,
-                "/".join(path_parts[-4:-2]),
-                sub.sub,
-                msg,
-                sub.scm_info or "",
-            )
-        except Exception:
-            log.exception("Gitea API error: Failed to approve PR %s", sub.sub)
-            return False
-        return True
+        return approve_pr(self.gitea_token, sub.submission.project, sub.sub, sub.scm_info or "", msg)

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -16,6 +16,7 @@ from openqabot.types.types import Data
 
 from .commenter import Commenter
 from .loader.gitea import (
+    approve_pr,
     generate_repo_url,
     get_gitea_staging_config,
     get_open_prs,
@@ -136,6 +137,15 @@ class GiteaTrigger:
 
         if res := self.commenter.generate_comment(pullrequest, jobs):
             self.commenter.gitea_comment(pullrequest, *res)
+            if res[1] == "passed":
+                if self.dry:
+                    log.info("Dry run: Would approve PR %s", pullrequest.number)
+                else:
+                    msg = (
+                        f"Request accepted for '{config.settings.obs_group}' "
+                        f"based on data in {config.settings.qem_dashboard_url}"
+                    )
+                    approve_pr(self.gitea_token, pullrequest.repo_name, pullrequest.number, pullrequest.commit_sha, msg)
 
     def get_prs_by_label(self) -> None:
         """Get all open PRs and filter them by defined label."""
@@ -160,6 +170,7 @@ class GiteaTrigger:
                     repo_name=pr["base"]["repo"]["name"],
                     branch=pr["base"]["label"],
                     url=pr["html_url"],
+                    commit_sha=pr["head"]["sha"],
                 )
                 # we looking only for PRs which has ALL labels defined via '--pr-label' parameter AND
                 # at least one for labels defined in staging.config

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -246,6 +246,16 @@ def review_pr(  # noqa: PLR0913
     post_json(review_url, token, review_data)
 
 
+def approve_pr(token: dict[str, str], repo_name: str, pr_number: int, commit_id: str, msg: str) -> bool:
+    """Approve a PR on Gitea using its repository name and commit ID."""
+    try:
+        review_pr(token, repo_name, pr_number, msg, commit_id, approve=True)
+    except Exception:
+        log.exception("Gitea API error: Failed to approve PR %s", pr_number)
+        return False
+    return True
+
+
 def get_name(review: dict[str, Any], of: str, via: str) -> str:
     """Extract a name from a Gitea review entity."""
     entity = review.get(of)

--- a/openqabot/types/pullrequest.py
+++ b/openqabot/types/pullrequest.py
@@ -28,6 +28,7 @@ class PullRequest:
     repo_name: str
     branch: str
     url: str
+    commit_sha: str
     raw_labels: list[dict[str, Any]] = field(repr=False)
 
     labels: set[str] = field(init=False)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -93,7 +93,7 @@ def f_sub_approver(*_args: Any) -> list[SubReq]:
                 "type": "git",
                 "url": "https://src.suse.de/products/SLFO/pulls/124",
                 "scm_info": "...",
-                "project": "SLFO",
+                "project": "products/SLFO",
                 "inReview": True,
                 "isActive": True,
                 "approved": False,

--- a/tests/test_approve_git.py
+++ b/tests/test_approve_git.py
@@ -16,9 +16,9 @@ if TYPE_CHECKING:
     import pytest
 
 
-def test_git_approve_no_url(caplog: pytest.LogCaptureFixture) -> None:
+def test_git_approve_no_project(caplog: pytest.LogCaptureFixture) -> None:
     approver_instance = Approver(args)
-    sub = SubReq(sub=1, req=100, type="git", url=None)
+    sub = SubReq(sub=1, req=100, type="git", url=None, submission=None)
     caplog.set_level(logging.ERROR)
     assert not approver_instance.git_approve(sub, "msg")
-    assert "Gitea API error: PR 1 has no URL" in caplog.text
+    assert "Gitea API error: PR 1 has no project (repo_name)" in caplog.text

--- a/tests/test_approve_obs.py
+++ b/tests/test_approve_obs.py
@@ -122,7 +122,7 @@ def test_osc_all_pass(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -
 
     mocker.patch("openqabot.approver.dashboard.get_json", return_value=[{"job_id": 100000, "status": "passed"}])
     mocker.patch("osc.core.change_review_state")
-    mock_review_pr = mocker.patch("openqabot.approver.review_pr")
+    mock_review_pr = mocker.patch("openqabot.approver.approve_pr")
 
     assert Approver(args)() == 0
     expected = [

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Tests GiteaTrigger class."""
 
+import logging
 from argparse import Namespace
 from typing import cast
 from unittest.mock import MagicMock
@@ -114,18 +115,21 @@ def test_get_prs_by_label_filtering(trigger: GiteaTrigger, mocker: MockerFixture
                 "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
                 "base": {"repo": {"name": "r"}, "label": "l"},
                 "html_url": "u",
+                "head": {"sha": "xyz"},
             },
             {
                 "number": 2,
                 "labels": [{"name": "wrong-label"}, {"name": "qalabel1"}],
                 "base": {"repo": {"name": "r"}, "label": "l"},
                 "html_url": "u",
+                "head": {"sha": "xyz"},
             },
             {
                 "number": 3,
                 "labels": [{"name": "needs-testing"}],
                 "base": {"repo": {"name": "r"}, "label": "l"},
                 "html_url": "u",
+                "head": {"sha": "xyz"},
             },
         ],
     )
@@ -203,6 +207,7 @@ def test_get_prs_by_label_specific_number(mock_args: Namespace, mocker: MockerFi
                 "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
                 "base": {"repo": {"name": "r"}, "label": "l"},
                 "html_url": "u",
+                "head": {"sha": "xyz"},
             }
         ],
     )
@@ -237,17 +242,37 @@ def test_check_pullrequest_comments_when_no_trigger_needed(trigger: GiteaTrigger
     mock_comment_on_pr.assert_called_once()
 
 
-def test_comment_on_pr_build_injection(trigger: GiteaTrigger) -> None:
+def test_comment_on_pr_build_injection(trigger: GiteaTrigger, mocker: MockerFixture) -> None:
     """Tests that the build string is injected into raw openQA jobs."""
+    mock_approve_pr = mocker.patch("openqabot.giteatrigger.approve_pr")
     mock_jobs = [{"id": 1, "state": "done", "result": "passed"}]
     cast("MagicMock", trigger.openqa.get_jobs).return_value = mock_jobs
     cast("MagicMock", trigger.commenter.generate_comment).return_value = ("Summary", "passed")
 
-    mock_pr = MagicMock(number=123, url="http://fake.url/123")
+    mock_pr = MagicMock(number=123, url="http://fake.url/123", commit_sha="sha123", repo_name="fake_repo")
     trigger.comment_on_pr(mock_pr, "product", "version", "arch", "PR-BUILD")
 
     assert mock_jobs[0]["build"] == "PR-BUILD"
     cast("MagicMock", trigger.commenter.generate_comment).assert_called_once_with(mock_pr, mock_jobs)
+    mock_approve_pr.assert_called_once_with(trigger.gitea_token, "fake_repo", 123, "sha123", mocker.ANY)
+
+
+def test_comment_on_pr_dry_run_approves(
+    trigger: GiteaTrigger, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Tests that approve_pr is not called during a dry run."""
+    caplog.set_level(logging.INFO)
+    trigger.dry = True
+    mock_approve_pr = mocker.patch("openqabot.giteatrigger.approve_pr")
+    mock_jobs = [{"id": 1, "state": "done", "result": "passed"}]
+    cast("MagicMock", trigger.openqa.get_jobs).return_value = mock_jobs
+    cast("MagicMock", trigger.commenter.generate_comment).return_value = ("Summary", "passed")
+
+    mock_pr = MagicMock(number=123, url="http://fake.url/123", commit_sha="sha123", repo_name="fake_repo")
+    trigger.comment_on_pr(mock_pr, "product", "version", "arch", "PR-BUILD")
+
+    mock_approve_pr.assert_not_called()
+    assert "Dry run: Would approve PR 123" in caplog.text
 
 
 def test_comment_on_pr_no_jobs(trigger: GiteaTrigger) -> None:

--- a/tests/test_pullrequest.py
+++ b/tests/test_pullrequest.py
@@ -41,6 +41,7 @@ def test_pull_request_has_labels() -> None:
         repo_name="os-autoinst",
         branch="master",
         url="http://gitea/pull/124",
+        commit_sha="abcd123",
         raw_labels=raw_data,
     )
 
@@ -57,6 +58,7 @@ def test_pull_request_id_property() -> None:
         repo_name="os-autoinst",
         branch="master",
         url="http://gitea/pull/124",
+        commit_sha="abcd123",
         raw_labels=[],
     )
     assert pr.id == 124


### PR DESCRIPTION
Motivation:
To align the staging PR submission workflows with the existing package
maintenance process in qem-bot (sub-approve), gitea-trigger should
automatically approve a PR when all its triggered openQA tests are ok.

Design Choices:
- Extended PullRequest to include commit_sha, needed for review_pr
- Centralized approval message and URL parsing in loader/gitea.py
- Updated gitea-trigger to call the shared approve_pr when jobs pass

Benefits:
- Provides automatic approval for staging PRs when openQA tests are ok
- Reduces code duplication between the approver and giteatrigger modules

Related issue: https://progress.opensuse.org/issues/197906