### PR TITLE
fix: implement cooldown for submission rescheduling

### DIFF
--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -80,6 +80,7 @@ class Settings(BaseSettings):
         default="Contact qem-bot maintainers for generic questions", alias="QEM_GENERIC_TOOL_ISSUES_CONTACT"
     )
     max_detailed_comment_entries: int = Field(default=7, alias="QEM_MAX_DETAILED_COMMENT_ENTRIES")
+    schedule_cooldown: int = Field(default=7200, alias="QEM_BOT_SCHEDULE_COOLDOWN")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -95,13 +95,33 @@ class Submissions(BaseConf):
             return False
 
         jobs = Submissions._get_scheduled_jobs(ctx.sub.id, submission_type)
-        return any(
-            job["flavor"] == ctx.flavor
-            and job["arch"] == ctx.arch
-            and job["version"] == ver
-            and job.get("settings", {}).get("REPOHASH") == revs
-            for job in jobs
-        )
+        relevant = [
+            j for j in jobs if j.get("flavor") == ctx.flavor and j.get("arch") == ctx.arch and j.get("version") == ver
+        ]
+
+        if not relevant:
+            return False
+
+        # Find the most recent REPOHASH among existing jobs
+        max_old = max(j.get("settings", {}).get("REPOHASH", 0) for j in relevant)
+
+        if revs <= max_old:
+            return True
+
+        # Check if the new REPOHASH is within the cooldown period
+        diff = revs - max_old
+        if diff < settings.schedule_cooldown:
+            log.info(
+                "Submission %s: Skipping re-schedule for %s on %s (RepoHash %s within %ss cooldown)",
+                ctx.sub,
+                ctx.flavor,
+                ctx.arch,
+                revs,
+                settings.schedule_cooldown,
+            )
+            return True
+
+        return False
 
     def make_repo_url(self, sub: Submission, chan: Repos) -> str:
         """Construct the repository URL for a submission channel."""

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -2,8 +2,14 @@
 # SPDX-License-Identifier: MIT
 """Test Submissions."""
 
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from openqabot.config import settings
 from openqabot.types.baseconf import JobConfig
-from openqabot.types.submissions import Submissions
+from openqabot.types.submissions import SubContext, Submissions
 from openqabot.types.types import Repos
 
 from .fixtures.submissions import MockSubmission
@@ -66,3 +72,48 @@ def test_making_repo_url() -> None:
     repo = subs.make_repo_url(sub, slfo_chan)
     exp_repo = "http://%REPO_MIRROR_HOST%/ibs/SUSE:/SLFO:/SUSE:/SLFO:/1.1.99:/PullRequest:/166:/SLES/product/repo/SLES-15.99-x86_64/"
     assert repo == exp_repo
+
+
+@pytest.fixture
+def sub_context() -> SubContext:
+    """Fixture for SubContext."""
+    sub = MagicMock()
+    sub.id = 123
+    sub.revisions_with_fallback.return_value = 2000
+    return SubContext(sub, "x86_64", "flavor", {"some": "data"})
+
+
+@pytest.mark.parametrize(
+    ("existing_flavor", "existing_rev", "new_rev", "cooldown", "expected"),
+    [
+        (None, None, 2000, 7200, False),  # No existing jobs
+        ("flavor", 2000, 2000, 7200, True),  # Exact match
+        ("flavor", 2001, 2000, 7200, True),  # Older match
+        ("flavor", 1000, 2000, 7200, True),  # Within cooldown
+        ("flavor", 1000, 9000, 7200, False),  # Outside cooldown
+        ("flavor", 1000, 2000, 500, False),  # Configurable cooldown - trigger
+        ("flavor", 1000, 2000, 1500, True),  # Configurable cooldown - skip
+        ("other", 2000, 2000, 7200, False),  # Different flavor
+    ],
+)
+def test_is_scheduled_job_scenarios(
+    mocker: Any,
+    sub_context: SubContext,
+    existing_flavor: str | None,
+    existing_rev: int | None,
+    new_rev: int,
+    cooldown: int,
+    *,
+    expected: bool,
+) -> None:
+    """Test various scheduling and cooldown scenarios."""
+    jobs = (
+        [{"flavor": existing_flavor, "arch": "x86_64", "version": "15-SP3", "settings": {"REPOHASH": existing_rev}}]
+        if existing_flavor
+        else []
+    )
+    mocker.patch("openqabot.types.submissions.Submissions._get_scheduled_jobs", return_value=jobs)
+    mocker.patch.object(settings, "schedule_cooldown", cooldown)
+    cast("MagicMock", sub_context.sub.revisions_with_fallback).return_value = new_rev
+
+    assert Submissions.is_scheduled_job(sub_context, "15-SP3") is expected


### PR DESCRIPTION
## Summary
- Introduced a configurable `schedule_cooldown` setting (defaulting to 2 hours) to stabilize the openQA job queue.
- Updated `is_scheduled_job` logic to prevent redundant rescheduling when `REPOHASH` changes within the cooldown window.
- Refactored logic to be more concise and improved log readability.

Related issue: https://progress.opensuse.org/issues/199793