### PR TITLE
feat: use REGEX query parameter for server-side filtering

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -593,7 +593,7 @@ def increment_approve(  # noqa: PLR0913
         typer.Option("--product-regex", help="The regex used to determine what products are relevant"),
     ] = "^SLE.*",
     build_filter: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--build-filter",
             envvar="QEM_BOT_BUILD_FILTER",

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -592,14 +592,6 @@ def increment_approve(  # noqa: PLR0913
         str,
         typer.Option("--product-regex", help="The regex used to determine what products are relevant"),
     ] = "^SLE.*",
-    build_filter: Annotated[
-        str | None,
-        typer.Option(
-            "--build-filter",
-            envvar="QEM_BOT_BUILD_FILTER",
-            help="The server-side pattern matching filter for the build listing",
-        ),
-    ] = config_module.settings.build_filter,
     increment_config: Annotated[
         Path | None,
         typer.Option(
@@ -626,7 +618,6 @@ def increment_approve(  # noqa: PLR0913
     args.build_listing_sub_path = build_listing_sub_path
     args.build_regex = build_regex
     args.product_regex = product_regex
-    args.build_filter = build_filter
     args.increment_config = increment_config
     args.comment = comment
 

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -45,7 +45,6 @@ class Settings(BaseSettings):
     singlearch: Path = Field(default=Path("/etc/openqabot/singlearch.yml"), alias="QEM_BOT_SINGLEARCH")
     retry: int = Field(default=2, alias="QEM_BOT_RETRY")
     approve_comment: bool = Field(default=False, alias="QEM_BOT_APPROVE_COMMENT")
-    build_filter: str | None = Field(default=None, alias="QEM_BOT_BUILD_FILTER")
 
     # App-specific settings
     qem_dashboard_url: str = Field(default="http://dashboard.qam.suse.de/", alias="QEM_DASHBOARD_URL")

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
     singlearch: Path = Field(default=Path("/etc/openqabot/singlearch.yml"), alias="QEM_BOT_SINGLEARCH")
     retry: int = Field(default=2, alias="QEM_BOT_RETRY")
     approve_comment: bool = Field(default=False, alias="QEM_BOT_APPROVE_COMMENT")
-    build_filter: str = Field(default="*spdx.json", alias="QEM_BOT_BUILD_FILTER")
+    build_filter: str | None = Field(default=None, alias="QEM_BOT_BUILD_FILTER")
 
     # App-specific settings
     qem_dashboard_url: str = Field(default="http://dashboard.qam.suse.de/", alias="QEM_DASHBOARD_URL")

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -32,7 +32,7 @@ def load_build_info(
     build_project_url = config.build_project_url()
     sub_path = config.build_listing_sub_path
     url = f"{build_project_url}/{sub_path}/"
-    params = get_obs_filter_params(config.build_filter)
+    params = get_obs_filter_params(config.build_filter or build_regex)
     log.debug("Checking for '%s' files on %s with params %s", build_regex, url, params)
     rows = retried_requests.get(url, params=params).json().get("data", [])
 

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -32,7 +32,7 @@ def load_build_info(
     build_project_url = config.build_project_url()
     sub_path = config.build_listing_sub_path
     url = f"{build_project_url}/{sub_path}/"
-    params = get_obs_filter_params(config.build_filter or build_regex)
+    params = get_obs_filter_params(build_regex)
     log.debug("Checking for '%s' files on %s with params %s", build_regex, url, params)
     rows = retried_requests.get(url, params=params).json().get("data", [])
 

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -41,7 +41,7 @@ class IncrementConfig:
     build_listing_sub_path: str = ""
     build_regex: str = ""
     product_regex: str = ""
-    build_filter: str = field(default_factory=lambda: config.settings.build_filter)
+    build_filter: str | None = field(default_factory=lambda: config.settings.build_filter)
     version_regex: str = DEFAULT_VERSION_REGEX
     packages: list[str] = field(default_factory=list)
     archs: set[str] = field(default_factory=set)

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -41,7 +41,6 @@ class IncrementConfig:
     build_listing_sub_path: str = ""
     build_regex: str = ""
     product_regex: str = ""
-    build_filter: str | None = field(default_factory=lambda: config.settings.build_filter)
     version_regex: str = DEFAULT_VERSION_REGEX
     packages: list[str] = field(default_factory=list)
     archs: set[str] = field(default_factory=set)
@@ -91,7 +90,6 @@ class IncrementConfig:
             build_listing_sub_path=entry["build_listing_sub_path"],
             build_regex=entry["build_regex"],
             product_regex=entry["product_regex"],
-            build_filter=entry.get("build_filter", config.settings.build_filter),
             version_regex=entry.get("version_regex", DEFAULT_VERSION_REGEX),
             packages=entry.get("packages", []),
             archs=set(entry.get("archs", [])),

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -109,7 +109,7 @@ class RepoDiff:
             url,
             f"repodata-listing-{project}.json",
             as_json=True,
-            params=get_obs_filter_params("*-primary.xml*"),
+            params=get_obs_filter_params(r".*-primary\.xml.*"),
         )
         if not repo_data_listing or not isinstance(repo_data_listing, dict):
             log.error("Could not load repo data for project %s", project)

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -109,15 +109,15 @@ def merge_dicts(dict1: dict[Any, Any], dict2: dict[Any, Any]) -> dict[Any, Any]:
 
 
 def get_obs_filter_params(pattern: str) -> dict[str, Any]:
-    """Reduce data transfer by evaluating the 'P' parameter at the source via 'jsontable'.
+    """Reduce data transfer by evaluating the 'REGEX' parameter at the source via 'jsontable'.
 
     References:
-        * https://github.com/openSUSE/MirrorCache/blob/207d61237c0597f8f4ff9d7ad12c4f9cb5d5cd1f/lib/MirrorCache/Datamodule.pm#L311
+        * https://github.com/openSUSE/MirrorCache/blob/207d61237c0597f8f4ff9d7ad12c4f9cb5d5cd1f/lib/MirrorCache/Datamodule.pm#L309
         * https://github.com/openSUSE/MirrorCache/issues/349
         * https://github.com/openSUSE/MirrorCache/pull/334
 
     """
-    return {"P": pattern, "jsontable": 1}
+    return {"REGEX": pattern, "jsontable": 1}
 
 
 def unique_dicts(dicts: list[dict[Any, Any]]) -> list[dict[Any, Any]]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,7 +38,7 @@ class ReviewState(NamedTuple):
 
 
 obs_product_table_url = (
-    f"{settings.obs_download_url}/OBS:/PROJECT:/TEST/product/?{urlencode(get_obs_filter_params(settings.build_filter))}"
+    f"{settings.obs_download_url}/OBS:/PROJECT:/TEST/product/?{urlencode(get_obs_filter_params(BUILD_REGEX))}"
 )
 
 


### PR DESCRIPTION
Motivation:
To provide more powerful and precise server-side filtering of directory
listings on IBS/OBS, switch from the globbing 'P' parameter to the 'REGEX'
parameter. This allows using the fully configured build regex for filtering
at the source, reducing data transfer and noise.

Design Choices:
- Updated get_obs_filter_params to use 'REGEX' key instead of 'P'.
- Changed build_filter default to None to allow leveraging build_regex as the
  default server-side filter.
- Updated load_build_info to use build_regex if no explicit build_filter is
  provided.
- Updated repodiff.py to use a proper regex for primary XML discovery.
- Updated test helpers to reflect the new URL format and parameters.

Benefits:
- More efficient artifact discovery by filtering out irrelevant files
  (e.g. -Debug, -Source) directly on the server.
- Better consistency by leveraging existing regex configurations for
  server-side filtering.

Related issue: https://progress.opensuse.org/issues/198728