### PR TITLE
fix: implement cooldown for submission rescheduling

### DIFF
--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -80,6 +80,7 @@ class Settings(BaseSettings):
         default="Contact qem-bot maintainers for generic questions", alias="QEM_GENERIC_TOOL_ISSUES_CONTACT"
     )
     max_detailed_comment_entries: int = Field(default=7, alias="QEM_MAX_DETAILED_COMMENT_ENTRIES")
+    schedule_cooldown: int = Field(default=7200, alias="QEM_BOT_SCHEDULE_COOLDOWN")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -95,13 +95,34 @@ class Submissions(BaseConf):
             return False
 
         jobs = Submissions._get_scheduled_jobs(ctx.sub.id, submission_type)
-        return any(
-            job["flavor"] == ctx.flavor
-            and job["arch"] == ctx.arch
-            and job["version"] == ver
-            and job.get("settings", {}).get("REPOHASH") == revs
-            for job in jobs
-        )
+        relevant_jobs = [
+            job for job in jobs if job["flavor"] == ctx.flavor and job["arch"] == ctx.arch and job["version"] == ver
+        ]
+
+        if not relevant_jobs:
+            return False
+
+        # Find the most recent REPOHASH among existing jobs
+        old_revs = [job.get("settings", {}).get("REPOHASH", 0) for job in relevant_jobs]
+        max_old_revs = max(old_revs)
+
+        if revs <= max_old_revs:
+            return True
+
+        # Check if the new REPOHASH is within the cooldown period
+        if (revs - max_old_revs) < settings.schedule_cooldown:
+            log.info(
+                "Submission %s: New RepoHash %s for %s on %s is within cooldown period (diff: %ss < %ss)",
+                ctx.sub,
+                revs,
+                ctx.flavor,
+                ctx.arch,
+                revs - max_old_revs,
+                settings.schedule_cooldown,
+            )
+            return True
+
+        return False
 
     def make_repo_url(self, sub: Submission, chan: Repos) -> str:
         """Construct the repository URL for a submission channel."""

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -2,8 +2,14 @@
 # SPDX-License-Identifier: MIT
 """Test Submissions."""
 
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from openqabot.config import settings
 from openqabot.types.baseconf import JobConfig
-from openqabot.types.submissions import Submissions
+from openqabot.types.submissions import SubContext, Submissions
 from openqabot.types.types import Repos
 
 from .fixtures.submissions import MockSubmission
@@ -66,3 +72,88 @@ def test_making_repo_url() -> None:
     repo = subs.make_repo_url(sub, slfo_chan)
     exp_repo = "http://%REPO_MIRROR_HOST%/ibs/SUSE:/SLFO:/SUSE:/SLFO:/1.1.99:/PullRequest:/166:/SLES/product/repo/SLES-15.99-x86_64/"
     assert repo == exp_repo
+
+
+@pytest.fixture
+def sub_context() -> SubContext:
+    """Fixture for SubContext."""
+    sub = MagicMock()
+    sub.id = 123
+    sub.revisions_with_fallback.return_value = 2000
+    return SubContext(sub, "x86_64", "flavor", {"some": "data"})
+
+
+def test_is_scheduled_job_no_existing_jobs(mocker: Any, sub_context: SubContext) -> None:
+    """Test when no jobs are scheduled."""
+    mocker.patch("openqabot.types.submissions.Submissions._get_scheduled_jobs", return_value=[])
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is False
+
+
+def test_is_scheduled_job_exact_match(mocker: Any, sub_context: SubContext) -> None:
+    """Test when a job with exact REPOHASH is already scheduled."""
+    mocker.patch(
+        "openqabot.types.submissions.Submissions._get_scheduled_jobs",
+        return_value=[{"flavor": "flavor", "arch": "x86_64", "version": "15-SP3", "settings": {"REPOHASH": 2000}}],
+    )
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is True
+
+
+def test_is_scheduled_job_older_match(mocker: Any, sub_context: SubContext) -> None:
+    """Test when a job with newer REPOHASH is already scheduled."""
+    mocker.patch(
+        "openqabot.types.submissions.Submissions._get_scheduled_jobs",
+        return_value=[{"flavor": "flavor", "arch": "x86_64", "version": "15-SP3", "settings": {"REPOHASH": 2001}}],
+    )
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is True
+
+
+def test_is_scheduled_job_within_cooldown(mocker: Any, sub_context: SubContext) -> None:
+    """Test when a new REPOHASH is within the cooldown period."""
+    # Existing job has REPOHASH 1000. New REPOHASH is 2000.
+    # Diff is 1000. Default cooldown is 7200.
+    mocker.patch(
+        "openqabot.types.submissions.Submissions._get_scheduled_jobs",
+        return_value=[{"flavor": "flavor", "arch": "x86_64", "version": "15-SP3", "settings": {"REPOHASH": 1000}}],
+    )
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is True
+
+
+def test_is_scheduled_job_outside_cooldown(mocker: Any, sub_context: SubContext) -> None:
+    """Test when a new REPOHASH is outside the cooldown period."""
+    # Existing job has REPOHASH 1000. New REPOHASH is 9000.
+    # Diff is 8000. Default cooldown is 7200.
+    cast("MagicMock", sub_context.sub.revisions_with_fallback).return_value = 9000
+    mocker.patch(
+        "openqabot.types.submissions.Submissions._get_scheduled_jobs",
+        return_value=[{"flavor": "flavor", "arch": "x86_64", "version": "15-SP3", "settings": {"REPOHASH": 1000}}],
+    )
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is False
+
+
+def test_is_scheduled_job_different_flavor(mocker: Any, sub_context: SubContext) -> None:
+    """Test when existing jobs are for a different flavor."""
+    mocker.patch(
+        "openqabot.types.submissions.Submissions._get_scheduled_jobs",
+        return_value=[
+            {"flavor": "other_flavor", "arch": "x86_64", "version": "15-SP3", "settings": {"REPOHASH": 2000}}
+        ],
+    )
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is False
+
+
+def test_is_scheduled_job_configurable_cooldown(mocker: Any, sub_context: SubContext) -> None:
+    """Test cooldown period override via settings."""
+    # Existing job has REPOHASH 1000. New REPOHASH is 2000.
+    # Diff is 1000.
+    mocker.patch(
+        "openqabot.types.submissions.Submissions._get_scheduled_jobs",
+        return_value=[{"flavor": "flavor", "arch": "x86_64", "version": "15-SP3", "settings": {"REPOHASH": 1000}}],
+    )
+
+    mocker.patch.object(settings, "schedule_cooldown", 500)
+    # Diff (1000) > cooldown (500) -> Should schedule
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is False
+
+    mocker.patch.object(settings, "schedule_cooldown", 1500)
+    # Diff (1000) < cooldown (1500) -> Should NOT schedule
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is True


### PR DESCRIPTION
- Introduced a configurable `schedule_cooldown` setting (defaulting to 2 hours) to stabilize the openQA job queue.
- Updated `is_scheduled_job` logic to prevent redundant rescheduling when `REPOHASH` changes within the cooldown window.

Related issue: https://progress.opensuse.org/issues/199793