### PR TITLE
feat: add devel flag to increment-approve and remove devel job filtering

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -528,6 +528,10 @@ def increment_approve(  # noqa: PLR0913
             help="Monitor and schedule only products with the specified DISTRI parameter",
         ),
     ] = "sle",
+    devel: Annotated[
+        bool,
+        typer.Option("--devel", envvar="QEM_BOT_DEVEL", help="Include development openQA jobs"),
+    ] = False,
     version: Annotated[
         str,
         typer.Option(
@@ -601,6 +605,7 @@ def increment_approve(  # noqa: PLR0913
     args.build_project_suffix = build_project_suffix
     args.diff_project_suffix = diff_project_suffix
     args.distri = distri
+    args.devel = devel
     args.version = version
     args.flavor = flavor
     args.schedule = schedule

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -43,6 +43,7 @@ class Settings(BaseSettings):
     gitea_branch_name: str | None = Field(default="slfo-main", alias="GITEA_BRANCH_NAME")
     openqa_instance: str = Field(default="https://openqa.suse.de", alias="OPENQA_INSTANCE")
     singlearch: Path = Field(default=Path("/etc/openqabot/singlearch.yml"), alias="QEM_BOT_SINGLEARCH")
+    devel: bool = Field(default=False, alias="QEM_BOT_DEVEL")
     retry: int = Field(default=2, alias="QEM_BOT_RETRY")
     approve_comment: bool = Field(default=False, alias="QEM_BOT_APPROVE_COMMENT")
 

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -102,18 +102,6 @@ class IncrementApprover:
             )
         return match
 
-    def _filter_jobs(self, jobs: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
-        """Filter jobs within a state, removing those in devel groups."""
-        return {
-            name: {**info, "job_ids": ids}
-            for name, info in jobs.items()
-            if (ids := [i for i in info["job_ids"] if not self.is_in_devel_group(i)])
-        }
-
-    def _filter_results(self, results: OpenQAResults) -> OpenQAResults:
-        """Remove jobs belonging to development groups from openQA results."""
-        return [{s: f for s, j in res.items() if (f := self._filter_jobs(j))} for res in results]
-
     def request_openqa_job_results(self, params: ScheduleParams, info_str: str) -> OpenQAResults:
         """Fetch results from openQA for the specified scheduling parameters."""
         log.debug("Checking openQA job results for %s", info_str)
@@ -143,11 +131,6 @@ class IncrementApprover:
             build_info.log_pending_jobs(pending_states)
             return False
         return True
-
-    def is_in_devel_group(self, job_id: int) -> bool:
-        """Fetch job details and check if it belongs to a development group."""
-        job = self.client.get_single_job(job_id)
-        return self.client.is_in_devel_group(job) if job else False
 
     def evaluate_openqa_job_results(
         self,
@@ -196,6 +179,9 @@ class IncrementApprover:
 
     def handle_approval(self, approval_status: ApprovalStatus) -> int:
         """Process approval or disapproval based on job results."""
+        if approval_status.devel:
+            log.info("Skip approval status because IncrementConfig has devel=True")
+            return 0
         reasons_to_disapprove = approval_status.reasons_to_disapprove
         reqid = approval_status.request.reqid
         id_msg = f"OBS request {config.settings.obs_web_url}/request/show/{reqid}"
@@ -469,7 +455,7 @@ class IncrementApprover:
             request.reqid,
             info_str,
         )
-        res = self._filter_results(self.request_openqa_job_results(params, info_str))
+        res = self.request_openqa_job_results(params, info_str)
 
         if self.args.reschedule:
             approval_status.reasons_to_disapprove.append(f"Re-scheduling jobs for {info_str}")
@@ -486,13 +472,13 @@ class IncrementApprover:
             build_info, params, info_str, openqa_jobs_ready=openqa_jobs_ready, approval_status=approval_status
         )
 
-    def _get_approval_status(self, request: osc.core.Request) -> ApprovalStatus:
+    def _get_approval_status(self, request: osc.core.Request, *, devel: bool) -> ApprovalStatus:
         """Get or create the approval status for an OBS request."""
         request_id = request.reqid
         if request_id in self.requests_to_approve:
             return self.requests_to_approve[request_id]
 
-        status = ApprovalStatus(request, set(), [], set(), set(), [])
+        status = ApprovalStatus(request, devel, set(), [], set(), set(), [])
         self.requests_to_approve[request_id] = status
         return status
 
@@ -501,7 +487,7 @@ class IncrementApprover:
         if request is None:
             return 0
 
-        approval_status = self._get_approval_status(request)
+        approval_status = self._get_approval_status(request, devel=config_inc.devel)
         error_count = 0
         found_relevant_build = False
         for build_info in load_build_info(

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -33,6 +33,7 @@ class IncrementConfig:
     distri: str
     version: str
     flavor: str
+    devel: bool = False
     flavor_suffix: str = DEFAULT_FLAVOR_SUFFIX
     project_base: str = ""
     build_project_suffix: str = ""
@@ -79,6 +80,7 @@ class IncrementConfig:
         """Create an IncrementConfig from a dictionary entry."""
         return IncrementConfig(
             distri=entry["distri"],
+            devel=entry.get("devel", False),
             version=entry.get("version", "any"),
             flavor=entry.get("flavor", "any"),
             flavor_suffix=entry.get("flavor_suffix", DEFAULT_FLAVOR_SUFFIX),
@@ -139,6 +141,7 @@ class IncrementConfig:
             field_name: getattr(args, field_name)
             for field_name in [
                 "distri",
+                "devel",
                 "version",
                 "flavor",
                 "flavor_suffix",

--- a/openqabot/types/increment.py
+++ b/openqabot/types/increment.py
@@ -79,6 +79,7 @@ class ApprovalStatus(NamedTuple):
     """Status of an approval request."""
 
     request: osc.core.Request
+    devel: bool
     ok_jobs: set[int]
     reasons_to_disapprove: list[str]
     processed_jobs: set[tuple[str, str, str, str, str, str]]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -229,6 +229,7 @@ def prepare_approver(
         build_project_suffix="TEST",
         diff_project_suffix=diff_project_suffix,
         distri="sle",
+        devel=False if config is None else config.devel,
         version="16.0",
         flavor="Online-Increments",
         schedule=schedule,
@@ -262,6 +263,7 @@ def prepare_approver_with_additional_config(caplog: pytest.LogCaptureFixture) ->
     increment_approver.config[0].product_regex = product_regex
     additional_config = IncrementConfig(
         distri="sle",
+        devel=True,
         version="16.0",
         flavor="Online-Increments",
         project_base="OBS:PROJECT",

--- a/tests/test_incrementapprover_build_info.py
+++ b/tests/test_incrementapprover_build_info.py
@@ -38,6 +38,7 @@ def test_no_approval_if_one_of_two_configs_has_no_builds(
     approver = prepare_approver(caplog)
     config2 = IncrementConfig(
         distri="sle",
+        devel=False,
         version="16.0",
         flavor="Full-Increments",
         project_base="OBS:PROJECT",
@@ -62,6 +63,7 @@ def testload_build_info_no_match(caplog: pytest.LogCaptureFixture, mocker: Mocke
     approver = prepare_approver(caplog)
     config = IncrementConfig(
         distri="other",
+        devel=True,
         version="any",
         flavor="any",
         project_base="BASE",

--- a/tests/test_incrementapprover_helpers.py
+++ b/tests/test_incrementapprover_helpers.py
@@ -80,13 +80,3 @@ def test_extra_builds_for_package_filtering(caplog: pytest.LogCaptureFixture) ->
     # nosrc architecture
     pkg5 = Package("kernel-livepatch", "0", "20240101", "1.1", "nosrc")
     assert approver.extra_builds_for_package(pkg5, config, build_info) is None
-
-
-def test_filter_results(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
-    approver = prepare_approver(caplog)
-    mocker.patch.object(approver.client, "is_in_devel_group", side_effect=lambda j: j.get("id") == 2)
-    mocker.patch.object(approver.client, "get_single_job", side_effect=lambda j: {"id": j})
-
-    results = [{"passed": {"j1": {"job_ids": [1]}, "j2": {"job_ids": [1, 2]}}, "failed": {"j3": {"job_ids": [2]}}}]
-    expected = [{"passed": {"j1": {"job_ids": [1]}, "j2": {"job_ids": [1]}}}]
-    assert approver._filter_results(results) == expected  # noqa: SLF001

--- a/tests/test_incrementapprover_obs.py
+++ b/tests/test_incrementapprover_obs.py
@@ -142,7 +142,15 @@ def testhandle_approval_dry(caplog: pytest.LogCaptureFixture, mocker: MockerFixt
         approver = IncrementApprover(args)
         req = mocker.Mock(spec=osc.core.Request)
         req.reqid = 123
-        status = ApprovalStatus(req, ok_jobs={1}, reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[])
+        status = ApprovalStatus(
+            req,
+            devel=False,
+            ok_jobs={1},
+            reasons_to_disapprove=[],
+            processed_jobs=set(),
+            builds=set(),
+            jobs=[],
+        )
         mock_osc_change = mocker.patch("osc.core.change_review_state")
 
         approver.handle_approval(status)
@@ -165,11 +173,38 @@ def testhandle_approval_no_jobs_safeguard(caplog: pytest.LogCaptureFixture, mock
     approver = prepare_approver(caplog)
     req = mocker.Mock(spec=osc.core.Request)
     req.reqid = 123
-    status = ApprovalStatus(req, ok_jobs=set(), reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[])
+    status = ApprovalStatus(
+        req,
+        devel=False,
+        ok_jobs=set(),
+        reasons_to_disapprove=[],
+        processed_jobs=set(),
+        builds=set(),
+        jobs=[],
+    )
 
     approver.handle_approval(status)
     assert "No openQA jobs were found/checked for this request." in caplog.text
     assert "Not approving OBS request https://build.suse.de/request/show/123 for the following reasons:" in caplog.text
+
+
+def test_handle_approval_devel_skip(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    approver = prepare_approver(caplog)
+    req = mocker.Mock(spec=osc.core.Request)
+    req.reqid = 123
+    status = ApprovalStatus(
+        req,
+        devel=True,
+        ok_jobs=set(),
+        reasons_to_disapprove=[],
+        processed_jobs=set(),
+        builds=set(),
+        jobs=[],
+    )
+
+    res = approver.handle_approval(status)
+    assert res == 0
+    assert "Skip approval status because IncrementConfig has devel=True" in caplog.text
 
 
 @responses.activate

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -268,7 +268,13 @@ def test_check_unique_jobid_request_pair_ambiguity_found(
 def test_handle_approval_valid_request_id(caplog: pytest.LogCaptureFixture, fake_osc_request: osc.core.Request) -> None:
     approver = prepare_approver(caplog)
     status = ApprovalStatus(
-        fake_osc_request, ok_jobs={1, 2}, reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[]
+        fake_osc_request,
+        devel=False,
+        ok_jobs={1, 2},
+        reasons_to_disapprove=[],
+        processed_jobs=set(),
+        builds=set(),
+        jobs=[],
     )
 
     approver.handle_approval(status)
@@ -282,6 +288,7 @@ def test_handle_approval_disapprove(caplog: pytest.LogCaptureFixture, fake_osc_r
     approver = prepare_approver(caplog)
     status = ApprovalStatus(
         fake_osc_request,
+        devel=False,
         ok_jobs=set(),
         reasons_to_disapprove=["failed jobs"],
         processed_jobs=set(),
@@ -491,116 +498,6 @@ def test_issue_194074_specific_request_sles(
     )
 
 
-@responses.activate
-@pytest.mark.usefixtures("fake_product_repo", "mock_osc")
-def test_approval_if_failing_jobs_are_in_development_group(
-    mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_openqa_url_job_stat: str
-) -> None:
-    # 1. Setup: a failed job exists in job_stats
-    responses.add(
-        responses.GET,
-        fake_openqa_url_job_stat,
-        json={"done": {"failed": {"job_ids": [123]}}},
-    )
-
-    # 2. Mock OpenQAInterface.get_single_job to return job details
-    # and OpenQAInterface.is_devel_group to return True for its group_id
-    mock_job = {
-        "id": 123,
-        "group": "Development Group",
-        "group_id": 9,
-        "result": "failed",
-    }
-    # 3. Run IncrementApprover
-    increment_approver = prepare_approver(caplog)
-    increment_approver.client.get_single_job = mocker.Mock(return_value=mock_job)
-    increment_approver.client.is_devel_group = mocker.Mock(return_value=True)
-    increment_approver()
-
-    # 4. Verification:
-    # Since the only job was in a development group, it should be ignored.
-    # The IncrementApprover should report "No jobs scheduled for ..."
-    # because the failed job was filtered out upfront.
-    assert "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:" in caplog.text
-    assert "No jobs scheduled for" in caplog.text
-
-
-@responses.activate
-@pytest.mark.usefixtures("fake_product_repo", "mock_osc")
-def test_approval_with_mixed_jobs_development_ignored(
-    mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_openqa_url_job_stat: str
-) -> None:
-    # 1. Setup: one failed (devel) and one passed (prod) job
-    responses.add(
-        responses.GET,
-        fake_openqa_url_job_stat,
-        json={"done": {"failed": {"job_ids": [123]}, "passed": {"job_ids": [456]}}},
-    )
-
-    def mock_get_single_job(job_id: int) -> dict[str, Any]:
-        if job_id == 123:
-            return {"id": 123, "group": "Development", "group_id": 9, "result": "failed"}
-        return {"id": 456, "group": "Production", "group_id": 1, "result": "passed"}
-
-    def mock_is_devel_group(group_id: int) -> bool:
-        return group_id == 9
-
-    mock_osc_approve = mocker.patch("osc.core.change_review_state")
-
-    # 3. Run IncrementApprover
-    increment_approver = prepare_approver(caplog)
-    increment_approver.client.get_single_job = mocker.Mock(side_effect=mock_get_single_job)
-    increment_approver.client.is_devel_group = mocker.Mock(side_effect=mock_is_devel_group)
-    increment_approver()
-
-    # 4. Verification:
-    # Job 123 (failed) is ignored. Job 456 (passed) is counted.
-    # The request should be approved because all RELEVANT jobs passed.
-    mock_osc_approve.assert_called()
-    # The message should say "All 1 openQA jobs have passed/softfailed"
-    # because only one job (456) was considered relevant.
-    _, kwargs = mock_osc_approve.call_args
-    assert "All 1 openQA jobs have passed/softfailed" in kwargs["message"]
-    assert (
-        "Approving OBS request https://build.suse.de/request/show/42: All 1 openQA jobs have passed/softfailed"
-        in caplog.text
-    )
-
-
-@responses.activate
-@pytest.mark.usefixtures("fake_product_repo", "mock_osc")
-def test_approval_if_running_jobs_are_in_development_group(
-    mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_openqa_url_job_stat: str
-) -> None:
-    # 1. Setup: a running job in devel group and a passed job in prod group
-    responses.add(
-        responses.GET,
-        fake_openqa_url_job_stat,
-        json={"running": {"some_job": {"job_ids": [123]}}, "done": {"passed": {"job_ids": [456]}}},
-    )
-
-    def mock_get_single_job(job_id: int) -> dict[str, Any]:
-        if job_id == 123:
-            return {"id": 123, "group": "Development", "group_id": 9, "state": "running"}
-        return {"id": 456, "group": "Production", "group_id": 1, "state": "done", "result": "passed"}
-
-    def mock_is_in_devel_group(job: dict[str, Any]) -> bool:
-        return "Development" in job.get("group", "")
-
-    mock_osc_approve = mocker.patch("osc.core.change_review_state")
-
-    increment_approver = prepare_approver(caplog)
-    increment_approver.client.get_single_job = mocker.Mock(side_effect=mock_get_single_job)
-    increment_approver.client.is_in_devel_group = mocker.Mock(side_effect=mock_is_in_devel_group)
-    increment_approver()
-
-    # 4. Verification:
-    # Job 123 (running) is ignored. Job 456 (passed) is counted.
-    # The request should be approved.
-    assert "All 1 openQA jobs have passed/softfailed" in caplog.text
-    mock_osc_approve.assert_called()
-
-
 def test_handle_approval_with_comment_flag(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_osc_request: osc.core.Request
 ) -> None:
@@ -611,6 +508,7 @@ def test_handle_approval_with_comment_flag(
     mocker.patch.object(approver, "approve_on_obs")
     status = ApprovalStatus(
         fake_osc_request,
+        devel=False,
         ok_jobs={1, 2},
         reasons_to_disapprove=[],
         processed_jobs=set(),


### PR DESCRIPTION


- Add --devel CLI option and QEM_BOT_DEVEL environment variable to the increment-approve command.
- Introduce devel field to IncrementConfig and ApprovalStatus to track development mode.
- Remove automatic filtering of openQA jobs in development groups by deleting _filter_results and _filter_jobs from IncrementApprover.
- Update handle_approval to skip OBS request approval when the devel flag is enabled.
- Align the test suite by removing tests for deleted filtering logic and updating ApprovalStatus constructor calls.
- Add test_handle_approval_devel_skip to verify approval skipping in development mode.
