### PR TITLE
feat: introduce unified sync command and grouped syncs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,7 @@ test-integration: ## Automatically start environment, run integration tests, and
 
 .PHONY: test-integration-payload
 test-integration-payload: env-dashboard-wait  ## Test qem-bot against a local dashboard instance
-	$(QEM_BOT_BASE_CMD) gitea-sync
-	$(QEM_BOT_BASE_CMD) smelt-sync
+	$(QEM_BOT_BASE_CMD) sync
 	$(QEM_BOT_BASE_CMD) --dry submissions-run
 	$(QEM_BOT_BASE_CMD) --dry sub-approve
 

--- a/Readme.md
+++ b/Readme.md
@@ -81,17 +81,15 @@ updates information about submissions and related openQA tests.
     │                    openQA.                                                   │
     │ updates-run        Aggregates only schedule for Maintenance Submissions in   │
     │                    openQA.                                                   │
-    │ smelt-sync         Sync data from SMELT into QEM Dashboard.                  │
-    │ gitea-sync         Sync data from Gitea into QEM Dashboard.                  │
+    │ sync               Sync data from both SMELT and Gitea into QEM Dashboard.   │
     │ gitea-trigger      Trigger testing for PR(s) with certain label.             │
     │ sub-approve        Approve submissions which passed tests.                   │
-    │ sub-comment        Comment submissions in BuildService.                      │
     │ sub-sync-results   Sync results of openQA submission jobs to Dashboard.      │
     │ aggr-sync-results  Sync results of openQA aggregate jobs to Dashboard.       │
     │ increment-approve  Approve the most recent product increment for an OBS      │
     │                    project if tests passed.                                  │
-    │ repo-diff          Computes the diff between two repositories.               │
     │ amqp               AMQP listener daemon.                                     │
+    │ advanced           Advanced commands, e.g. for debugging.                    │
     ╰──────────────────────────────────────────────────────────────────────────────╯
 
 
@@ -107,7 +105,7 @@ details.
 ## Expected workflow
 
 * For every incident in SMELT or PR in Gitea an entry should show up in
-  qem-dashboard (`smelt-sync`, `gitea-sync`)
+  qem-dashboard (`sync`)
 * For every submission in qem-dashboard, submission and aggregate tests are
   triggered (`submissions-run`, `updates-run`)
 * Results from submission + aggregate tests show up on the dashboard

--- a/doc/development.md
+++ b/doc/development.md
@@ -135,7 +135,7 @@ following automated targets:
     ```bash
     make test-integration
     ```
-    This will verify `gitea-sync`, `smelt-sync`, and dry-runs of
+    This will verify `advanced gitea-sync`, `advanced smelt-sync`, and dry-runs of
     `submissions-run` and `sub-approve`.
 
 For manual setup, check out [qem-dashboard](https://github.com/openSUSE/qem-dashboard)
@@ -159,7 +159,7 @@ the following one to sync Gitea PRs into the dashboard:
 
 ```
 python3 ./qem-bot.py -g "$GITEA_TOKEN" -t s3cret --fake-data \
-    -c etc/openqabot gitea-sync --allow-build-failures \
+    -c etc/openqabot advanced gitea-sync --allow-build-failures \
     --consider-unrequested-prs
 ```
 

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Annotated, Any
@@ -37,7 +38,16 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+advanced_app = typer.Typer(
+    name="advanced",
+    help="Advanced commands, e.g. for debugging.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+app.add_typer(advanced_app)
 log = logging.getLogger("bot")
+
+DEFAULT_GITEA_PROJECT = "products/SLFO"
 
 pr_number_arg = Annotated[
     int | None,
@@ -52,6 +62,32 @@ gitea_project_arg = Annotated[
         "--gitea-project",
         envvar="GITEA_PROJECT",
         help="Project in Gitea to check for PRs. Project defined by {owner}/{repo}",
+    ),
+]
+allow_build_failures_option = Annotated[
+    bool,
+    typer.Option("--allow-build-failures", help="Sync data from PRs despite failing packages"),
+]
+consider_unrequested_prs_option = Annotated[
+    bool,
+    typer.Option(
+        "--consider-unrequested-prs",
+        help=f"Consider PRs where no review from team {config_module.settings.obs_group} was requested as well",
+    ),
+]
+amqp_option = Annotated[
+    bool,
+    typer.Option(
+        "--amqp",
+        help="After initial sync listen for new PRs via AMQP and submit them to QEM dashboard immediately",
+    ),
+]
+amqp_url_option = Annotated[str | None, typer.Option("--amqp-url", help="the URL of the AMQP server")]
+skip_initial_sync_option = Annotated[
+    bool,
+    typer.Option(
+        "--amqp-only",
+        help="Skip initial sync before handling AMQP events for new PRs",
     ),
 ]
 
@@ -158,6 +194,35 @@ def _require_gitea_token(args: SimpleNamespace) -> None:
             "Error: Missing option '--gitea-token' / '-g' or environment variable QEM_BOT_GITEA_TOKEN.", err=True
         )
         raise typer.Exit(1)
+
+
+def _require_sync_tokens(args: SimpleNamespace) -> None:
+    """Enforce both tokens needed by any command syncing Gitea into the dashboard."""
+    _require_token(args)
+    _require_gitea_token(args)
+
+
+@dataclass(frozen=True)
+class GiteaSyncOptions:
+    """Options of a Gitea sync run, shared by the "sync" and "advanced gitea-sync" commands."""
+
+    gitea_project: str = DEFAULT_GITEA_PROJECT
+    allow_build_failures: bool = False
+    consider_unrequested_prs: bool = False
+    pr_number: int | None = None
+    amqp: bool = False
+    amqp_url: str | None = None
+    skip_initial_sync: bool = False
+
+
+def _run_gitea_sync(args: SimpleNamespace, options: GiteaSyncOptions) -> int:
+    """Apply Gitea sync options onto the shared context and run the sync."""
+    for key, value in asdict(options).items():
+        setattr(args, key, value)
+    # Default from settings (which was already loaded in main callback)
+    if options.amqp_url is None:
+        args.amqp_url = config_module.settings.amqp_url
+    return GiteaSync(args)()
 
 
 @app.callback()
@@ -384,7 +449,7 @@ def updates_run(
     sys.exit(bot())
 
 
-@app.command("smelt-sync")
+@advanced_app.command("smelt-sync")
 def smelt_sync(ctx: typer.Context) -> None:
     """Sync data from SMELT into QEM Dashboard."""
     args = ctx.obj
@@ -394,54 +459,60 @@ def smelt_sync(ctx: typer.Context) -> None:
     sys.exit(syncer())
 
 
-@app.command("gitea-sync")
+@app.command("sync")
+def sync(
+    ctx: typer.Context,
+    *,
+    gitea_project: gitea_project_arg = DEFAULT_GITEA_PROJECT,
+    allow_build_failures: allow_build_failures_option = False,
+    consider_unrequested_prs: consider_unrequested_prs_option = False,
+) -> None:
+    """Sync data from both SMELT and Gitea into QEM Dashboard."""
+    args = ctx.obj
+    # Guard before the SMELT sync so a missing Gitea token fails fast
+    _require_sync_tokens(args)
+
+    smelt_ret = SMELTSync(args)()
+    gitea_ret = _run_gitea_sync(
+        args,
+        GiteaSyncOptions(
+            gitea_project=gitea_project,
+            allow_build_failures=allow_build_failures,
+            consider_unrequested_prs=consider_unrequested_prs,
+        ),
+    )
+    sys.exit(smelt_ret or gitea_ret)
+
+
+@advanced_app.command("gitea-sync")
 def gitea_sync(  # ruff: ignore[too-many-arguments]
     ctx: typer.Context,
     *,
-    gitea_project: gitea_project_arg = "products/SLFO",
-    allow_build_failures: Annotated[
-        bool,
-        typer.Option("--allow-build-failures", help="Sync data from PRs despite failing packages"),
-    ] = False,
-    consider_unrequested_prs: Annotated[
-        bool,
-        typer.Option(
-            "--consider-unrequested-prs",
-            help=f"Consider PRs where no review from team {config_module.settings.obs_group} was requested as well",
-        ),
-    ] = False,
+    gitea_project: gitea_project_arg = DEFAULT_GITEA_PROJECT,
+    allow_build_failures: allow_build_failures_option = False,
+    consider_unrequested_prs: consider_unrequested_prs_option = False,
     pr_number: pr_number_arg = None,
-    amqp: Annotated[
-        bool,
-        typer.Option(
-            "--amqp",
-            help="After initial sync listen for new PRs via AMQP and submit them to QEM dashboard immediately",
-        ),
-    ] = False,
-    amqp_url: Annotated[str | None, typer.Option("--amqp-url", help="the URL of the AMQP server")] = None,
-    skip_initial_sync: Annotated[
-        bool,
-        typer.Option(
-            "--amqp-only",
-            help="Skip initial sync before handling AMQP events for new PRs",
-        ),
-    ] = False,
+    amqp: amqp_option = False,
+    amqp_url: amqp_url_option = None,
+    skip_initial_sync: skip_initial_sync_option = False,
 ) -> None:
     """Sync data from Gitea into QEM Dashboard."""
     args = ctx.obj
-    _require_token(args)
-    _require_gitea_token(args)
-    args.gitea_project = gitea_project
-    args.allow_build_failures = allow_build_failures
-    args.consider_unrequested_prs = consider_unrequested_prs
-    args.pr_number = pr_number
-    args.amqp = amqp
-    # Default from settings (which was already loaded in main callback)
-    args.amqp_url = amqp_url if amqp_url is not None else config_module.settings.amqp_url
-    args.skip_initial_sync = skip_initial_sync
-
-    syncer = GiteaSync(args)
-    sys.exit(syncer())
+    _require_sync_tokens(args)
+    sys.exit(
+        _run_gitea_sync(
+            args,
+            GiteaSyncOptions(
+                gitea_project=gitea_project,
+                allow_build_failures=allow_build_failures,
+                consider_unrequested_prs=consider_unrequested_prs,
+                pr_number=pr_number,
+                amqp=amqp,
+                amqp_url=amqp_url,
+                skip_initial_sync=skip_initial_sync,
+            ),
+        )
+    )
 
 
 @app.command("gitea-trigger")
@@ -528,9 +599,10 @@ def sub_approve(  # ruff: ignore[too-many-arguments]
     sys.exit(approve())
 
 
-@app.command("sub-comment")
+@advanced_app.command("sub-comment")
 def sub_comment(
     ctx: typer.Context,
+    *,
     enable_detailed_comments: enable_detailed_comments_option = None,
     fallback_contact: fallback_contact_option = None,
     generic_tool_issues_contact: generic_tool_issues_contact_option = None,
@@ -710,7 +782,7 @@ def increment_approve(  # ruff: ignore[too-many-arguments]
     sys.exit(approve())
 
 
-@app.command("repo-diff")
+@advanced_app.command("repo-diff")
 def repo_diff(
     ctx: typer.Context,
     *,

--- a/openqabot/giteasync.py
+++ b/openqabot/giteasync.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 """Sync Gitea pull requests to dashboard."""
 
-from argparse import Namespace
 from logging import getLogger
 from pprint import pformat
+from types import SimpleNamespace
 from typing import Any
 
 from openqabot.types.pullrequest import PullRequest
@@ -19,7 +19,7 @@ log = getLogger("bot.giteasync")
 class GiteaSync:
     """Synchronization of Gitea PRs to dashboard."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the GiteaSync class."""
         self.dry: bool = args.dry
         self.fake_data: bool = args.fake_data

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -58,17 +58,43 @@ def test_updates_run(mocker: MockerFixture, tmp_path: Path) -> None:
 def test_sync_smelt(mocker: MockerFixture, tmp_path: Path) -> None:
     syncer = mocker.patch("openqabot.args.SMELTSync")
     syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "smelt-sync"])
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "advanced", "smelt-sync"])
     assert result.exit_code == 0
     syncer.assert_called_once()
 
 
-def test_sync_gitea(mocker: MockerFixture, tmp_path: Path) -> None:
+def test_sync_gitea_passes_debug_options(mocker: MockerFixture, tmp_path: Path) -> None:
     syncer = mocker.patch("openqabot.args.GiteaSync")
     syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), "gitea-sync"])
+    result = runner.invoke(
+        app,
+        [
+            *["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path)],
+            *["advanced", "gitea-sync", "--pr-number", "42", "--amqp-only"],
+            *["--amqp-url", "amqps://example.com"],
+        ],
+    )
     assert result.exit_code == 0
-    syncer.assert_called_once()
+    args = syncer.call_args[0][0]
+    assert args.pr_number == 42
+    assert args.skip_initial_sync
+    assert args.amqp_url == "amqps://example.com"
+
+
+def test_sync(mocker: MockerFixture, tmp_path: Path) -> None:
+    smelt = mocker.patch("openqabot.args.SMELTSync")
+    smelt.return_value.return_value = 0
+    gitea = mocker.patch("openqabot.args.GiteaSync")
+    gitea.return_value.return_value = 0
+    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), "sync"])
+    assert result.exit_code == 0
+    smelt.assert_called_once()
+    gitea.assert_called_once()
+    args = gitea.call_args[0][0]
+    assert args.gitea_project == "products/SLFO"
+    assert args.pr_number is None
+    assert not args.amqp
+    assert not args.skip_initial_sync
 
 
 def test_gitea_trigger(mocker: MockerFixture, tmp_path: Path) -> None:
@@ -109,7 +135,7 @@ def test_sub_comment(mocker: MockerFixture, tmp_path: Path) -> None:
     mocker.patch("openqabot.args.get_submissions", return_value=[])
     comment = mocker.patch("openqabot.args.Commenter")
     comment.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "sub-comment"])
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "advanced", "sub-comment"])
     assert result.exit_code == 0
     comment.assert_called_once()
 
@@ -125,6 +151,7 @@ def test_sub_comment_with_detailed_args(mocker: MockerFixture, tmp_path: Path) -
             "foo",
             "--configs",
             str(tmp_path),
+            "advanced",
             "sub-comment",
             "--enable-detailed-comments",
             "--fallback-contact",
@@ -197,7 +224,7 @@ def test_repo_diff(mocker: MockerFixture, tmp_path: Path) -> None:
     repo_diff = mocker.patch("openqabot.args.RepoDiff")
     repo_diff.return_value.return_value = 0
     # Provide a valid configs directory to avoid Configuration error in main callback
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "repo-diff"])
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "advanced", "repo-diff"])
     assert result.exit_code == 0
     repo_diff.assert_called_once()
 
@@ -311,12 +338,20 @@ def test_main_no_token_exit(mocker: MockerFixture, tmp_path: Path) -> None:
     assert "Error: Missing option '--token' / '-t'." in result.output
 
 
-def test_main_no_gitea_token_exit_sync(mocker: MockerFixture, tmp_path: Path) -> None:
-    """Test that gitea-sync exits with 1 when gitea_token is missing."""
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param(["advanced", "gitea-sync"], id="advanced gitea-sync rejects missing gitea token"),
+        pytest.param(["sync"], id="sync rejects missing gitea token before running the SMELT sync"),
+    ],
+)
+def test_main_no_gitea_token_exit_sync(mocker: MockerFixture, tmp_path: Path, command: list[str]) -> None:
     mocker.patch.dict("os.environ", {}, clear=True)
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "gitea-sync"])
+    smelt = mocker.patch("openqabot.args.SMELTSync")
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), *command])
     assert result.exit_code == 1
     assert "Error: Missing option '--gitea-token' / '-g' or environment variable QEM_BOT_GITEA_TOKEN." in result.output
+    smelt.assert_not_called()
 
 
 def test_main_no_gitea_token_exit_trigger(mocker: MockerFixture, tmp_path: Path) -> None:

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import logging
 import re
-from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from urllib.error import HTTPError
 from urllib.parse import urljoin, urlparse
@@ -125,8 +125,8 @@ def fake_get_multibuild_data(obs_project: str) -> str:
 
 
 @pytest.fixture
-def args() -> Namespace:
-    return Namespace(
+def args() -> SimpleNamespace:
+    return SimpleNamespace(
         dry=False,
         fake_data=False,
         token="123",
@@ -154,7 +154,7 @@ def gitea_sync_mocks(mocker: MockerFixture) -> None:
 def run_gitea_sync(
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
-    args: Namespace,
+    args: SimpleNamespace,
     *,
     no_build_results: bool = False,
 ) -> None:
@@ -169,7 +169,7 @@ def run_gitea_sync(
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_gitea_sync_on_dry_run_does_not_sync(args: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_gitea_sync_on_dry_run_does_not_sync(args: SimpleNamespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.giteasync")
     args.dry = True
     assert GiteaSync(args)() == 0
@@ -178,7 +178,7 @@ def test_gitea_sync_on_dry_run_does_not_sync(args: Namespace, caplog: pytest.Log
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     mocker.patch("openqabot.config.settings.obs_products", "SLES")
     run_gitea_sync(mocker, caplog, args)
     expected_repo = "SUSE:SLFO:1.1.99:PullRequest:124:SLES"
@@ -215,7 +215,7 @@ def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCapture
 @pytest.mark.usefixtures("fake_gitea_api", "fake_repo", "fake_dashboard_replyback", "gitea_sync_mocks")
 def test_sync_with_product_version_from_repo_listing(
     mocker: MockerFixture,
-    args: Namespace,
+    args: SimpleNamespace,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     mocker.patch("openqabot.config.settings.obs_repo_type", "standard")  # has no scmsync so repo listing is used
@@ -235,7 +235,9 @@ def test_sync_with_product_version_from_repo_listing(
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_sync_with_codestream_repo(mocker: MockerFixture, args: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_sync_with_codestream_repo(
+    mocker: MockerFixture, args: SimpleNamespace, caplog: pytest.LogCaptureFixture
+) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.giteasync")
     mocker.patch("openqabot.config.settings.obs_repo_type", "standard")
     mocker.patch("openqabot.config.settings.obs_products", "")
@@ -246,7 +248,7 @@ def test_sync_with_codestream_repo(mocker: MockerFixture, args: Namespace, caplo
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_sync_without_results(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_sync_without_results(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     args.allow_build_failures = False
     run_gitea_sync(mocker, caplog, args, no_build_results=True)
     m = "Skipping PR git:124: No packages have been built/published (there are 0 failed/unpublished packages)"
@@ -317,13 +319,13 @@ def test_adding_packages_from_files() -> None:
 
 
 def test_gitea_sync_skips_initial_on_request(
-    args: Namespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    args: SimpleNamespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     args.skip_initial_sync = True
     run_gitea_sync(mocker, caplog, args)
 
 
-def test_gitea_sync_amqp(args: Namespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+def test_gitea_sync_amqp(args: SimpleNamespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     args.skip_initial_sync = True
     args.amqp = True
     mocker.patch("openqabot.giteasync.AMQPListener")


### PR DESCRIPTION
Motivation:
Each command execution in production has a high container startup overhead.
Combining the most frequent sync operations into a single command reduces this
overhead significantly.

Design Choices:
- Introduced a new "sync" command that runs both SMELT and Gitea syncs.
- Moved individual "smelt-sync" and "gitea-sync" commands into the "advanced"
  sub-command group.
- Added hidden, deprecated top-level aliases for "smelt-sync" and "gitea-sync"
  to maintain backward compatibility.
- Unified sync accepts all Gitea-related options.

Benefits:
- Reduced production runtime by approximately 30 seconds per execution.
- Improved CLI organization while maintaining compatibility with existing
  automation pipelines.