### PR TITLE
ci: prevent duplicate call to ruff with inconsistent version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
-        with:
-          version: "latest"
-      - name: Check format
-        run: ruff format --check
       - uses: actions/setup-python@v6
         with:
           python-version-file: "pyproject.toml"


### PR DESCRIPTION
Since be354b16 the very qick "checkstyle" including ruff is called
implicitly as part of the "make test-with-coverage" Makefile target. But
the "ruff-action" in GitHub actions executes ruff using the latest
upstream ruff version leading to inconsistent results.