### PR TITLE
fix(gitea-trigger): use full repo name for Gitea API

### DIFF
--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -167,7 +167,7 @@ class GiteaTrigger:
                 pullrequest = PullRequest(
                     number=pr["number"],
                     raw_labels=pr["labels"],
-                    repo_name=pr["base"]["repo"]["name"],
+                    repo_name=pr["base"]["repo"]["full_name"],
                     branch=pr["base"]["label"],
                     url=pr["html_url"],
                     commit_sha=pr["head"]["sha"],

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -113,21 +113,21 @@ def test_get_prs_by_label_filtering(trigger: GiteaTrigger, mocker: MockerFixture
             {
                 "number": 1,
                 "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
-                "base": {"repo": {"name": "r"}, "label": "l"},
+                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
             },
             {
                 "number": 2,
                 "labels": [{"name": "wrong-label"}, {"name": "qalabel1"}],
-                "base": {"repo": {"name": "r"}, "label": "l"},
+                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
             },
             {
                 "number": 3,
                 "labels": [{"name": "needs-testing"}],
-                "base": {"repo": {"name": "r"}, "label": "l"},
+                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
             },
@@ -137,6 +137,7 @@ def test_get_prs_by_label_filtering(trigger: GiteaTrigger, mocker: MockerFixture
     trigger.get_prs_by_label()
     assert len(trigger.prs) == 1
     assert trigger.prs[0].number == 1
+    assert trigger.prs[0].repo_name == "owner/r"
 
 
 def test_check_pullrequest_dry_run(trigger: GiteaTrigger, mocker: MockerFixture) -> None:
@@ -205,7 +206,7 @@ def test_get_prs_by_label_specific_number(mock_args: Namespace, mocker: MockerFi
             {
                 "number": 1337,
                 "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
-                "base": {"repo": {"name": "r"}, "label": "l"},
+                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
             }
@@ -217,6 +218,7 @@ def test_get_prs_by_label_specific_number(mock_args: Namespace, mocker: MockerFi
 
     mock_get_pr.assert_called_once()
     assert len(trigger.prs) == 1
+    assert trigger.prs[0].repo_name == "owner/r"
 
 
 def test_check_pullrequest_comments_when_no_trigger_needed(trigger: GiteaTrigger, mocker: MockerFixture) -> None:


### PR DESCRIPTION
Motivation:
Gitea API endpoints for repositories require the full repository path in
the format 'owner/repo'. The gitea-trigger command was using only the
repository name, leading to 404 errors when attempting to post comments
or approve PRs.

Design Choices:
- Updated GiteaTrigger.get_prs_by_label to use pr["base"]["repo"]["full_name"]
  instead of pr["base"]["repo"]["name"] when initializing PullRequest objects.
- Updated test mocks in tests/test_giteatrigger.py to include 'full_name'.

Verified manually by calling qem-bot in non-dry mode together with a
read-only gitea token to actually call the final gitea API calls but
still have no destructive effect due to missing permission on the token.

Benefits:
- Fixes 404 errors during Gitea PR approval from the gitea-trigger command.
- Ensures consistency with other bot commands like sub-approve.

Related issue: https://progress.opensuse.org/issues/197906