### PR TITLE
fix: prevent duplicate approval comments on Gitea PRs

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -218,6 +218,19 @@ def get_open_prs(token: dict[str, str], repo: str, *, number: int | None) -> lis
         return []
 
 
+def _approval_identifiers(bot_user: str, commit_id: str, *, approve: bool = True) -> tuple[str, str]:
+    action = "approved" if approve else "decline"
+    return f"@{bot_user}: {action}", f"Tested commit: {commit_id}"
+
+
+def _is_bot_approval_comment(comment: dict[str, Any], bot_user: str, commit_id: str) -> bool:
+    """Check if a comment is an authentic approval from the bot."""
+    body = comment.get("body", "")
+    is_author = comment.get("user", {}).get("login") == bot_user
+    review_cmd, commit_str = _approval_identifiers(bot_user, commit_id)
+    return is_author and review_cmd in body and commit_str in body
+
+
 def review_pr(  # noqa: PLR0913
     token: dict[str, str],
     repo_name: str,
@@ -228,11 +241,11 @@ def review_pr(  # noqa: PLR0913
     approve: bool = True,
 ) -> None:
     """Post a review or comment on a Gitea PR."""
-    if config.settings.git_review_bot_user:
+    bot_user = config.settings.git_review_bot_user
+    if bot_user:
         review_url = comments_url(repo_name, pr_number)
-        review_cmd = f"@{config.settings.git_review_bot_user}: "
-        review_cmd += "approved" if approve else "decline"
-        review_data = {"body": f"{review_cmd}\n{msg}\nTested commit: {commit_id}"}
+        review_cmd, commit_str = _approval_identifiers(bot_user, commit_id, approve=approve)
+        review_data = {"body": f"{review_cmd}\n{msg}\n{commit_str}"}
     else:
         review_url = reviews_url(repo_name, pr_number)
         review_data = {
@@ -247,6 +260,21 @@ def review_pr(  # noqa: PLR0913
 def approve_pr(token: dict[str, str], repo_name: str, pr_number: int, commit_id: str, msg: str) -> bool:
     """Approve a PR on Gitea using its repository name and commit ID."""
     try:
+        bot_user = config.settings.git_review_bot_user
+        if bot_user:
+            comments = get_json_list(comments_url(repo_name, pr_number), token)
+            if any(_is_bot_approval_comment(c, bot_user, commit_id) for c in comments):
+                log.info("PR %s already approved via comment for commit %s", pr_number, commit_id)
+                return True
+        else:
+            reviews = get_json_list(reviews_url(repo_name, pr_number), token)
+            if any(
+                r.get("commit_id") == commit_id and r.get("state") == "APPROVED" and is_review_requested_by(r)
+                for r in reviews
+            ):
+                log.info("PR %s already approved for commit %s", pr_number, commit_id)
+                return True
+
         review_pr(token, repo_name, pr_number, msg, commit_id, approve=True)
     except Exception:
         log.exception("Gitea API error: Failed to approve PR %s", pr_number)

--- a/tests/test_approve_obs.py
+++ b/tests/test_approve_obs.py
@@ -52,7 +52,11 @@ def f_osconf(mocker: MockerFixture) -> Any:
 
 @pytest.fixture
 def fake_responses_for_creating_pr_review() -> None:
-
+    responses.add(
+        responses.GET,
+        "https://src.suse.de/api/v1/repos/products/SLFO/pulls/5/reviews",
+        json=[],
+    )
     responses.add(
         responses.POST,
         "https://src.suse.de/api/v1/repos/products/SLFO/pulls/5/reviews",

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -215,3 +215,84 @@ def test_generate_repo_url_two_label_match(labeled_pr: PullRequest) -> None:
 def test_get_gitea_staging_config(mocked_response: dict[str, str | list]) -> None:
     conf = gitea.get_gitea_staging_config({"token": "token"})
     assert conf == mocked_response
+
+
+@pytest.fixture
+def mock_review_pr(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("openqabot.loader.gitea.review_pr")
+
+
+@pytest.fixture
+def mock_settings(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("openqabot.loader.gitea.config.settings")
+
+
+@pytest.mark.parametrize(
+    ("bot_user", "api_response", "expected_log", "should_call_review"),
+    [
+        # Case 1: Already approved via official review
+        (
+            None,
+            [{"commit_id": "sha123", "state": "APPROVED", "user": {"login": "openqa"}}],
+            "PR 123 already approved for commit sha123",
+            False,
+        ),
+        # Case 2: Not yet approved (no reviews)
+        (None, [], None, True),
+        # Case 3: Already approved via bot comment
+        (
+            "bot",
+            [{"body": "@bot: approved\nTested commit: sha123", "user": {"login": "bot"}}],
+            "PR 123 already approved via comment for commit sha123",
+            False,
+        ),
+        # Case 4: Comment matches but author is wrong (spoofing attempt)
+        (
+            "bot",
+            [{"body": "@bot: approved\nTested commit: sha123", "user": {"login": "imposter"}}],
+            None,
+            True,
+        ),
+        # Case 5: No bot comments found
+        ("bot", [], None, True),
+    ],
+)
+def test_approve_pr_scenarios(
+    *,
+    mock_review_pr: MagicMock,
+    mock_settings: MagicMock,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    bot_user: str | None,
+    api_response: list[dict],
+    expected_log: str | None,
+    should_call_review: bool,
+) -> None:
+    caplog.set_level(logging.INFO, logger="bot.loader.gitea")
+    mocker.patch("openqabot.loader.gitea.get_json_list", return_value=api_response)
+
+    mock_settings.obs_group = "openqa"
+    mock_settings.git_review_bot_user = bot_user
+
+    res = gitea.approve_pr({}, "repo", 123, "sha123", "msg")
+
+    assert res is True
+    if expected_log:
+        assert expected_log in caplog.text
+    if should_call_review:
+        mock_review_pr.assert_called_once_with({}, "repo", 123, "msg", "sha123", approve=True)
+    else:
+        mock_review_pr.assert_not_called()
+
+
+def test_approve_pr_exception(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mocker.patch("openqabot.loader.gitea.get_json_list", side_effect=Exception("API fail"))
+    caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
+
+    res = gitea.approve_pr({}, "repo", 123, "sha123", "msg")
+
+    assert res is False
+    assert "Gitea API error: Failed to approve PR 123" in caplog.text


### PR DESCRIPTION
Motivation:
Gitea PRs were receiving multiple duplicate approval comments from the bot
whenever the gitea-trigger ran and tests were already passed.

Design Choices:
- Implement a check in approve_pr to fetch existing reviews/comments.
- Verify both official Gitea APPROVED reviews and bot-specific comments.
- Match against the specific Tested commit ID to allow re-approval if the
  commit changes.

Benefits:
- Reduces spam on Gitea PRs.
- Consistent behavior across periodic trigger runs.

Related issue: https://progress.opensuse.org/issues/197906