### PR TITLE
fix(increment-approve): exclude dev groups (regression from  fdc3dd8c)

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -115,7 +115,7 @@ class IncrementApprover:
         """Fetch results from openQA for the specified scheduling parameters."""
         log.debug("Checking openQA job results for %s", info_str)
 
-        def fetch(p: dict[str, Any]) -> OpenQAResult:
+        def fetch_stats(p: dict[str, Any]) -> OpenQAResult:
             return self.client.get_scheduled_product_stats({
                 "distri": p["DISTRI"],
                 "version": p["VERSION"],
@@ -126,7 +126,19 @@ class IncrementApprover:
             })
 
         with ThreadPoolExecutor() as executor:
-            res = list(executor.map(fetch, params))
+            stats = list(executor.map(fetch_stats, params))
+
+        # Fetch all relevant job details in a single API call to avoid N+1 query problem
+        job_ids = [
+            int(ids[0])
+            for stat in stats
+            for jobs in stat.values()
+            for info in jobs.values()
+            if (ids := info.get("job_ids"))
+        ]
+        job_map = {job["id"]: job for job in self.client.get_jobs_by_ids(job_ids)}
+
+        res = [self.client.enrich_stats(stat, job_map) for stat in stats]
 
         log.debug("Job statistics:\n%s", pformat(res))
         return res

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -123,6 +123,18 @@ class OpenQAInterface:
             log.exception("openQA API error when fetching job %s", job_id)
         return None
 
+    def get_jobs_by_ids(self, job_ids: list[int]) -> list[dict[str, Any]]:
+        """Fetch details for multiple jobs in a single API call."""
+        if not job_ids:
+            return []
+
+        ids_str = ",".join(map(str, sorted(set(job_ids))))
+        try:
+            return self.openqa.openqa_request("GET", "jobs", {"ids": ids_str}).get("jobs", [])
+        except RequestError:
+            log.exception("openQA API error when fetching multiple jobs")
+        return []
+
     def is_in_devel_group(self, job: dict[str, Any]) -> bool:
         """Check if a job belongs to a development group."""
         if config.settings.allow_development_groups:
@@ -164,3 +176,25 @@ class OpenQAInterface:
         except RequestError:
             log.exception("openQA API error when fetching job group %s", group_id)
         return None
+
+    @staticmethod
+    def enrich_job_info(info: dict[str, Any], job_map: dict[int, dict[str, Any]]) -> dict[str, Any]:
+        """Enrich job information with metadata from the first job ID."""
+        if not (ids := info.get("job_ids")) or not (job := job_map.get(int(ids[0]))):
+            return info
+
+        return info | {
+            "group": job.get("group"),
+            "group_id": job.get("group_id"),
+            "distri": job.get("distri"),
+            "version": job.get("version"),
+            "build": job.get("build"),
+        }
+
+    @staticmethod
+    def enrich_stats(stat: dict[str, Any], job_map: dict[int, dict[str, Any]]) -> dict[str, Any]:
+        """Enrich all jobs in a scheduled product result with metadata."""
+        return {
+            status: {name: OpenQAInterface.enrich_job_info(info, job_map) for name, info in jobs.items()}
+            for status, jobs in stat.items()
+        }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -255,6 +255,9 @@ def prepare_approver(
         approver.client.get_single_job = MagicMock(  # ty: ignore[invalid-assignment]
             side_effect=lambda job_id: {"id": job_id, "group": "Production", "group_id": 1}
         )
+        approver.client.get_jobs_by_ids = MagicMock(  # ty: ignore[invalid-assignment]
+            side_effect=lambda ids: [{"id": jid, "group": "Production", "group_id": 1} for jid in ids]
+        )
         approver.client.is_devel_group = MagicMock(return_value=False)  # ty: ignore[invalid-assignment]
         return approver
 

--- a/tests/test_incrementapprover_helpers.py
+++ b/tests/test_incrementapprover_helpers.py
@@ -94,3 +94,37 @@ def test_filter_results(caplog: pytest.LogCaptureFixture, mocker: MockerFixture)
     ]
     expected = [{"passed": {"j1": {"job_ids": [1], "group_id": 1}}}]
     assert approver._filter_results(results) == expected  # noqa: SLF001
+
+
+@responses.activate
+def test_request_openqa_job_results_enrichment_missing_data(
+    caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+) -> None:
+    """Test job results enrichment with missing or incomplete data."""
+    approver = prepare_approver(caplog)
+
+    mock_stats = {
+        "done": {
+            "passed": {"no_job_ids": []},  # Missing job_ids
+            "failed": {"job_ids": ["123"]},  # get_single_job will return None
+        }
+    }
+
+    mocker.patch.object(approver.client, "get_scheduled_product_stats", return_value=mock_stats)
+    mocker.patch.object(approver.client, "get_jobs_by_ids", return_value=[])
+
+    params: list[dict[str, str]] = [
+        {
+            "DISTRI": "sle",
+            "VERSION": "15-SP4",
+            "FLAVOR": "Online",
+            "ARCH": "x86_64",
+            "BUILD": "123",
+            "PRODUCT": "SLES",
+        }
+    ]
+
+    res = approver.request_openqa_job_results(params, "info")
+
+    assert len(res) == 1
+    assert "done" in res[0]

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -512,7 +512,7 @@ def test_approval_if_failing_jobs_are_in_development_group(
     responses.add(responses.GET, fake_openqa_url_job_stat, json={"done": {"failed": {"job_ids": [123], "group_id": 9}}})
     increment_approver = prepare_approver(caplog, schedule=schedule)
     # is_devel_group is called with group_id (int), unlike is_in_devel_group which takes a job dict
-    increment_approver.client.get_single_job = mocker.Mock(return_value=_devel_job(123, result="failed"))
+    increment_approver.client.get_jobs_by_ids = mocker.Mock(return_value=[_devel_job(123, result="failed")])
     increment_approver.client.is_devel_group = mocker.Mock(return_value=True)
     mock_post_job = mocker.patch.object(increment_approver.client, "post_job")
     mock_change_review = mocker.patch("osc.core.change_review_state")
@@ -544,7 +544,9 @@ def test_approval_with_mixed_jobs_development_ignored(
     job_map = {123: _devel_job(123, result="failed"), 456: _prod_job(456, result="passed")}
     mock_osc_approve = mocker.patch("osc.core.change_review_state")
     increment_approver = prepare_approver(caplog)
-    increment_approver.client.get_single_job = mocker.Mock(side_effect=job_map.get)
+    increment_approver.client.get_jobs_by_ids = mocker.Mock(
+        side_effect=lambda ids: [job_map[jid] for jid in ids if jid in job_map]
+    )
     increment_approver.client.is_devel_group = mocker.Mock(side_effect=lambda gid: gid == 9)
     increment_approver()
 
@@ -573,7 +575,9 @@ def test_approval_if_running_jobs_are_in_development_group(
     job_map = {123: _devel_job(123, state="running"), 456: _prod_job(456, state="done", result="passed")}
     mock_osc_approve = mocker.patch("osc.core.change_review_state")
     increment_approver = prepare_approver(caplog)
-    increment_approver.client.get_single_job = mocker.Mock(side_effect=job_map.get)
+    increment_approver.client.get_jobs_by_ids = mocker.Mock(
+        side_effect=lambda ids: [job_map[jid] for jid in ids if jid in job_map]
+    )
     increment_approver.client.is_in_devel_group = mocker.Mock(side_effect=lambda j: "Development" in j.get("group", ""))
     increment_approver()
 

--- a/tests/test_openqaclient.py
+++ b/tests/test_openqaclient.py
@@ -95,7 +95,24 @@ def test_get_methods_handle_errors_gracefully() -> None:
     with patch("openqabot.openqa.OpenQA_Client.openqa_request", side_effect=error):
         assert client.get_job_comments(42) == []
         assert not client.get_single_job(42)
+        assert client.get_jobs_by_ids([1, 2]) == []
         assert client.get_older_jobs(42, 0) == {"data": []}
+
+
+@responses.activate
+def test_get_jobs_by_ids(fake_openqa_url: str) -> None:
+    client = oQAI()
+    mock_jobs = [{"id": 1}, {"id": 2}]
+    responses.add(
+        responses.GET,
+        f"{fake_openqa_url}/api/v1/jobs",
+        json={"jobs": mock_jobs},
+        status=200,
+        match=[matchers.query_param_matcher({"ids": "1,2"})],
+    )
+
+    assert client.get_jobs_by_ids([2, 1, 2]) == mock_jobs
+    assert client.get_jobs_by_ids([]) == []
 
 
 def test_get_job_comments_request_exception(caplog: pytest.LogCaptureFixture) -> None:
@@ -166,3 +183,46 @@ def test_get_job_group_info_error(fake_openqa_url: str, caplog: pytest.LogCaptur
     result = client.get_job_group_info(42)
     assert result is None
     assert "openQA API error when fetching job group 42" in caplog.text
+
+
+def test_enrich_job_info() -> None:
+    """Test enrich_job_info with various inputs."""
+    job_map = {
+        1: {
+            "id": 1,
+            "group": "Group1",
+            "group_id": 10,
+            "distri": "dist",
+            "version": "1.0",
+            "build": "123",
+        }
+    }
+
+    # Successful enrichment
+    info = {"job_ids": [1], "other": "data"}
+    enriched = oQAI.enrich_job_info(info, job_map)
+    assert enriched["group"] == "Group1"
+    assert enriched["group_id"] == 10
+    assert enriched["distri"] == "dist"
+    assert enriched["other"] == "data"
+
+    # Missing job_ids
+    info2 = {"other": "data"}
+    assert oQAI.enrich_job_info(info2, job_map) == info2
+
+    # Job ID not in map
+    info3 = {"job_ids": [2]}
+    assert oQAI.enrich_job_info(info3, job_map) == info3
+
+
+def test_enrich_stats() -> None:
+    """Test enrich_stats properly traverses the stats structure."""
+    job_map = {1: {"id": 1, "group": "G1", "group_id": 10, "distri": "d", "version": "v", "build": "b"}}
+    stats = {
+        "passed": {"job1": {"job_ids": [1], "result": "passed"}},
+        "failed": {"job2": {"job_ids": [2], "result": "failed"}},
+    }
+
+    enriched = oQAI.enrich_stats(stats, job_map)
+    assert enriched["passed"]["job1"]["group"] == "G1"
+    assert "group" not in enriched["failed"]["job2"]


### PR DESCRIPTION
Motivation:
Jobs in development groups incorrectly blocked product increment approvals
when in pending states, a regression introduced in fdc3dd8c. Additionally,
fetching job details sequentially for large sets of scheduled products
caused significant latency (N+1 query problem).

Design Choices:
Refactored `increment-approve` to ensure openQA jobs belonging to development
groups are properly filtered out before evaluation. To optimize performance,
implemented `get_jobs_by_ids` in `OpenQAInterface` to leverage the openQA
batch job query API (`/api/v1/jobs?ids=...`). This allows fetching all
relevant job details in a single network request. The enrichment logic was
also refactored into descriptive private helper methods (`_enrich_job_info`,
`_enrich_stats`) using a functional pipeline to improve maintainability.

Benefits:
Prevents development jobs from blocking production pipelines.
Significantly reduces execution time by collapsing hundreds of
sequential API calls into a single batch request. Improves code
readability and maintainability.

Related issue: https://progress.opensuse.org/issues/198728
Fixes: fdc3dd8c ("fix: prevent constant retriggering of development job groups")