### PR TITLE
Fix repeated comments on gitea-trigger approvals

### DIFF
--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -164,13 +164,13 @@ class Commenter:
         # Add a marker so we can find our own comments later
         msg = add_marker(msg, "openqa", {"state": state})
 
-        comments = gitea.get_json_list(gitea.comments_url(repo, sub.id), self.gitea_token)
+        comments = gitea.iter_gitea_items(gitea.comments_url(repo, sub.id), self.gitea_token)
         formatted = {str(c["id"]): {"id": c["id"], "comment": c["body"]} for c in comments}
-        comment, _ = self.commentapi.comment_find(formatted, "openqa", {"state": state})
+        comment, info = self.commentapi.comment_find(formatted, "openqa")
 
         # To prevent spam, assume same state/result
         # and number of lines in message is a duplicate message
-        if comment and comment["comment"].count("\n") == msg.count("\n"):
+        if comment and info and info.get("state") == state and comment["comment"].count("\n") == msg.count("\n"):
             log.debug("Comment skipped: Previous comment is too similar")
             return
 

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -175,10 +175,11 @@ class GiteaTrigger:
                 )
                 # we looking only for PRs which has ALL labels defined via '--pr-label' parameter AND
                 # at least one for labels defined in staging.config
-                if pullrequest.has_all_labels(self.pr_required_labels) and pullrequest.has_any_label(
-                    set(self.staging_config_qa_labels.keys())
-                ):
+                qa_labels = set(self.staging_config_qa_labels.keys())
+                if pullrequest.has_all_labels(self.pr_required_labels) and pullrequest.has_any_label(qa_labels):
                     self.prs.append(pullrequest)
+                else:
+                    log.debug("PR %s disregarded (labels: %s)", pr_id, pullrequest.labels)
             except KeyError:
                 log.exception("Unable to process PR git:%s", pr_id)
         log.debug(

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -153,19 +153,19 @@ def read_xml(name: str) -> etree.ElementTree:
 
 def reviews_url(repo_name: str, number: int) -> str:
     """Construct the URL for PR reviews."""
-    # https://docs.gitea.com/api/1.20/#tag/repository/operation/repolistPullReviews
+    # https://docs.gitea.com/api/1.25/#tag/repository/operation/repolistPullReviews
     return f"repos/{repo_name}/pulls/{number}/reviews"
 
 
 def changed_files_url(repo_name: str, number: int) -> str:
     """Construct the URL for PR changed files."""
-    # https://docs.gitea.com/api/1.20/#tag/repository/operation/repoGetPullRequestFiles
+    # https://docs.gitea.com/api/1.25/#tag/repository/operation/repoGetPullRequestFiles
     return f"repos/{repo_name}/pulls/{number}/files"
 
 
 def comments_url(repo_name: str, number: int) -> str:
     """Construct the URL for PR comments."""
-    # https://docs.gitea.com/api/1.20/#tag/issue/operation/issueCreateComment
+    # https://docs.gitea.com/api/1.25/#tag/issue/operation/issueCreateComment
     return f"repos/{repo_name}/issues/{number}/comments"
 
 
@@ -210,7 +210,7 @@ def get_open_prs(token: dict[str, str], repo: str, *, number: int | None) -> lis
         return [cast("dict[str, Any]", pr)]
 
     try:
-        # https://docs.gitea.com/api/1.20/#tag/repository/operation/repolistPullRequests
+        # https://docs.gitea.com/api/1.25/#tag/repository/operation/repolistPullRequests
         return list(iter_gitea_items(f"repos/{repo}/pulls?state=open", token))
     except (requests.exceptions.RequestException, TypeError):
         log.exception("Gitea API error: Could not fetch open PRs from %s", repo)

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -80,24 +80,33 @@ def get_json(
     return response.json()
 
 
-def get_json_list(
-    query: str,
-    token: dict[str, str],
-    host: str | None = None,
-    params: dict[str, Any] | None = None,
-) -> list[Any]:
-    """Fetch a list of JSON data from Gitea API."""
-    res = get_json(query, token, host, params=params)
-    if not isinstance(res, list):
-        msg = f"Gitea API returned {type(res).__name__} instead of list for query: {query}"
-        raise TypeError(msg)
-    return res
+def iter_gitea_items(query: str, token: dict[str, str], host: str | None = None) -> Iterator[Any]:
+    """Fetch a list of JSON data from Gitea API with pagination support.
+
+    Yields:
+        JSON items from the paginated response.
+
+    """
+    host = host or config.settings.gitea_url
+    url = f"{host}/api/v1/{query}"
+
+    while url:
+        response = retried_requests.get(url, verify=not config.settings.insecure, headers=token)
+        response.raise_for_status()
+        res = response.json()
+
+        if not isinstance(res, list):
+            msg = f"Gitea API returned {type(res).__name__} instead of list for query: {query}"
+            raise TypeError(msg)
+
+        yield from res
+        url = response.links.get("next", {}).get("url")
 
 
 def _request_json(method: str, query: str, token: dict[str, str], post_data: JsonType, host: str | None = None) -> None:
     """Send a JSON request to Gitea API."""
     host = host or config.settings.gitea_url
-    url = host + "/api/v1/" + query
+    url = f"{host}/api/v1/{query}"
     res = getattr(retried_requests, method.lower())(
         url, verify=not config.settings.insecure, headers=token, json=post_data
     )
@@ -200,32 +209,11 @@ def get_open_prs(token: dict[str, str], repo: str, *, number: int | None) -> lis
         log.debug("PR git:%i: %s", number, pr)
         return [cast("dict[str, Any]", pr)]
 
-    def iter_pr_pages() -> Iterator[list[dict[str, Any]]]:
-        """Iterate through all pages of open PRs.
-
-        Yields:
-            Lists of open PRs.
-
-        """
-        page = 1
-        while True:
-            # https://docs.gitea.com/api/1.20/#tag/repository/operation/repolistPullRequests
-            prs_on_page = get_json(f"repos/{repo}/pulls", token, params={"state": "open", "page": page})
-            if not isinstance(prs_on_page, list):
-                msg = f"Gitea API returned {type(prs_on_page).__name__} instead of list for PR pages"
-                raise TypeError(msg)
-            if not prs_on_page:
-                return
-            yield prs_on_page
-            page += 1
-
     try:
-        return [pr for page in iter_pr_pages() for pr in page]
-    except requests.exceptions.JSONDecodeError:
-        log.exception("Gitea API error: Invalid JSON received for open PRs")
-        return []
-    except requests.exceptions.RequestException:
-        log.exception("Gitea API error: Could not fetch open PRs")
+        # https://docs.gitea.com/api/1.20/#tag/repository/operation/repolistPullRequests
+        return list(iter_gitea_items(f"repos/{repo}/pulls?state=open", token))
+    except (requests.exceptions.RequestException, TypeError):
+        log.exception("Gitea API error: Could not fetch open PRs from %s", repo)
         return []
 
 
@@ -237,7 +225,8 @@ def _approval_identifiers(bot_user: str, commit_id: str, *, approve: bool = True
 def _is_bot_approval_comment(comment: dict[str, Any], bot_user: str, commit_id: str) -> bool:
     """Check if a comment is an authentic approval from the bot."""
     body = comment.get("body", "")
-    is_author = comment.get("user", {}).get("login") == bot_user
+    allowed_authors = {bot_user, config.settings.obs_group}
+    is_author = comment.get("user", {}).get("login") in allowed_authors
     review_cmd, commit_str = _approval_identifiers(bot_user, commit_id)
     return is_author and review_cmd in body and commit_str in body
 
@@ -273,12 +262,12 @@ def approve_pr(token: dict[str, str], repo_name: str, pr_number: int, commit_id:
     try:
         bot_user = config.settings.git_review_bot_user
         if bot_user:
-            comments = get_json_list(comments_url(repo_name, pr_number), token)
+            comments = iter_gitea_items(comments_url(repo_name, pr_number), token)
             if any(_is_bot_approval_comment(c, bot_user, commit_id) for c in comments):
                 log.info("PR %s already approved via comment for commit %s", pr_number, commit_id)
                 return True
         else:
-            reviews = get_json_list(reviews_url(repo_name, pr_number), token)
+            reviews = iter_gitea_items(reviews_url(repo_name, pr_number), token)
             if any(
                 r.get("commit_id") == commit_id and r.get("state") == "APPROVED" and is_review_requested_by(r)
                 for r in reviews
@@ -286,6 +275,7 @@ def approve_pr(token: dict[str, str], repo_name: str, pr_number: int, commit_id:
                 log.info("PR %s already approved for commit %s", pr_number, commit_id)
                 return True
 
+        log.info("PR %s approved for commit %s", pr_number, commit_id)
         review_pr(token, repo_name, pr_number, msg, commit_id, approve=True)
     except Exception:
         log.exception("Gitea API error: Failed to approve PR %s", pr_number)
@@ -689,9 +679,9 @@ def _fetch_details(
             )
         return [], [], []
     return (
-        get_json_list(reviews_url(repo_name, number), token),
-        get_json_list(comments_url(repo_name, number), token),
-        get_json_list(changed_files_url(repo_name, number), token),
+        list(iter_gitea_items(reviews_url(repo_name, number), token)),
+        list(iter_gitea_items(comments_url(repo_name, number), token)),
+        list(iter_gitea_items(changed_files_url(repo_name, number), token)),
     )
 
 

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -44,7 +44,7 @@ def fake_gitea_api() -> None:
     # ruff: noqa: E501 line-too-long
     patchinfo_path = "products/SLFO/raw/commit/2cf58b3a9c32d139470a5f32d5aa64efbd0fa90dda0144b09421709252fcb0ea/patchinfo.23193048203482931/_patchinfo"
     patchinfo_data = Path("tests/fixtures/responses/patch-info.xml").read_bytes()
-    responses.add(GET, pulls_url + "?state=open&page=1", json=read_json_file("pulls"))
+    responses.add(GET, pulls_url + "?state=open", json=read_json_file("pulls"))
     responses.add(GET, re.compile(pulls_url + r"\?state=open&page=.*"), json=[])
     responses.add(GET, pulls_url + "/124/reviews", json=read_json_file("reviews-124"))
     responses.add(GET, pulls_url + "/124/files", json=read_json_file("files-124"))
@@ -174,7 +174,7 @@ def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCapture
     assert "Loaded 7 active PRs from products/SLFO" in caplog.messages
     assert "Fetching info for PR git:131 from Gitea" in caplog.messages
     assert "Syncing Gitea PRs to QEM Dashboard: Considering 1 submissions" in caplog.messages
-    assert len(responses.calls) == 25
+    assert len(responses.calls) == 24
     assert len(cast("Any", responses.calls[-1].response).json()) == 1
     submission = cast("Any", responses.calls[-1].response).json()[0]
     assert submission["number"] == 124

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -157,18 +157,45 @@ def test_add_channel_for_build_result_local() -> None:
     assert len(projects) == 0
 
 
-def test_get_json_list_success(mocker: MockerFixture) -> None:
-    mocker.patch("openqabot.loader.gitea.get_json", return_value=[{"id": 1}])
-    res = gitea.get_json_list("some/query", {"Authorization": "token test"})
-    assert res == [{"id": 1}]
+def test_get_json_success(mocker: MockerFixture) -> None:
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"id": 1}
+    mocker.patch("openqabot.loader.gitea.retried_requests.get", return_value=mock_response)
+    res = gitea.get_json("some/query", {"Authorization": "token test"})
+    assert res == {"id": 1}
 
 
-def test_get_json_list_throws_on_dict(mocker: MockerFixture) -> None:
-    # Mock get_json to return a dict instead of a list
-    mocker.patch("openqabot.loader.gitea.get_json", return_value={"message": "Not Found"})
+def test_iter_gitea_items_success(mocker: MockerFixture) -> None:
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = [{"id": 1}]
+    mock_response.links = {}
+    mocker.patch("openqabot.loader.gitea.retried_requests.get", return_value=mock_response)
+    res = gitea.iter_gitea_items("some/query", {"Authorization": "token test"})
+    assert list(res) == [{"id": 1}]
+
+
+def test_iter_gitea_items_pagination(mocker: MockerFixture) -> None:
+    mock_response1 = mocker.Mock()
+    mock_response1.json.return_value = [{"id": 1}]
+    mock_response1.links = {"next": {"url": "https://gitea.com/api/v1/some/query?page=2"}}
+    mock_response2 = mocker.Mock()
+    mock_response2.json.return_value = [{"id": 2}]
+    mock_response2.links = {}
+    mock_responses = [mock_response1, mock_response2]
+    mock_get = mocker.patch("openqabot.loader.gitea.retried_requests.get", side_effect=mock_responses)
+    res = gitea.iter_gitea_items("some/query", {"Authorization": "token test"})
+    assert list(res) == [{"id": 1}, {"id": 2}]
+    assert mock_get.call_count == 2
+
+
+def test_iter_gitea_items_throws_on_dict(mocker: MockerFixture) -> None:
+    mock_response = mocker.Mock()
+    mock_response.json.return_value = {"message": "Not Found"}
+    mock_response.links = {}
+    mocker.patch("openqabot.loader.gitea.retried_requests.get", return_value=mock_response)
     # New behavior: throws TypeError
     with pytest.raises(TypeError, match="Gitea API returned dict instead of list"):
-        gitea.get_json_list("some/query", {"Authorization": "token test"})
+        list(gitea.iter_gitea_items("some/query", {"Authorization": "token test"}))
 
 
 def test_read_json_file_list_success(mocker: MockerFixture) -> None:
@@ -253,7 +280,14 @@ def mock_settings(mocker: MockerFixture) -> MagicMock:
             None,
             True,
         ),
-        # Case 5: No bot comments found
+        # Case 5: Already approved via bot comment using obs_group name
+        (
+            "bot-review",
+            [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "openqa"}}],
+            "PR 123 already approved via comment for commit sha123",
+            False,
+        ),
+        # Case 6: No bot comments found
         ("bot", [], None, True),
     ],
 )
@@ -269,7 +303,7 @@ def test_approve_pr_scenarios(
     should_call_review: bool,
 ) -> None:
     caplog.set_level(logging.INFO, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json_list", return_value=api_response)
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=api_response)
 
     mock_settings.obs_group = "openqa"
     mock_settings.git_review_bot_user = bot_user
@@ -289,7 +323,7 @@ def test_approve_pr_exception(
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    mocker.patch("openqabot.loader.gitea.get_json_list", side_effect=Exception("API fail"))
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", side_effect=Exception("API fail"))
     caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
 
     res = gitea.approve_pr({}, "repo", 123, "sha123", "msg")

--- a/tests/test_loader_gitea_prs.py
+++ b/tests/test_loader_gitea_prs.py
@@ -26,32 +26,37 @@ def test_get_open_prs_metadata_error(mocker: MockerFixture, caplog: pytest.LogCa
 
 
 def test_get_open_prs_iter_pages(mocker: MockerFixture) -> None:
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=[[1], [2], []])
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[1, 2])
     res = gitea.get_open_prs({}, "repo", number=None)
     assert res == [1, 2]
 
 
-def test_get_open_prs_iter_pages_unexpected_dict(mocker: MockerFixture) -> None:
+def test_get_open_prs_iter_pages_unexpected_dict(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     """Cover the case where pagination returns a dict instead of a list."""
-    mocker.patch("openqabot.loader.gitea.get_json", return_value={"message": "error"})
-    with pytest.raises(TypeError, match="Gitea API returned dict instead of list for PR pages"):
-        gitea.get_open_prs({}, "repo", number=None)
+    caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
+    mocker.patch(
+        "openqabot.loader.gitea.iter_gitea_items", side_effect=TypeError("Gitea API returned dict instead of list")
+    )
+    res = gitea.get_open_prs({}, "repo", number=None)
+    assert res == []
+    assert "Gitea API error: Could not fetch open PRs from repo" in caplog.text
 
 
 def test_get_open_prs_json_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=requests.exceptions.JSONDecodeError("msg", "doc", 0))
+    # iter_gitea_items uses requests which might throw JSONDecodeError
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", side_effect=requests.exceptions.RequestException("error"))
     res = gitea.get_open_prs({}, "repo", number=None)
     assert res == []
-    assert "Gitea API error: Invalid JSON received for open PRs" in caplog.text
+    assert "Gitea API error: Could not fetch open PRs from repo" in caplog.text
 
 
 def test_get_open_prs_request_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=requests.exceptions.RequestException("error"))
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", side_effect=requests.exceptions.RequestException("error"))
     res = gitea.get_open_prs({}, "repo", number=None)
     assert res == []
-    assert "Gitea API error: Could not fetch open PRs" in caplog.text
+    assert "Gitea API error: Could not fetch open PRs from repo" in caplog.text
 
 
 def test_get_open_prs_specific_number_json_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_loader_gitea_submissions.py
+++ b/tests/test_loader_gitea_submissions.py
@@ -33,7 +33,7 @@ def test_make_submission_from_gitea_pr_dry(mocker: MockerFixture) -> None:
 def test_make_submission_from_gitea_pr_skips(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO, logger="bot.loader.gitea")
     pr = {"number": 123, "state": "open", "url": "url", "base": {"repo": {"full_name": "owner/repo", "name": "repo"}}}
-    mocker.patch("openqabot.loader.gitea.get_json", return_value=[])
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[])
 
     # Skip due to no channels
     res = gitea.make_submission_from_gitea_pr(pr, {}, only_successful_builds=False, only_requested_prs=False, dry=False)
@@ -61,6 +61,7 @@ def test_make_submission_from_gitea_pr_skips(mocker: MockerFixture, caplog: pyte
 
 def test_make_submission_from_gitea_pr_dry_other_number_passes(mocker: MockerFixture) -> None:
     pr = {"number": 999, "state": "open", "url": "url", "base": {"repo": {"full_name": "owner/repo", "name": "repo"}}}
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[])
     mocker.patch("openqabot.loader.gitea.add_reviews", return_value=1)
 
     def mock_add_chan(inc: dict, *_: Any, **__: Any) -> None:
@@ -81,7 +82,7 @@ def test_make_submission_from_gitea_pr_dry_other_number_passes(mocker: MockerFix
 def test_make_submission_from_gitea_pr_no_reviews(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO, logger="bot.loader.gitea")
     pr = {"number": 123, "state": "open", "url": "url", "base": {"repo": {"full_name": "owner/repo", "name": "repo"}}}
-    mocker.patch("openqabot.loader.gitea.get_json", return_value=[])
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[])
     mocker.patch("openqabot.loader.gitea.add_reviews", return_value=0)
     res = gitea.make_submission_from_gitea_pr(pr, {}, only_successful_builds=False, only_requested_prs=True, dry=False)
     assert res is None


### PR DESCRIPTION
* fix: handle bot author mismatch in Gitea approval deduplication
* fix: avoid repeated Gitea PR comments with pagination and matching

Verified manually with a wet-run and a read-only gitea token using the command

```
./qem-bot.py --gitea-token … --debug gitea-trigger --pr-label "staging/In Progress"
```

which now yields log messages like

```
Evaluating PR 3225 for openQA triggering
openQA tests for PR 3225 (build PR-3225-3.19:SLES-16.1) are already covered
PR 3225 already approved via comment for commit …
```

Related issue: https://progress.opensuse.org/issues/197906