### PR TITLE
fix: approve increments when blockers only remain in dev  groups

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -200,7 +200,10 @@ class IncrementApprover:
         reqid = approval_status.request.reqid
         id_msg = f"OBS request {config.settings.obs_web_url}/request/show/{reqid}"
 
-        if not reasons_to_disapprove and not approval_status.ok_jobs:
+        # Safeguard: only block if NO jobs were ever identified for this request.
+        # If processed_jobs is set but ok_jobs is empty, it means all jobs were filtered
+        # (e.g. development groups) and approval should proceed if there are no other blockers.
+        if not reasons_to_disapprove and not approval_status.ok_jobs and not approval_status.processed_jobs:
             reasons_to_disapprove.append("No openQA jobs were found/checked for this request.")
 
         if self.comment and approval_status.builds:
@@ -448,9 +451,7 @@ class IncrementApprover:
             return 0
 
         if jobs_were_filtered:
-            approval_status.reasons_to_disapprove.append(
-                f"No jobs left for evaluation (all were filtered) for {info_str}"
-            )
+            log.info("All jobs filtered for %s (development groups ignored)", info_str)
             return 0
 
         approval_status.reasons_to_disapprove.append(f"No jobs scheduled for {info_str}")

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -515,12 +515,19 @@ def test_approval_if_failing_jobs_are_in_development_group(
     increment_approver.client.get_single_job = mocker.Mock(return_value=_devel_job(123, result="failed"))
     increment_approver.client.is_devel_group = mocker.Mock(return_value=True)
     mock_post_job = mocker.patch.object(increment_approver.client, "post_job")
+    mock_change_review = mocker.patch("osc.core.change_review_state")
     increment_approver()
 
     # regardless of schedule flag, filtered-out jobs must never trigger post_job
     mock_post_job.assert_not_called()
-    assert "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:" in caplog.text
-    assert "No jobs left for evaluation (all were filtered) for" in caplog.text
+    # All jobs filtered, so approval should proceed (no blocking failures)
+    mock_change_review.assert_called_once()
+    assert mock_change_review.call_args[1]["newstate"] == "accepted"
+    assert "All 0 openQA jobs have passed/softfailed" in mock_change_review.call_args[1]["message"]
+    assert "Approving OBS request https://build.suse.de/request/show/42:" in caplog.text
+    assert "All jobs filtered for" in caplog.text
+    assert "development groups ignored" in caplog.text
+    assert "No jobs left for evaluation (all were filtered)" not in caplog.text
     assert "Scheduling jobs for" not in caplog.text
 
 


### PR DESCRIPTION
Motivation:
Product increment requests were incorrectly blocked when all scheduled openQA
jobs belonged to development groups. While these jobs were correctly filtered
out from evaluation, the approval logic misinterpreted the resulting empty job
list as a failure state.

Design Choices:
- Updated handle_approval to check processed_jobs in addition to ok_jobs. This
  allows distinguishing between truly missing jobs and jobs that were found
  but filtered out.
- Removed the disapproval reason in _handle_not_ready_jobs when jobs are
  filtered, replacing it with an informational log message.
- Added code comments to clarify the safeguard logic in handle_approval.

Benefits:
- Correctly approves increments that are only "blocked" by development jobs.
- Preserves the safety check against approving requests with no identified jobs.

Related issue: https://progress.opensuse.org/issues/200009