### PR TITLE
fix: use env in shebang for virtual environment support

### DIFF
--- a/qem-bot.py
+++ b/qem-bot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright SUSE LLC
 # SPDX-License-Identifier: MIT
 """Main script to run the bot."""


### PR DESCRIPTION


 Changes the shebang in qem-bot.py
from /usr/bin/python3 to /usr/bin/env python3.
This allows the script to use the Python interpreter
from an active virtual environment.
