### PR TITLE
refactor: centralize Gitea PR validation and simplify loader logic

### DIFF
--- a/openqabot/giteasync.py
+++ b/openqabot/giteasync.py
@@ -7,6 +7,8 @@ from logging import getLogger
 from pprint import pformat
 from typing import Any
 
+from openqabot.types.pullrequest import PullRequest
+
 from .loader.amqp_listener import AMQPListener
 from .loader.gitea import get_open_prs, get_submissions_from_open_prs, make_submission_from_gitea_pr, make_token_header
 from .loader.qem import update_submissions
@@ -76,10 +78,11 @@ class GiteaSync:
         return update_submissions(submissions, params={"type": "git"}, retry=self.retry)
 
     def _on_amqp_message(self, message: dict[str, Any], _: str) -> None:
-        if message["pull_request"]["base"]["repo"]["full_name"] == self.gitea_repo:
-            log.info("PR #%s on %s %s", message["pull_request"]["number"], self.gitea_repo, message["action"])
+        pr = PullRequest.from_json(message["pull_request"])
+        if pr and pr.project == self.gitea_repo:
+            log.info("PR #%s on %s %s", pr.number, self.gitea_repo, message["action"])
             submission = make_submission_from_gitea_pr(
-                message["pull_request"],
+                pr,
                 self.gitea_token,
                 only_successful_builds=not self.allow_build_failures,
                 only_requested_prs=not self.consider_unrequested_prs,

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -147,11 +147,11 @@ class GiteaTrigger:
                         f"Request accepted for '{config.settings.obs_group}' "
                         f"based on data in {config.settings.dashboard_url()}"
                     )
-                    approve_pr(self.gitea_token, pullrequest.repo_name, pullrequest.number, pullrequest.commit_sha, msg)
+                    approve_pr(self.gitea_token, pullrequest.project, pullrequest.number, pullrequest.commit_sha, msg)
 
     def get_prs_by_label(self) -> None:
         """Get all open PRs and filter them by defined label."""
-        open_prs: list[Any] = get_open_prs(
+        open_prs: list[PullRequest] = get_open_prs(
             self.gitea_token,
             self.gitea_repo,
             number=self.pr_number,
@@ -162,26 +162,13 @@ class GiteaTrigger:
             self.gitea_repo,
         )
         for pr in open_prs:
-            pr_id = pr.get("number", "?")
-            log.debug("Fetching info for PR git:%s from Gitea", pr_id)
-            try:
-                pullrequest = PullRequest(
-                    number=pr["number"],
-                    raw_labels=pr["labels"],
-                    repo_name=pr["base"]["repo"]["full_name"],
-                    branch=pr["base"]["label"],
-                    url=pr["html_url"],
-                    commit_sha=pr["head"]["sha"],
-                )
-                # we looking only for PRs which has ALL labels defined via '--pr-label' parameter AND
-                # at least one for labels defined in staging.config
-                qa_labels = set(self.staging_config_qa_labels.keys())
-                if pullrequest.has_all_labels(self.pr_required_labels) and pullrequest.has_any_label(qa_labels):
-                    self.prs.append(pullrequest)
-                else:
-                    log.debug("PR %s disregarded (labels: %s)", pr_id, pullrequest.labels)
-            except KeyError:
-                log.exception("Unable to process PR git:%s", pr_id)
+            # we looking only for PRs which has ALL labels defined via '--pr-label' parameter AND
+            # at least one for labels defined in staging.config
+            qa_labels = set(self.staging_config_qa_labels.keys())
+            if pr.has_all_labels(self.pr_required_labels) and pr.has_any_label(qa_labels):
+                self.prs.append(pr)
+            else:
+                log.debug("PR %s disregarded (labels: %s)", pr.number, pr.labels)
         log.debug(
             "Data for %d pullrequest: %s",
             len(self.prs),

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -26,12 +26,12 @@ from osc.core import MultibuildFlavorResolver
 
 from openqabot import config
 from openqabot.errors import NoRepoFoundError
+from openqabot.types.pullrequest import PullRequest
 from openqabot.utils import retry10 as retried_requests
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from openqabot.types.pullrequest import PullRequest
     from openqabot.types.types import Repos
 
 ARCHS = {"x86_64", "aarch64", "ppc64le", "s390x"}
@@ -195,26 +195,34 @@ def compute_repo_url_for_job_setting(
     return ",".join(repo_with_opts.compute_url(base, p, path="", project="SLFO") for p in product_list)
 
 
-def get_open_prs(token: dict[str, str], repo: str, *, number: int | None) -> list[dict[str, Any]]:
+def _fetch_all_prs(repo: str, token: dict[str, str]) -> list[PullRequest]:
+    try:
+        return [
+            pr
+            for pr_json in iter_gitea_items(f"repos/{repo}/pulls?state=open", token)
+            if (pr := PullRequest.from_json(pr_json)) is not None
+        ]
+    except (requests.exceptions.RequestException, json.JSONDecodeError):
+        log.exception("Gitea API error: Could not fetch open PRs from %s", repo)
+    return []
+
+
+def get_open_prs(token: dict[str, str], repo: str, *, number: int | None) -> list[PullRequest]:
     """Fetch open PRs from a Gitea repository."""
     log.debug("Fetching open PRs from '%s'", repo)
-    if number is not None:
-        try:
-            pr = get_json(f"repos/{repo}/pulls/{number}", token)
-        # Catching RequestException for general API errors, and json's JSONDecodeError
-        # for cases where requests might not wrap it in RequestException
-        except (requests.exceptions.RequestException, json.JSONDecodeError, KeyError):
-            log.exception("PR git:%s ignored: Could not read PR metadata", number)
-            return []
-        log.debug("PR git:%i: %s", number, pr)
-        return [cast("dict[str, Any]", pr)]
+    if number is None:
+        return _fetch_all_prs(repo, token)
+    return _get_single_pr(token, repo, number)
 
+
+def _get_single_pr(token: dict[str, str], repo: str, number: int) -> list[PullRequest]:
     try:
         # https://docs.gitea.com/api/1.25/#tag/repository/operation/repolistPullRequests
-        return list(iter_gitea_items(f"repos/{repo}/pulls?state=open", token))
-    except (requests.exceptions.RequestException, TypeError):
-        log.exception("Gitea API error: Could not fetch open PRs from %s", repo)
-        return []
+        if pr := PullRequest.from_json(cast("dict[str, Any]", get_json(f"repos/{repo}/pulls/{number}", token))):
+            return [pr]
+    except (requests.exceptions.RequestException, json.JSONDecodeError) as ex:
+        log.error("PR git:%s ignored: %s", number, ex, exc_info=True)  # noqa: G201
+    return []
 
 
 def _approval_identifiers(bot_user: str, commit_id: str, *, approve: bool = True) -> tuple[str, str]:
@@ -269,7 +277,7 @@ def approve_pr(token: dict[str, str], repo_name: str, pr_number: int, commit_id:
         else:
             reviews = iter_gitea_items(reviews_url(repo_name, pr_number), token)
             if any(
-                r.get("commit_id") == commit_id and r.get("state") == "APPROVED" and is_review_requested_by(r)
+                (r.get("commit_id"), r.get("state")) == (commit_id, "APPROVED") and is_review_requested_by(r)
                 for r in reviews
             ):
                 log.info("PR %s already approved for commit %s", pr_number, commit_id)
@@ -312,6 +320,7 @@ def add_reviews(submission: dict[str, Any], reviews: list[Any]) -> int:
     open_reviews = [r for r in reviews if not r.get("dismissed", True)]
     qam_states = [r.get("state", "") for r in open_reviews if is_review_requested_by(r)]
     has_other_pending = any(r.get("state", "") in pending_states for r in open_reviews if not is_review_requested_by(r))
+
     counts = Counter(qam_states)
     qam_pending = counts["PENDING"] + counts["REQUEST_REVIEW"]
     qam_blocking = counts["REQUEST_CHANGES"] + counts["REQUEST_REVIEW"]
@@ -354,14 +363,12 @@ def get_product_version_from_repo_listing(project: str, product_name: str, repos
 def _get_product_version(res: etree._Element, project: str, product_name: str) -> str:
     """Extract product version from scmsync element or repository listing."""
     # read product version from scmsync element if possible, e.g. 15.99
-    product_version = next(
-        (
-            pv
-            for _, pv in (get_product_name_and_version_from_scmsync(e.text) for e in res.findall("scmsync"))
-            if len(pv) > 0
-        ),
-        "",
-    )
+    product_version = ""
+    for e in res.findall("scmsync"):
+        _, pv = get_product_name_and_version_from_scmsync(e.text)
+        if pv:
+            product_version = pv
+            break
 
     # read product version from directory listing if the project is for a concrete product
     if (
@@ -402,12 +409,15 @@ def add_channel_for_build_result(
 def _update_scminfo(submission: dict[str, Any], res: etree._Element, project: str, product: str) -> None:
     """Update SCM info in the submission dict."""
     scm_key = f"scminfo_{product}" if product else "scminfo"
-    for found in (e.text for e in res.findall("scminfo") if e.text):
-        if (existing := submission.get(scm_key)) and found != existing:
-            msg = "PR git:%s: Inconsistent SCM info for project %s: found '%s' vs '%s'"
-            log.warning(msg, submission["number"], project, found, existing)
-            continue
-        submission[scm_key] = found
+    for e in res.findall("scminfo"):
+        found = e.text
+        if found:
+            existing = submission.get(scm_key)
+            if existing and found != existing:
+                msg = "PR git:%s: Inconsistent SCM info for project %s: found '%s' vs '%s'"
+                log.warning(msg, submission["number"], project, found, existing)
+                continue
+            submission[scm_key] = found
 
 
 def _update_build_statuses(res: etree._Element, results: BuildResults) -> None:
@@ -538,18 +548,13 @@ def add_build_results(submission: dict[str, Any], obs_urls: list[str], *, dry: b
         "successful_packages": sorted(results.successful),
     })
 
-    if "channels" not in submission:
-        submission["channels"] = []
+    channels = submission.setdefault("channels", [])
+    channels.extend(result for result in sorted(results.projects) if result not in channels)
 
-    for result in sorted(results.projects):
-        if result not in submission["channels"]:
-            submission["channels"].append(result)
-
-    if (
-        "scminfo" not in submission
-        and len(config.settings.obs_products_set) == 1
-        and "all" not in config.settings.obs_products_set
-    ):
+    if "scminfo" not in submission and (
+        len(config.settings.obs_products_set),
+        "all" in config.settings.obs_products_set,
+    ) == (1, False):
         submission["scminfo"] = submission.get("scminfo_" + next(iter(config.settings.obs_products_set)), "")
 
 
@@ -668,7 +673,7 @@ def is_build_acceptable_and_log_if_not(submission: dict[str, Any], number: int) 
 
 
 def _fetch_details(
-    repo_name: str, number: int, token: dict[str, str], *, dry: bool
+    project: str, number: int, token: dict[str, str], *, dry: bool
 ) -> tuple[list[Any], list[Any], list[Any]]:
     if dry:
         if number == 124:  # noqa: PLR2004
@@ -679,14 +684,50 @@ def _fetch_details(
             )
         return [], [], []
     return (
-        list(iter_gitea_items(reviews_url(repo_name, number), token)),
-        list(iter_gitea_items(comments_url(repo_name, number), token)),
-        list(iter_gitea_items(changed_files_url(repo_name, number), token)),
+        list(iter_gitea_items(reviews_url(project, number), token)),
+        list(iter_gitea_items(comments_url(project, number), token)),
+        list(iter_gitea_items(changed_files_url(project, number), token)),
     )
 
 
+def _init_submission_dict(pr: PullRequest) -> dict[str, Any]:
+    """Initialize a submission dictionary with default values from a PR."""
+    return {
+        "number": pr.number,
+        "project": pr.project,
+        # "Emergency Maintenance Update", a flag used to raise a priority in scheduler
+        # see openqabot/types/incidents.py#L227
+        "emu": False,
+        "isActive": pr.is_active(),
+        "inReviewQAM": False,
+        "inReview": False,
+        "approved": False,
+        # `_patchinfo` should contain something like <embargo_date>2025-05-01</embargo_date> if embargo applies
+        "embargoed": False,
+        "priority": 0,  # only used for display purposes on the dashboard, maybe read from a label at some point
+        "rr_number": None,
+        "packages": [],
+        "channels": [],
+        "url": pr.url,
+        "type": "git",
+    }
+
+
+def _validate_submission(
+    submission: dict[str, Any],
+    number: int,
+    *,
+    only_successful_builds: bool,
+) -> bool:
+    """Validate if the submission has channels, acceptable builds, and packages."""
+    if not submission["channels"]:
+        log.info("PR git:%s skipped: No channels found", number)
+        return False
+    return not (only_successful_builds and not is_build_acceptable_and_log_if_not(submission, number))
+
+
 def make_submission_from_gitea_pr(
-    pr: dict[str, Any],
+    pr: PullRequest,
     token: dict[str, str],
     *,
     only_successful_builds: bool,
@@ -694,54 +735,31 @@ def make_submission_from_gitea_pr(
     dry: bool,
 ) -> dict[str, Any] | None:
     """Create a dashboard-compatible submission record from a Gitea PR."""
-    log.debug("Fetching info for PR git:%s from Gitea", pr.get("number", "?"))
+    log.debug("Fetching info for PR git:%s from Gitea", pr.number)
     try:
-        number = pr["number"]
-        repo = pr["base"]["repo"]
-        repo_name = repo["full_name"]
-        submission = {
-            "number": number,
-            "project": repo["full_name"],
-            # "Emergency Maintenance Update", a flag used to raise a priority in scheduler
-            # see openqabot/types/incidents.py#L227
-            "emu": False,
-            "isActive": pr["state"] == "open",
-            "inReviewQAM": False,
-            "inReview": False,
-            "approved": False,
-            # `_patchinfo` should contain something like <embargo_date>2025-05-01</embargo_date> if embargo applies
-            "embargoed": False,
-            "priority": 0,  # only used for display purposes on the dashboard, maybe read from a label at some point
-            "rr_number": None,
-            "packages": [],
-            "channels": [],
-            "url": pr["url"],
-            "type": "git",
-        }
-        reviews, comments, files = _fetch_details(repo_name, number, token, dry=dry)
+        submission = _init_submission_dict(pr)
+        reviews, comments, files = _fetch_details(pr.project, pr.number, token, dry=dry)
 
         if add_reviews(submission, reviews) < 1 and only_requested_prs:
-            log.info("PR git:%s skipped: No reviews by %s", number, config.settings.obs_group)
+            log.info("PR git:%s skipped: No reviews by %s", pr.number, config.settings.obs_group)
             return None
+
         add_comments_and_referenced_build_results(submission, comments, dry=dry)
-        if not submission["channels"]:
-            log.info("PR git:%s skipped: No channels found", number)
-            return None
-        if only_successful_builds and not is_build_acceptable_and_log_if_not(submission, number):
+        if not _validate_submission(submission, pr.number, only_successful_builds=only_successful_builds):
             return None
         add_packages_from_files(submission, token, files, dry=dry)
         if not submission["packages"]:
-            log.info("PR git:%s skipped: No packages found", number)
+            log.info("PR git:%s skipped: No packages found", pr.number)
             return None
 
     except Exception:
-        log.exception("Gitea API error: Unable to process PR git:%s", pr.get("number", "?"))
+        log.exception("Gitea API error: Unable to process PR git:%s", pr.number)
         return None
     return submission
 
 
 def get_submissions_from_open_prs(
-    open_prs: list[dict[str, Any]],
+    open_prs: list[PullRequest],
     token: dict[str, str],
     *,
     only_successful_builds: bool,

--- a/openqabot/types/pullrequest.py
+++ b/openqabot/types/pullrequest.py
@@ -3,7 +3,10 @@
 """Gitea Pullrequest type definition."""
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from logging import getLogger
+from typing import Any, Protocol, Self
+
+log = getLogger("bot.loader.pullrequest")
 
 
 class CommentableProtocol(Protocol):
@@ -25,7 +28,8 @@ class PullRequest:
     """Represent all information to operate Gitea pull requests."""
 
     number: int
-    repo_name: str
+    state: str
+    project: str
     branch: str
     url: str
     commit_sha: str
@@ -49,3 +53,28 @@ class PullRequest:
     def has_any_label(self, search_labels: set[str]) -> bool:
         """Check if pull request has at least one label from the input set."""
         return not self.labels.isdisjoint(search_labels)
+
+    def is_active(self) -> bool:
+        """Check if the pull request is in an active state."""
+        return self.state == "open"
+
+    @classmethod
+    def from_json(cls: type[Self], pr_json: dict[str, Any]) -> Self | None:
+        """Return instance of PullRequest created from dict."""
+        try:
+            instance = cls(
+                number=pr_json["number"],
+                state=pr_json.get("state", "open"),
+                raw_labels=pr_json.get("labels", []),
+                project=pr_json["base"]["repo"]["full_name"],
+                branch=pr_json["base"].get("label", pr_json["base"].get("ref", "unknown")),
+                url=pr_json.get("html_url", pr_json.get("url", "")),
+                commit_sha=pr_json.get("head", {}).get("sha", "unknown"),
+            )
+            log.debug("PR git:%i: %s", instance.number, instance)
+        except KeyError:
+            pr_id = pr_json.get("number", "?")
+            log.exception("PR git:%s ignored: Could not read PR metadata", pr_id)
+            return None
+        else:
+            return instance

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,8 @@ import ast
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from openqabot.config import Settings, get_default_obs_url
 
 
@@ -70,8 +72,9 @@ def test_cli_envvars_covered_by_settings() -> None:
     assert not missing, f"envvars in args.py missing from config.py Settings: {missing}"
 
 
-def test_obs_web_url_property() -> None:
+def test_obs_web_url_property(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the obs_web_url property."""
+    monkeypatch.delenv("OBS_URL", raising=False)
     settings = Settings(obs_url="https://api.suse.de")
     assert settings.obs_web_url == "https://build.suse.de"
 
@@ -80,6 +83,18 @@ def test_obs_web_url_property() -> None:
 
     settings = Settings(obs_url="https://some.api.server.com")
     assert settings.obs_web_url == "https://some.build.server.com"
+
+
+def test_obs_products_set() -> None:
+    """Test the obs_products_set property."""
+    settings = Settings(obs_products="p1,p2,p3")
+    assert settings.obs_products_set == {"p1", "p2", "p3"}
+
+
+def test_dashboard_token_dict() -> None:
+    """Test the dashboard_token_dict property."""
+    settings = Settings(token="mytoken")
+    assert settings.dashboard_token_dict == {"Authorization": "Token mytoken"}
 
 
 def test_insecure_setting() -> None:

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -13,6 +13,7 @@ import requests
 from pytest_mock import MockerFixture
 
 from openqabot.giteatrigger import GiteaTrigger
+from openqabot.types.pullrequest import PullRequest
 from openqabot.types.types import Data
 
 
@@ -111,34 +112,37 @@ def test_get_prs_by_label_filtering(trigger: GiteaTrigger, mocker: MockerFixture
     mocker.patch(
         "openqabot.giteatrigger.get_open_prs",
         return_value=[
-            {
+            PullRequest.from_json({
                 "number": 1,
                 "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
                 "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
-            },
-            {
+                "state": "open",
+            }),
+            PullRequest.from_json({
                 "number": 2,
                 "labels": [{"name": "wrong-label"}, {"name": "qalabel1"}],
                 "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
-            },
-            {
+                "state": "open",
+            }),
+            PullRequest.from_json({
                 "number": 3,
                 "labels": [{"name": "needs-testing"}],
                 "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
-            },
+                "state": "open",
+            }),
         ],
     )
 
     trigger.get_prs_by_label()
     assert len(trigger.prs) == 1
     assert trigger.prs[0].number == 1
-    assert trigger.prs[0].repo_name == "owner/r"
+    assert trigger.prs[0].project == "owner/r"
 
 
 def test_check_pullrequest_dry_run(trigger: GiteaTrigger, mocker: MockerFixture) -> None:
@@ -204,13 +208,13 @@ def test_get_prs_by_label_specific_number(mock_args: Namespace, mocker: MockerFi
     mock_get_pr = mocker.patch(
         "openqabot.giteatrigger.get_open_prs",
         return_value=[
-            {
+            PullRequest.from_json({
                 "number": 1337,
                 "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
                 "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
                 "html_url": "u",
                 "head": {"sha": "xyz"},
-            }
+            })
         ],
     )
 
@@ -219,7 +223,7 @@ def test_get_prs_by_label_specific_number(mock_args: Namespace, mocker: MockerFi
 
     mock_get_pr.assert_called_once()
     assert len(trigger.prs) == 1
-    assert trigger.prs[0].repo_name == "owner/r"
+    assert trigger.prs[0].project == "owner/r"
 
 
 def test_check_pullrequest_comments_when_no_trigger_needed(trigger: GiteaTrigger, mocker: MockerFixture) -> None:
@@ -252,7 +256,7 @@ def test_comment_on_pr_build_injection(trigger: GiteaTrigger, mocker: MockerFixt
     cast("MagicMock", trigger.openqa.get_jobs).return_value = mock_jobs
     cast("MagicMock", trigger.commenter.generate_comment).return_value = ("Summary", "passed")
 
-    mock_pr = MagicMock(number=123, url="http://fake.url/123", commit_sha="sha123", repo_name="fake_repo")
+    mock_pr = MagicMock(number=123, url="http://fake.url/123", commit_sha="sha123", project="fake_repo")
     trigger.comment_on_pr(mock_pr, "product", "version", "arch", "PR-BUILD")
 
     assert mock_jobs[0]["build"] == "PR-BUILD"
@@ -297,19 +301,6 @@ def test_comment_on_pr_exception(trigger: GiteaTrigger) -> None:
     trigger.comment_on_pr(mock_pr, "product", "version", "arch", "build")
 
     cast("MagicMock", trigger.commenter.gitea_comment).assert_not_called()
-
-
-def test_get_prs_by_label_exception_during_pr_processing(
-    trigger: GiteaTrigger, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Tests get_prs_by_label when an exception occurs while processing a PR."""
-    mocker.patch(
-        "openqabot.giteatrigger.get_open_prs",
-        return_value=[{"number": 1}],  # Missing required fields to trigger exception
-    )
-    trigger.get_prs_by_label()
-    assert len(trigger.prs) == 0
-    assert "Unable to process PR git:1" in caplog.text
 
 
 def test_check_pullrequest_no_matched_iso(trigger: GiteaTrigger, mocker: MockerFixture) -> None:

--- a/tests/test_loader_gitea_prs.py
+++ b/tests/test_loader_gitea_prs.py
@@ -2,80 +2,67 @@
 # SPDX-License-Identifier: MIT
 """Test loader Gitea PRs."""
 
-import logging
+import json
 
 import pytest
 import requests
 from pytest_mock import MockerFixture
 
 from openqabot.loader import gitea
+from openqabot.types.pullrequest import PullRequest
 
 
 def test_get_open_prs_returns_specified_pr(mocker: MockerFixture) -> None:
-    mocked_get_json = mocker.patch("openqabot.loader.gitea.get_json", return_value=42)
-    assert gitea.get_open_prs({"Authorization": "token my_token"}, "my_repo", number=1) == [42]
+    pr_data = {
+        "number": 1,
+        "state": "open",
+        "labels": [],
+        "base": {"repo": {"full_name": "my_repo"}},
+    }
+    mocked_get_json = mocker.patch("openqabot.loader.gitea.get_json", return_value=pr_data)
+    res = gitea.get_open_prs({"Authorization": "token my_token"}, "my_repo", number=1)
+    assert len(res) == 1
+    assert isinstance(res[0], PullRequest)
+    assert res[0].number == 1
     mocked_get_json.assert_called_once_with("repos/my_repo/pulls/1", {"Authorization": "token my_token"})
 
 
-def test_get_open_prs_metadata_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    caplog.set_level(logging.WARNING, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=requests.RequestException("error"))
-    res = gitea.get_open_prs({}, "repo", number=124)
+def test_get_open_prs_returns_empty_list_on_invalid_pr(mocker: MockerFixture) -> None:
+    mocker.patch("openqabot.loader.gitea.get_json", return_value={"invalid": "data"})
+    res = gitea.get_open_prs({}, "my_repo", number=1)
     assert res == []
-    assert "PR git:124 ignored: Could not read PR metadata" in caplog.text
 
 
 def test_get_open_prs_iter_pages(mocker: MockerFixture) -> None:
-    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[1, 2])
+    pr_data = [
+        {"number": 1, "state": "open", "base": {"repo": {"full_name": "repo"}}},
+        {"number": 2, "state": "open", "base": {"repo": {"full_name": "repo"}}},
+    ]
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=pr_data)
     res = gitea.get_open_prs({}, "repo", number=None)
-    assert res == [1, 2]
+    assert len(res) == 2
+    assert all(isinstance(pr, PullRequest) for pr in res)
+    assert [pr.number for pr in res] == [1, 2]
 
 
-def test_get_open_prs_iter_pages_unexpected_dict(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    """Cover the case where pagination returns a dict instead of a list."""
-    caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
+def test_get_open_prs_single_request_exception(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+    mocker.patch("openqabot.loader.gitea.get_json", side_effect=requests.exceptions.RequestException("Request failed"))
+    res = gitea.get_open_prs({}, "my_repo", number=1)
+    assert res == []
+    assert "PR git:1 ignored: Request failed" in caplog.text
+
+
+def test_get_open_prs_iter_request_exception(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     mocker.patch(
-        "openqabot.loader.gitea.iter_gitea_items", side_effect=TypeError("Gitea API returned dict instead of list")
+        "openqabot.loader.gitea.iter_gitea_items", side_effect=requests.exceptions.RequestException("Iter failed")
     )
     res = gitea.get_open_prs({}, "repo", number=None)
     assert res == []
     assert "Gitea API error: Could not fetch open PRs from repo" in caplog.text
 
 
-def test_get_open_prs_json_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
-    # iter_gitea_items uses requests which might throw JSONDecodeError
-    mocker.patch("openqabot.loader.gitea.iter_gitea_items", side_effect=requests.exceptions.RequestException("error"))
+def test_get_open_prs_iter_json_exception(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", side_effect=json.JSONDecodeError("JSON error", "doc", 0))
     res = gitea.get_open_prs({}, "repo", number=None)
     assert res == []
     assert "Gitea API error: Could not fetch open PRs from repo" in caplog.text
-
-
-def test_get_open_prs_request_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.iter_gitea_items", side_effect=requests.exceptions.RequestException("error"))
-    res = gitea.get_open_prs({}, "repo", number=None)
-    assert res == []
-    assert "Gitea API error: Could not fetch open PRs from repo" in caplog.text
-
-
-def test_get_open_prs_specific_number_json_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    """Cover JSONDecodeError when fetching a specific PR number."""
-    caplog.set_level(logging.WARNING, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=requests.exceptions.JSONDecodeError("msg", "doc", 0))
-
-    res = gitea.get_open_prs({}, "repo", number=124)
-
-    assert res == []
-    assert "PR git:124 ignored: Could not read PR metadata" in caplog.text
-
-
-def test_get_open_prs_specific_number_key_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    """Cover KeyError (e.g. missing expected fields in API response)."""
-    caplog.set_level(logging.WARNING, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=KeyError("missing_field"))
-
-    res = gitea.get_open_prs({}, "repo", number=124)
-
-    assert res == []
-    assert "PR git:124 ignored: Could not read PR metadata" in caplog.text

--- a/tests/test_loader_gitea_submissions.py
+++ b/tests/test_loader_gitea_submissions.py
@@ -7,13 +7,22 @@ import logging
 from typing import Any
 
 import pytest
+from lxml import etree  # ty: ignore[unresolved-import]
 from pytest_mock import MockerFixture
 
 from openqabot.loader import gitea
+from openqabot.types.pullrequest import PullRequest
 
 
 def test_make_submission_from_gitea_pr_dry(mocker: MockerFixture) -> None:
-    pr = {"number": 124, "state": "open", "url": "url", "base": {"repo": {"full_name": "owner/repo", "name": "repo"}}}
+    pr_dict = {
+        "number": 124,
+        "state": "open",
+        "url": "url",
+        "base": {"repo": {"full_name": "owner/repo", "name": "repo"}},
+    }
+    pr = PullRequest.from_json(pr_dict)
+    assert pr is not None
     mocker.patch("openqabot.loader.gitea.read_json_file", return_value=[])
 
     def mock_add_comments(incident: dict, _comments: list, *, dry: bool) -> None:
@@ -32,7 +41,14 @@ def test_make_submission_from_gitea_pr_dry(mocker: MockerFixture) -> None:
 
 def test_make_submission_from_gitea_pr_skips(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO, logger="bot.loader.gitea")
-    pr = {"number": 123, "state": "open", "url": "url", "base": {"repo": {"full_name": "owner/repo", "name": "repo"}}}
+    pr_dict = {
+        "number": 123,
+        "state": "open",
+        "url": "url",
+        "base": {"repo": {"full_name": "owner/repo", "name": "repo"}},
+    }
+    pr = PullRequest.from_json(pr_dict)
+    assert pr is not None
     mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[])
 
     # Skip due to no channels
@@ -60,7 +76,14 @@ def test_make_submission_from_gitea_pr_skips(mocker: MockerFixture, caplog: pyte
 
 
 def test_make_submission_from_gitea_pr_dry_other_number_passes(mocker: MockerFixture) -> None:
-    pr = {"number": 999, "state": "open", "url": "url", "base": {"repo": {"full_name": "owner/repo", "name": "repo"}}}
+    pr_dict = {
+        "number": 999,
+        "state": "open",
+        "url": "url",
+        "base": {"repo": {"full_name": "owner/repo", "name": "repo"}},
+    }
+    pr = PullRequest.from_json(pr_dict)
+    assert pr is not None
     mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[])
     mocker.patch("openqabot.loader.gitea.add_reviews", return_value=1)
 
@@ -81,7 +104,14 @@ def test_make_submission_from_gitea_pr_dry_other_number_passes(mocker: MockerFix
 
 def test_make_submission_from_gitea_pr_no_reviews(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO, logger="bot.loader.gitea")
-    pr = {"number": 123, "state": "open", "url": "url", "base": {"repo": {"full_name": "owner/repo", "name": "repo"}}}
+    pr_dict = {
+        "number": 123,
+        "state": "open",
+        "url": "url",
+        "base": {"repo": {"full_name": "owner/repo", "name": "repo"}},
+    }
+    pr = PullRequest.from_json(pr_dict)
+    assert pr is not None
     mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=[])
     mocker.patch("openqabot.loader.gitea.add_reviews", return_value=0)
     res = gitea.make_submission_from_gitea_pr(pr, {}, only_successful_builds=False, only_requested_prs=True, dry=False)
@@ -89,14 +119,85 @@ def test_make_submission_from_gitea_pr_no_reviews(mocker: MockerFixture, caplog:
     assert "PR git:123 skipped: No reviews by" in caplog.text
 
 
-def test_make_submission_from_gitea_pr_exception(caplog: pytest.LogCaptureFixture) -> None:
-    pr = {"number": 123}  # Missing base/repo
-    res = gitea.make_submission_from_gitea_pr(pr, {}, only_successful_builds=False, only_requested_prs=False, dry=False)
-    assert res is None
-    assert "Gitea API error: Unable to process PR git:123" in caplog.text
-
-
 def test_is_review_requested_by_explicit_users() -> None:
     review = {"user": {"login": "user1"}}
     assert gitea.is_review_requested_by(review, users=("user1",))
     assert not gitea.is_review_requested_by(review, users=("user2",))
+
+
+def test_add_reviews_coverage(mocker: MockerFixture) -> None:
+    submission: dict[str, Any] = {}
+    reviews = [
+        {"dismissed": True, "state": "APPROVED"},
+        {"dismissed": False, "state": "PENDING", "user": {"login": "qam-bot"}},
+        {"dismissed": False, "state": "APPROVED", "user": {"login": "other"}},
+        {"dismissed": False, "state": "REQUEST_REVIEW", "user": {"login": "other"}},
+        {"dismissed": False, "state": "COMMENT", "user": {"login": "other"}},
+    ]
+
+    def mock_is_req(r: dict[str, Any], users: Any = None) -> bool:
+        return r.get("user", {}).get("login") == "qam-bot"
+
+    mocker.patch("openqabot.loader.gitea.is_review_requested_by", side_effect=mock_is_req)
+
+    count = gitea.add_reviews(submission, reviews)
+    assert count == 1
+    assert submission["inReview"] is True
+
+
+def test_update_scminfo_coverage(caplog: pytest.LogCaptureFixture) -> None:
+    submission = {"number": 123}
+    res = etree.fromstring("<root><scminfo></scminfo><scminfo>new</scminfo><scminfo>other</scminfo></root>")
+    gitea._update_scminfo(submission, res, "project", "")  # noqa: SLF001
+    assert submission["scminfo"] == "new"
+    assert "Inconsistent SCM info" in caplog.text
+
+    caplog.clear()
+    submission = {"number": 123, "scminfo_prod": "old"}
+    res = etree.fromstring("<root><scminfo>new</scminfo></root>")
+    gitea._update_scminfo(submission, res, "project", "prod")  # noqa: SLF001
+    assert submission["scminfo_prod"] == "old"
+    assert "Inconsistent SCM info" in caplog.text
+
+
+def test_make_submission_from_gitea_pr_no_packages(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bot.loader.gitea")
+    pr_dict = {
+        "number": 123,
+        "state": "open",
+        "url": "url",
+        "base": {"repo": {"full_name": "owner/repo", "name": "repo"}},
+    }
+    pr = PullRequest.from_json(pr_dict)
+    assert pr is not None
+    # Mocking _fetch_details to return empty lists for reviews, comments, and files
+    mocker.patch("openqabot.loader.gitea._fetch_details", return_value=([], [], []))
+
+    # Ensure it skips due to no packages
+    def mock_add_chan(inc: dict, *_: Any, **__: Any) -> None:
+        inc["channels"].append("chan")
+
+    mocker.patch("openqabot.loader.gitea.add_comments_and_referenced_build_results", side_effect=mock_add_chan)
+    # mock add_packages_from_files to do nothing (default)
+
+    res = gitea.make_submission_from_gitea_pr(pr, {}, only_successful_builds=False, only_requested_prs=False, dry=False)
+    assert res is None
+    assert "PR git:123 skipped: No packages found" in caplog.text
+
+
+def test_make_submission_from_gitea_pr_exception(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+    """Cover the exception block in make_submission_from_gitea_pr."""
+    caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
+    pr_dict = {
+        "number": 123,
+        "state": "open",
+        "url": "url",
+        "base": {"repo": {"full_name": "owner/repo", "name": "repo"}},
+    }
+    pr = PullRequest.from_json(pr_dict)
+    assert pr is not None
+    mocker.patch("openqabot.loader.gitea._fetch_details", side_effect=Exception("API failure"))
+
+    res = gitea.make_submission_from_gitea_pr(pr, {}, only_successful_builds=False, only_requested_prs=False, dry=False)
+    assert res is None
+    assert "Gitea API error: Unable to process PR git:123" in caplog.text

--- a/tests/test_openqabot_simple.py
+++ b/tests/test_openqabot_simple.py
@@ -130,7 +130,6 @@ def test_passed_post_osd_failed(mocked_openqa_bot: Namespace, caplog: pytest.Log
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
 def test_post_qem_success(mocked_openqa_bot: Namespace, mocker: MockerFixture) -> None:
-
     bot = OpenQABot(mocked_openqa_bot)
     bot.openqa = mocker.Mock(spec=OpenQAInterface)
     test_api = "api/jobs/incident/1"

--- a/tests/test_pullrequest.py
+++ b/tests/test_pullrequest.py
@@ -2,35 +2,9 @@
 # SPDX-License-Identifier: MIT
 """Test PullRequest class."""
 
-import logging
-
 import pytest
-import requests
-from pytest_mock import MockerFixture
 
-from openqabot.loader import gitea
 from openqabot.types.pullrequest import PullRequest
-
-
-def test_get_open_prs_specific_number_json_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    """Cover JSONDecodeError when fetching a specific PR number."""
-    caplog.set_level(logging.WARNING, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=requests.exceptions.JSONDecodeError("msg", "doc", 0))
-    res = gitea.get_open_prs({}, "repo", number=124)
-
-    assert res == []
-    assert "PR git:124 ignored: Could not read PR metadata" in caplog.text
-
-
-def test_get_open_prs_specific_number_key_error(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    """Cover KeyError (simulating unexpected API response structure)."""
-    caplog.set_level(logging.WARNING, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.get_json", side_effect=KeyError("missing_field"))
-
-    res = gitea.get_open_prs({}, "repo", number=124)
-
-    assert res == []
-    assert "PR git:124 ignored: Could not read PR metadata" in caplog.text
 
 
 def test_pull_request_has_labels() -> None:
@@ -38,7 +12,8 @@ def test_pull_request_has_labels() -> None:
     raw_data = [{"name": "bug", "id": 1}, {"name": "urgent", "id": 2}, {"name": "v1.0", "id": 3}]
     pr = PullRequest(
         number=124,
-        repo_name="os-autoinst",
+        state="open",
+        project="os-autoinst",
         branch="master",
         url="http://gitea/pull/124",
         commit_sha="abcd123",
@@ -55,10 +30,23 @@ def test_pull_request_id_property() -> None:
     """Verify that id property returns the same value as number."""
     pr = PullRequest(
         number=124,
-        repo_name="os-autoinst",
+        state="open",
+        project="os-autoinst",
         branch="master",
         url="http://gitea/pull/124",
         commit_sha="abcd123",
         raw_labels=[],
     )
     assert pr.id == 124
+
+
+def test_create_from_json_invalid_data(caplog: pytest.LogCaptureFixture) -> None:
+    """Verify create_from_json returns None and logs error on invalid data."""
+    # Missing 'number'
+    assert PullRequest.from_json({"base": {"repo": {"full_name": "repo"}}}) is None
+    assert "PR git:? ignored: Could not read PR metadata" in caplog.text
+
+    # Missing 'base'
+    caplog.clear()
+    assert PullRequest.from_json({"number": 123}) is None
+    assert "PR git:123 ignored: Could not read PR metadata" in caplog.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -184,7 +184,6 @@ def test_unique_dicts() -> None:
 
 
 def test_create_logger_duplicate_handlers() -> None:
-
     name = "test_duplicate_logger"
     log = create_logger(name)
     assert len(log.handlers) == 1


### PR DESCRIPTION
Alternative to https://github.com/openSUSE/qem-bot/pull/501 with slight refactoring to bring back maintainability score to A.