### PR TITLE
refactor: use params for all other URL constructions

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -66,17 +66,28 @@ def make_token_header(token: str) -> dict[str, str]:
     return {} if token is None else {"Authorization": "token " + token}
 
 
-def get_json(query: str, token: dict[str, str], host: str | None = None) -> JsonType:
+def get_json(
+    query: str,
+    token: dict[str, str],
+    host: str | None = None,
+    params: dict[str, Any] | None = None,
+) -> JsonType:
     """Fetch JSON data from Gitea API."""
     host = host or config.settings.gitea_url
-    response = retried_requests.get(host + "/api/v1/" + query, verify=not config.settings.insecure, headers=token)
+    url = f"{host}/api/v1/{query}"
+    response = retried_requests.get(url, verify=not config.settings.insecure, headers=token, params=params)
     response.raise_for_status()
     return response.json()
 
 
-def get_json_list(query: str, token: dict[str, str], host: str | None = None) -> list[Any]:
+def get_json_list(
+    query: str,
+    token: dict[str, str],
+    host: str | None = None,
+    params: dict[str, Any] | None = None,
+) -> list[Any]:
     """Fetch a list of JSON data from Gitea API."""
-    res = get_json(query, token, host)
+    res = get_json(query, token, host, params=params)
     if not isinstance(res, list):
         msg = f"Gitea API returned {type(res).__name__} instead of list for query: {query}"
         raise TypeError(msg)
@@ -199,7 +210,7 @@ def get_open_prs(token: dict[str, str], repo: str, *, number: int | None) -> lis
         page = 1
         while True:
             # https://docs.gitea.com/api/1.20/#tag/repository/operation/repolistPullRequests
-            prs_on_page = get_json(f"repos/{repo}/pulls?state=open&page={page}", token)
+            prs_on_page = get_json(f"repos/{repo}/pulls", token, params={"state": "open", "page": page})
             if not isinstance(prs_on_page, list):
                 msg = f"Gitea API returned {type(prs_on_page).__name__} instead of list for PR pages"
                 raise TypeError(msg)
@@ -330,10 +341,10 @@ def _extract_version(name: str, prefix: str) -> str:
 def get_product_version_from_repo_listing(project: str, product_name: str, repository: str) -> str:
     """Determine the product version by inspecting an OBS repository listing."""
     project_path = project.replace(":", ":/")
-    url = f"{config.settings.obs_download_url}/{project_path}/{repository}/repo?jsontable"
+    url = f"{config.settings.obs_download_url}/{project_path}/{repository}/repo"
     start = f"{product_name}-"
     try:
-        r = retried_requests.get(url)
+        r = retried_requests.get(url, params={"jsontable": 1})
         r.raise_for_status()
         data = r.json()["data"]
     except requests.exceptions.HTTPError as e:

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -226,8 +226,11 @@ def get_aggregate_settings(sub: int, submission_type: str | None = None) -> list
 
 def get_aggregate_settings_data(data: Data) -> Sequence[Data]:
     """Fetch aggregate job settings data for a product and architecture."""
-    url = "api/update_settings" + f"?product={data.product}&arch={data.arch}"
-    settings = dashboard.get_json(url, headers=config_module.settings.dashboard_token_dict)
+    settings = dashboard.get_json(
+        "api/update_settings",
+        headers=config_module.settings.dashboard_token_dict,
+        params={"product": data.product, "arch": data.arch},
+    )
     if not settings:
         log.info("No aggregate settings found for product %s on arch %s", data.product, data.arch)
         return []

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -141,7 +141,10 @@ class OpenQAInterface:
         """Fetch older jobs for a specific job."""
         try:
             return self.openqa.openqa_request(
-                "GET", f"/tests/{job_id}/ajax?previous_limit={limit}&next_limit=0", retries=self.retries
+                "GET",
+                f"/tests/{job_id}/ajax",
+                {"previous_limit": limit, "next_limit": 0},
+                retries=self.retries,
             )
         except RequestError:
             log.exception("openQA API error when fetching older jobs for job %s", job_id)

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -77,9 +77,9 @@ def fake_dashboard_replyback() -> None:
 
 @pytest.fixture
 def fake_repo() -> None:
-    url = f"{settings.obs_download_url}/SUSE:/SLFO:/1.1.99:/PullRequest:/124:/SLES/standard/repo?jsontable"
+    url = f"{settings.obs_download_url}/SUSE:/SLFO:/1.1.99:/PullRequest:/124:/SLES/standard/repo"
     listing = Path("tests/fixtures/responses/test-product-repo.json").read_bytes()
-    responses.add(GET, url, body=listing)
+    responses.add(GET, url, body=listing, match=[matchers.query_param_matcher({"jsontable": "1"})])
 
 
 def fake_osc_http_get(url: str) -> etree.ElementTree:

--- a/tests/test_loader_qem.py
+++ b/tests/test_loader_qem.py
@@ -301,7 +301,9 @@ def test_get_aggregate_settings_data(mock_get_json: MagicMock) -> None:
     assert len(res) == 1
     assert res[0].settings_id == 1
     mock_get_json.assert_called_once_with(
-        "api/update_settings?product=product&arch=arch", headers=settings.dashboard_token_dict
+        "api/update_settings",
+        headers=settings.dashboard_token_dict,
+        params={"product": "product", "arch": "arch"},
     )
 
 


### PR DESCRIPTION
Motivation:
Consistently use the 'params' argument for URL query parameters
across the codebase to avoid manual string manipulation and ensure
proper encoding.

Design Choices:
- Refactored `get_json` and `get_json_list` in `openqabot/loader/gitea.py`
  to support `params` and updated callers.
- Updated `get_aggregate_settings_data` in `openqabot/loader/qem.py` to
  pass parameters via `params`.
- Refactored `get_older_jobs` in `openqabot/openqa.py` to use positional
  arguments for params as expected by `openqa_client`.
- Updated relevant test mocks in `tests/test_giteasync.py` and
  `tests/test_loader_qem.py`.

Benefits:
- Code consistency and readability.
- Robust handling of query parameters across different modules.