### PR TITLE
perf: optimize more commands with parallel execution

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,10 @@ updates information about submissions and related openQA tests.
     │ --retry            -r                   <int>   Number of retries            │
     │                                                 [env var: QEM_BOT_RETRY]     │
     │                                                 [default: (2)]               │
+    │ --max-workers                           <int>   Maximum number of workers    │
+    │                                                 for parallel processing      │
+    │                                                 [env var:                    │
+    │                                                 QEM_BOT_MAX_WORKERS]         │
     │ --help                                          Show this message and exit.  │
     ╰──────────────────────────────────────────────────────────────────────────────╯
     ╭─ Commands ───────────────────────────────────────────────────────────────────╮

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -248,6 +248,14 @@ def main(  # ruff: ignore[too-many-arguments]
             show_default=str(_default("retry")),
         ),
     ] = None,
+    max_workers: Annotated[
+        int | None,
+        typer.Option(
+            "--max-workers",
+            envvar="QEM_BOT_MAX_WORKERS",
+            help="Maximum number of workers for parallel processing",
+        ),
+    ] = None,
 ) -> None:
     """QEM-Dashboard, SMELT, Gitea and openQA connector."""
     # Configure logging
@@ -278,6 +286,7 @@ def main(  # ruff: ignore[too-many-arguments]
             "singlearch": singlearch,
             "retry": retry,
             "strict_metadata": strict_metadata,
+            "max_workers": max_workers,
         },
     )
 
@@ -303,6 +312,7 @@ def main(  # ruff: ignore[too-many-arguments]
         singlearch=settings.singlearch,
         retry=settings.retry,
         strict_metadata=settings.strict_metadata,
+        max_workers=settings.max_workers,
     )
 
 

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -47,7 +47,7 @@ class Commenter:
         """Run the commenting process."""
         log.info("Starting to comment SMELT incidents in OBS")
 
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
             futures = [executor.submit(self.comment_on_submission, sub) for sub in self.submissions]
             for future in as_completed(futures):
                 future.result()

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from logging import getLogger
 from pprint import pformat
 from typing import TYPE_CHECKING, Any
@@ -46,8 +47,10 @@ class Commenter:
         """Run the commenting process."""
         log.info("Starting to comment SMELT incidents in OBS")
 
-        for sub in self.submissions:
-            self.comment_on_submission(sub)
+        with ThreadPoolExecutor() as executor:
+            futures = [executor.submit(self.comment_on_submission, sub) for sub in self.submissions]
+            for future in as_completed(futures):
+                future.result()
 
         return 0
 

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -3,7 +3,7 @@
 """Trigger testing for PR(s) with certain label."""
 
 from argparse import Namespace
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from itertools import chain
 from logging import getLogger
@@ -374,6 +374,8 @@ class GiteaTrigger:
             self.load_prs_for_project(trigger_config.project)
 
         with ThreadPoolExecutor() as executor:
-            list(executor.map(self.check_pullrequest, chain.from_iterable(self.prs.values())))
+            futures = [executor.submit(self.check_pullrequest, pr) for pr in chain.from_iterable(self.prs.values())]
+            for future in as_completed(futures):
+                future.result()
 
         return 0

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -373,7 +373,7 @@ class GiteaTrigger:
         for trigger_config in self.config_list:
             self.load_prs_for_project(trigger_config.project)
 
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
             futures = [executor.submit(self.check_pullrequest, pr) for pr in chain.from_iterable(self.prs.values())]
             for future in as_completed(futures):
                 future.result()

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -3,6 +3,7 @@
 """Trigger testing for PR(s) with certain label."""
 
 from argparse import Namespace
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from itertools import chain
 from logging import getLogger
@@ -371,7 +372,8 @@ class GiteaTrigger:
         """
         for trigger_config in self.config_list:
             self.load_prs_for_project(trigger_config.project)
-        for pr in chain.from_iterable(self.prs.values()):
-            self.check_pullrequest(pr)
+
+        with ThreadPoolExecutor() as executor:
+            list(executor.map(self.check_pullrequest, chain.from_iterable(self.prs.values())))
 
         return 0

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -619,7 +619,7 @@ def add_build_results(submission: dict[str, Any], obs_urls: list[str], *, dry: b
     """Aggregate build results from multiple OBS URLs into a submission."""
     results = BuildResults()
 
-    with futures.ThreadPoolExecutor() as executor:
+    with futures.ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
         futs = [executor.submit(_fetch_obs_url_data, url, dry=dry) for url in obs_urls]
         _process_fetched_data(submission, results, futs)
 
@@ -849,7 +849,7 @@ def get_submissions_from_open_prs(
     # configure osc to be able to request build info from OBS
     osc.conf.get_config(override_apiurl=config.settings.obs_url)
 
-    with futures.ThreadPoolExecutor() as executor:
+    with futures.ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
         future_sub = [
             executor.submit(
                 make_submission_from_gitea_pr,

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -541,45 +541,56 @@ def is_build_result_relevant(res: etree._Element, relevant_archs: set[str] | Non
     return arch == "local" or relevant_archs is None or arch in relevant_archs
 
 
-def _get_project_results(obs_project: str, *, dry: bool, results: BuildResults) -> list[etree._Element]:
-    """Fetch build results for an OBS project."""
+def _get_project_results(obs_project: str, *, dry: bool) -> tuple[list[etree._Element], bool]:
+    """Fetch build results for an OBS project. Returns a tuple of (results, is_unavailable)."""
     build_info_url = osc.core.makeurl(config.settings.obs_url, ["build", obs_project, "_result"])
     if dry:
-        return read_xml("build-results-124-" + obs_project).getroot().findall("result")
+        return read_xml("build-results-124-" + obs_project).getroot().findall("result"), False
     try:
-        return osc.util.xml.xml_parse(http_GET(build_info_url)).getroot().findall("result")
+        return osc.util.xml.xml_parse(http_GET(build_info_url)).getroot().findall("result"), False
     except urllib.error.HTTPError:
-        results.unavailable.add(obs_project)
         log.info("Build results for project %s unreadable, skipping: %s", obs_project, build_info_url)
-        return []
+        return [], True
 
 
-def _process_obs_url(
+def _fetch_obs_url_data(
     url: str,
-    submission: dict[str, Any],
     *,
     dry: bool,
-    results: BuildResults,
-) -> None:
-    """Process an OBS URL and update submission build results."""
+) -> tuple[str | None, set[str] | None, list[etree._Element], bool]:
+    """Fetch all necessary data for an OBS URL concurrently."""
     if not (project_match := OBS_PROJECT_SHOW_REGEX.search(url)):
-        return
+        return None, None, [], False
     obs_project = project_match.group(1)
     log.debug("Checking OBS project %s", obs_project)
     relevant_archs = determine_relevant_archs_from_multibuild_info(obs_project, dry=dry)
 
-    for res in _get_project_results(obs_project, dry=dry, results=results):
-        if is_build_result_relevant(res, relevant_archs):
-            add_build_result(submission, res, results)
+    xml_results, is_unavailable = _get_project_results(obs_project, dry=dry)
+    return obs_project, relevant_archs, xml_results, is_unavailable
 
 
-def add_build_results(submission: dict[str, Any], obs_urls: list[str], *, dry: bool) -> None:
-    """Aggregate build results from multiple OBS URLs into a submission."""
-    results = BuildResults()
+def _process_fetched_data(
+    submission: dict[str, Any],
+    results: BuildResults,
+    futs: list[futures.Future[tuple[str | None, set[str] | None, list[etree._Element], bool]]],
+) -> None:
+    """Process data fetched concurrently in the main thread."""
+    for fut in futures.as_completed(futs):
+        obs_project, relevant_archs, xml_results, is_unavailable = fut.result()
 
-    for url in obs_urls:
-        _process_obs_url(url, submission, dry=dry, results=results)
+        if obs_project is None:
+            continue
 
+        if is_unavailable:
+            results.unavailable.add(obs_project)
+
+        for res in xml_results:
+            if is_build_result_relevant(res, relevant_archs):
+                add_build_result(submission, res, results)
+
+
+def _update_submission_from_results(submission: dict[str, Any], results: BuildResults) -> None:
+    """Update submission dictionary with aggregated build results."""
     if results.unpublished:
         log.info(
             "PR git:%i: Some repos not published yet: %s",
@@ -602,6 +613,17 @@ def add_build_results(submission: dict[str, Any], obs_urls: list[str], *, dry: b
         "all" in config.settings.obs_products_set,
     ) == (1, False):
         submission["scminfo"] = submission.get("scminfo_" + next(iter(config.settings.obs_products_set)), "")
+
+
+def add_build_results(submission: dict[str, Any], obs_urls: list[str], *, dry: bool) -> None:
+    """Aggregate build results from multiple OBS URLs into a submission."""
+    results = BuildResults()
+
+    with futures.ThreadPoolExecutor() as executor:
+        futs = [executor.submit(_fetch_obs_url_data, url, dry=dry) for url in obs_urls]
+        _process_fetched_data(submission, results, futs)
+
+    _update_submission_from_results(submission, results)
 
 
 def add_comments_and_referenced_build_results(

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -3,7 +3,7 @@
 """Main OpenQABot logic."""
 
 from argparse import Namespace
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from logging import getLogger
 from os import environ
 from typing import Any
@@ -81,6 +81,8 @@ class OpenQABot:
                 self.post_qem(job["qem"], job["api"])
 
         with ThreadPoolExecutor(max_workers=config_module.settings.max_workers) as executor:
-            wait([executor.submit(poster, job) for job in post])
+            futures = [executor.submit(poster, job) for job in post]
+            for future in as_completed(futures):
+                future.result()
         log.info("Bot run completed")
         return 0


### PR DESCRIPTION
* perf(approver): parallelize submission filtering and approval
* perf(gitea-loader): parallelize build result fetching
* perf(commenter): parallelize incident commenting

Similar to #495 but independant.

This brings the runtime for one gitea-trigger cycle down from
40280±1654.52 ms to 33785±125.34 ms which is a 16%
improvement (speedup 1.2x).

For one sub-approve cycle this brings the time down from
135907±5291.28 ms to 20724±384.48 ms which is a big 84%
improvement (speedup 6.6x).