### PR TITLE
fix: drop radon from our pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ ruff.
 ## Build & Test Commands
 
 - `make tidy`: Format code with ruff.
-- `make checkstyle`: Run full linting (ruff + radon + vulture).
+- `make checkstyle`: Run full linting (ruff + vulture).
 - `make typecheck-ty`: Type checking.
 - `make test`: Run all tests with full coverage
 

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,6 @@ check-code-health: ## Find dead code (vulture)
 	@echo "Checking code health…"
 	@vulture ${SOURCE_FILES} --min-confidence 80
 
-.PHONY: check-maintainability
-check-maintainability: ## Check maintainability index (radon)
-	@echo "Checking maintainability (grade B or worse) …"
-	@radon mi ${SOURCE_FILES} -n B | (! grep ".")
-
 .PHONY: check-types-ty
 check-types-ty: ## Run ty type checker
 	ty check
@@ -71,7 +66,7 @@ checkstyle: ## Run fast style and static analysis checks
 
 .PHONY: checkstyle-all
 checkstyle-all: ## Run all style and static analysis checks
-	@$(MAKE) -j checkstyle check-code-health check-maintainability
+	@$(MAKE) -j checkstyle check-code-health
 
 .PHONY: test
 test: ## Run all tests with coverage analysis and style checks

--- a/doc/development.md
+++ b/doc/development.md
@@ -98,16 +98,6 @@ tests/test_amqp.py` to execute a single test.
 
 Run `make checkstyle` to run all style and static analysis checks.
 
-Run `check-maintainability` to check maintainability. This requires the tool
-`radon`. You can also check individual files displaying the exact percentage via
-e.g. `radon mi --show tests/test_loader_incrementconfig.py`. Note that this kind
-of metric is not about specific bad patterns but rather counts constructs like
-`if` statements. Check out the
-[Radon documentation](https://radon.readthedocs.io/en/latest/intro.html) for
-details. There is also
-[documentation about the thresholds](https://radon.readthedocs.io/en/latest/commandline.html#the-mi-command)
-for the grades.
-
 Run `make test-all-commands-unstable` to quickly verify that all bot subcommands
 can be parsed and executed (using `--dry` and `--fake-data`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dev = [
     "pytest-xdist",
     "pyupgrade",
     "coverage",
-    "radon",
     "responses>=0.21.0",
     "urllib3",
     "ruff",
@@ -155,7 +154,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 10
+max-complexity = 9
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["PLR2004", "ANN401", "PLR0913", "S101", "S105", "S106", "PLR0917", "D103"]


### PR DESCRIPTION
Radon was the gold standard in 2017, but it hasn't kept pace with the Python language's evolution.
 Continuing to use it risks CI/CD failures as we adopt newer Python versions.  By moving its responsibilities to Ruff, we consolidate our toolchain, and ensure our complexity checks actually understand modern syntax.
