### PR TITLE
fix: resolve ty type check errors revealed by new ty version

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -151,7 +151,7 @@ def fake_get_request_list(url: str, project: str, **_kwargs: Any) -> list[osc.co
     assert "OBS:PROJECT" in project
     req = osc.core.Request()
     req.reqid = 42
-    req.state = "review"
+    req.state = "review"  # ty: ignore[invalid-assignment]
     req.reviews = [ReviewState("review", settings.obs_group)]
     req.actions = [
         Action(

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -353,7 +353,7 @@ def test_skipping_with_mismatching_package(mocker: MockerFixture, caplog: pytest
 def mock_osc_requests(mocker: MockerFixture) -> None:
     def fake_get_request_list(_url: str, project: str, **_kwargs: Any) -> list[osc.core.Request]:
         req = osc.core.Request()
-        req.state = "review"
+        req.state = "review"  # ty: ignore[invalid-assignment]
         req.reviews = [ReviewState("review", "qam-openqa")]
         if "SL-Micro" in project:
             req.reqid = "399766"

--- a/tests/test_openqabot_simple.py
+++ b/tests/test_openqabot_simple.py
@@ -14,6 +14,7 @@ import pytest
 import responses
 from openqabot.config import QEM_DASHBOARD
 from openqabot.errors import PostOpenQAError
+from openqabot.openqa import OpenQAInterface
 from openqabot.openqabot import OpenQABot
 
 if TYPE_CHECKING:
@@ -128,10 +129,10 @@ def test_passed_post_osd_failed(mocked_openqa_bot: Namespace, caplog: pytest.Log
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_post_qem_success(mocked_openqa_bot: Namespace) -> None:
+def test_post_qem_success(mocked_openqa_bot: Namespace, mocker: MockerFixture) -> None:
 
     bot = OpenQABot(mocked_openqa_bot)
-    bot.openqa = True
+    bot.openqa = mocker.Mock(spec=OpenQAInterface)
     test_api = "api/jobs/incident/1"
     test_data = {"status": "passed", "job_id": 999}
     responses.add(


### PR DESCRIPTION
Design Choices:
- Applied '# ty: ignore[invalid-assignment]' to 'osc.core.Request().state'
  assignments in 'tests/helpers.py' and also in
  'tests/test_incrementapprover_scenarios.py'. This avoids AttributeError
  when 'to_xml()' is called on real Request objects during debug logging,
  as our fake Action objects lack this method.
- Replaced 'bot.openqa = True' with a proper mock of 'OpenQAInterface'
  in 'tests/test_openqabot_simple.py' to satisfy strict type checking
  while maintaining boolean truthiness for conditional logic.