### PR TITLE
perf: filter directory listing on server side using P=*spdx.json

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -585,6 +585,14 @@ def increment_approve(  # noqa: PLR0913
         str,
         typer.Option("--product-regex", help="The regex used to determine what products are relevant"),
     ] = "^SLE.*",
+    build_filter: Annotated[
+        str,
+        typer.Option(
+            "--build-filter",
+            envvar="QEM_BOT_BUILD_FILTER",
+            help="The server-side pattern matching filter for the build listing",
+        ),
+    ] = config_module.settings.build_filter,
     increment_config: Annotated[
         Path | None,
         typer.Option(
@@ -610,6 +618,7 @@ def increment_approve(  # noqa: PLR0913
     args.build_listing_sub_path = build_listing_sub_path
     args.build_regex = build_regex
     args.product_regex = product_regex
+    args.build_filter = build_filter
     args.increment_config = increment_config
     args.comment = comment
 

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
     singlearch: Path = Field(default=Path("/etc/openqabot/singlearch.yml"), alias="QEM_BOT_SINGLEARCH")
     retry: int = Field(default=2, alias="QEM_BOT_RETRY")
     approve_comment: bool = Field(default=False, alias="QEM_BOT_APPROVE_COMMENT")
+    build_filter: str = Field(default="*spdx.json", alias="QEM_BOT_BUILD_FILTER")
 
     # App-specific settings
     qem_dashboard_url: str = Field(default="http://dashboard.qam.suse.de/", alias="QEM_DASHBOARD_URL")

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -30,9 +30,10 @@ def load_build_info(
     """Determine build information from the project's repository listing."""
     build_project_url = config.build_project_url()
     sub_path = config.build_listing_sub_path
-    url = f"{build_project_url}/{sub_path}/?P=*spdx.json&jsontable=1"
-    log.debug("Checking for '%s' files on %s", build_regex, url)
-    rows = retried_requests.get(url).json().get("data", [])
+    url = f"{build_project_url}/{sub_path}/"
+    params = {"P": "*spdx.json", "jsontable": 1}
+    log.debug("Checking for '%s' files on %s with params %s", build_regex, url, params)
+    rows = retried_requests.get(url, params=params).json().get("data", [])
 
     def get_build_info_from_row(row: dict[str, Any]) -> BuildInfo | None:
         name = row.get("name", "")

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -30,7 +30,7 @@ def load_build_info(
     """Determine build information from the project's repository listing."""
     build_project_url = config.build_project_url()
     sub_path = config.build_listing_sub_path
-    url = f"{build_project_url}/{sub_path}/?jsontable=1"
+    url = f"{build_project_url}/{sub_path}/?P=*spdx.json&jsontable=1"
     log.debug("Checking for '%s' files on %s", build_regex, url)
     rows = retried_requests.get(url).json().get("data", [])
 

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 from openqabot.types.increment import BuildInfo
+from openqabot.utils import get_obs_filter_params
 from openqabot.utils import retry10 as retried_requests
 
 if TYPE_CHECKING:
@@ -31,7 +32,7 @@ def load_build_info(
     build_project_url = config.build_project_url()
     sub_path = config.build_listing_sub_path
     url = f"{build_project_url}/{sub_path}/"
-    params = {"P": "*spdx.json", "jsontable": 1}
+    params = get_obs_filter_params(config.build_filter)
     log.debug("Checking for '%s' files on %s with params %s", build_regex, url, params)
     rows = retried_requests.get(url, params=params).json().get("data", [])
 

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -40,6 +40,7 @@ class IncrementConfig:
     build_listing_sub_path: str = ""
     build_regex: str = ""
     product_regex: str = ""
+    build_filter: str = field(default_factory=lambda: config.settings.build_filter)
     version_regex: str = DEFAULT_VERSION_REGEX
     packages: list[str] = field(default_factory=list)
     archs: set[str] = field(default_factory=set)
@@ -88,6 +89,7 @@ class IncrementConfig:
             build_listing_sub_path=entry["build_listing_sub_path"],
             build_regex=entry["build_regex"],
             product_regex=entry["product_regex"],
+            build_filter=entry.get("build_filter", config.settings.build_filter),
             version_regex=entry.get("version_regex", DEFAULT_VERSION_REGEX),
             packages=entry.get("packages", []),
             archs=set(entry.get("archs", [])),

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -67,7 +67,14 @@ class RepoDiff:
             return pyzstd.decompress(repo_data_raw)
         return repo_data_raw
 
-    def request_and_dump(self, url: str, name: str, *, as_json: bool = False) -> bytes | dict[str, Any] | None:
+    def request_and_dump(
+        self,
+        url: str,
+        name: str,
+        *,
+        as_json: bool = False,
+        params: dict[str, Any] | None = None,
+    ) -> bytes | dict[str, Any] | None:
         """Fetch data from a URL and optionally dump it to a file for fake data usage."""
         log.debug("Fetching repository data from %s", url)
         name = "tests/fixtures/responses/" + name.replace("/", "_")
@@ -77,7 +84,7 @@ class RepoDiff:
             if fake_data:
                 content = Path(name).read_bytes()
             else:
-                resp = retried_requests.get(url)
+                resp = retried_requests.get(url, params=params)
                 if not resp.ok:
                     log.info("Failed to fetch data from %s: %s %s", source, resp.status_code, resp.reason)
                     return None
@@ -98,9 +105,10 @@ class RepoDiff:
         """Load and parse repository primary metadata for an OBS project."""
         url = self.make_repodata_url(project)
         repo_data_listing = self.request_and_dump(
-            url + "?P=*-primary.xml*&jsontable=1",
+            url,
             f"repodata-listing-{project}.json",
             as_json=True,
+            params={"P": "*-primary.xml*", "jsontable": 1},
         )
         if not repo_data_listing or not isinstance(repo_data_listing, dict):
             log.error("Could not load repo data for project %s", project)

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -18,6 +18,7 @@ import requests
 from lxml import etree  # ty: ignore[unresolved-import]
 
 from .config import settings
+from .utils import get_obs_filter_params
 from .utils import retry10 as retried_requests
 
 if TYPE_CHECKING:
@@ -108,7 +109,7 @@ class RepoDiff:
             url,
             f"repodata-listing-{project}.json",
             as_json=True,
-            params={"P": "*-primary.xml*", "jsontable": 1},
+            params=get_obs_filter_params("*-primary.xml*"),
         )
         if not repo_data_listing or not isinstance(repo_data_listing, dict):
             log.error("Could not load repo data for project %s", project)

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -98,7 +98,7 @@ class RepoDiff:
         """Load and parse repository primary metadata for an OBS project."""
         url = self.make_repodata_url(project)
         repo_data_listing = self.request_and_dump(
-            url + "?jsontable=1",
+            url + "?P=*-primary.xml*&jsontable=1",
             f"repodata-listing-{project}.json",
             as_json=True,
         )

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -108,6 +108,18 @@ def merge_dicts(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, Any]:
     return copy
 
 
+def get_obs_filter_params(pattern: str) -> dict[str, Any]:
+    """Reduce data transfer by evaluating the 'P' parameter at the source via 'jsontable'.
+
+    References:
+        * https://github.com/openSUSE/MirrorCache/blob/207d61237c0597f8f4ff9d7ad12c4f9cb5d5cd1f/lib/MirrorCache/Datamodule.pm#L311
+        * https://github.com/openSUSE/MirrorCache/issues/349
+        * https://github.com/openSUSE/MirrorCache/pull/334
+
+    """
+    return {"P": pattern, "jsontable": 1}
+
+
 def unique_dicts(dicts: list[dict[Any, Any]]) -> list[dict[Any, Any]]:
     """De-duplicate a list of dictionaries while preserving order."""
     seen: set[tuple[tuple[Any, Any], ...]] = set()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlencode
 
 import osc.core
 import responses
@@ -21,7 +22,7 @@ from openqabot.incrementapprover import IncrementApprover
 from openqabot.loader.incrementconfig import IncrementConfig
 from openqabot.loader.qem import SubReq
 from openqabot.types.submission import Submission
-from openqabot.utils import merge_dicts
+from openqabot.utils import get_obs_filter_params, merge_dicts
 
 if TYPE_CHECKING:
     import pytest
@@ -36,7 +37,9 @@ class ReviewState(NamedTuple):
     by_group: str
 
 
-obs_product_table_url = settings.obs_download_url + "/OBS:/PROJECT:/TEST/product/?P=*spdx.json&jsontable=1"
+obs_product_table_url = (
+    f"{settings.obs_download_url}/OBS:/PROJECT:/TEST/product/?{urlencode(get_obs_filter_params(settings.build_filter))}"
+)
 
 
 @dataclass

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,7 +36,7 @@ class ReviewState(NamedTuple):
     by_group: str
 
 
-obs_product_table_url = settings.obs_download_url + "/OBS:/PROJECT:/TEST/product/?jsontable=1"
+obs_product_table_url = settings.obs_download_url + "/OBS:/PROJECT:/TEST/product/?P=*spdx.json&jsontable=1"
 
 
 @dataclass


### PR DESCRIPTION
Motivation:
To reduce the amount of data transferred and noise in logs, use the P=
query parameter to filter the directory listing to only relevant .spdx.json
files at the IBS/OBS source.

Design Choices:
- Added ?P=*spdx.json to the directory listing URL in load_build_info.
- Updated test helper to reflect the new URL format.

Benefits:
- Faster artifact discovery.
- Reduced network overhead.

Related issue: https://progress.opensuse.org/issues/198728