### PR TITLE
feat: auto-discover increment configs from global directory

### DIFF
--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -31,6 +31,13 @@ def get_default_obs_url() -> str:
 class Settings(BaseSettings):
     """Configuration settings managed by Pydantic."""
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+        """Initialize settings with optional overrides.
+
+        This explicit constructor helps type checkers like 'ty' recognize valid parameters.
+        """
+        super().__init__(*args, **kwargs)
+
     # Global options
     configs: Path = Field(default=Path("/etc/openqabot"), alias="QEM_BOT_CONFIGS")
     dry: bool = Field(default=False, alias="QEM_BOT_DRY")

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -134,8 +134,11 @@ class IncrementConfig:
     @staticmethod
     def from_args(args: Namespace) -> list[IncrementConfig]:
         """Create increment configurations from command line arguments."""
-        if args.increment_config:
-            configs = list(IncrementConfig.from_config_path(args.increment_config))
+        source = args.increment_config or (
+            args.configs if getattr(args, "configs", None) and args.configs.exists() else None
+        )
+
+        if configs := (list(IncrementConfig.from_config_path(source)) if source else []):
             # Apply CLI filter overrides to YAML-loaded configs if they differ from defaults
             overrides = {"distri": "sle", "version": "any", "flavor": "any", "arch": "any"}
             for c in configs:
@@ -143,6 +146,7 @@ class IncrementConfig:
                     if (val := getattr(args, field, default)) != default:
                         setattr(c, field, val)
             return configs
+
         # Create a dictionary from arguments for IncrementConfig
         config_args = {
             field_name: getattr(args, field_name)

--- a/tests/test_loader_incrementconfig.py
+++ b/tests/test_loader_incrementconfig.py
@@ -85,6 +85,25 @@ def test_config_parsing_from_args_with_path(config_index: int, expected_distri: 
     assert additional_settings.items() <= config.settings.items()
 
 
+def test_config_parsing_from_args_with_auto_discovery() -> None:
+    path = Path("tests/fixtures/config-increment-approver")
+    configs = IncrementConfig.from_args(
+        Namespace(increment_config=None, configs=path, distri="sle", version="16.0", flavor="Online-Increments")
+    )
+    assert len(configs) == 2
+    assert configs[0].distri == "foo"
+    assert configs[1].distri == "bar"
+
+
+def test_config_parsing_from_args_fallback_to_cli() -> None:
+    path = Path("tests/fixtures/config")
+    configs = IncrementConfig.from_args(
+        Namespace(increment_config=None, configs=path, distri="sle", version="16.0", flavor="Online-Increments")
+    )
+    assert len(configs) == 1
+    assert configs[0].distri == "sle"
+
+
 def test_config_parsing_reference_repos() -> None:
     entry = {
         "distri": "sle",


### PR DESCRIPTION
Motivation:
Users (like me) can forget to specify --increment-config for
increment-approve, leading to confusing 'No builds found' errors. Since
the global configuration directory is already known via the -c flag (or
.env), it should be used as a default source for increment
configurations.

Design Choices:
* Updated IncrementConfig.from_args to check args.configs if
  args.increment_config is omitted.
* Loaded configurations are still filtered by explicit CLI overrides.
* Added an explicit __init__ to Settings to help the 'ty' type checker.

Benefits:
* Improved DX: increment-approve now automatically finds relevant
  configurations based on the project's metadata.