### PR TITLE
fix: improve kernel-livepatch regex to handle underscores

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -191,9 +191,9 @@ product_increments:
   - foo
   - bar
   additional_builds:
-  - build_suffix: kernel-livepatch
-    regex: 'kernel-livepatch-(?P<kernel_version>[^\-]*?-[^\-]*?)-(?P<kind>rt)'
-    settings:
+   - build_suffix: kernel-livepatch
+     regex: 'kernel-livepatch-(?P<kernel_version>[^-]+(?:-[^-]+)?)(?:-(?P<kind>rt))?$'
+     settings:
       FLAVOR: Base-RT-Updates
       KGRAFT: '1'
   - build_suffix: …

--- a/tests/fixtures/config-increment-approver/increment-definitions.yaml
+++ b/tests/fixtures/config-increment-approver/increment-definitions.yaml
@@ -21,12 +21,12 @@ product_increments:
     FOO: bar
   additional_builds:
   - build_suffix: kernel-livepatch
-    regex: 'kernel-livepatch-(?P<kernel_version>[^\-]*?-[^\-]*?)-(?P<kind>rt)'
+    regex: 'kernel-livepatch-(?P<kernel_version>[^-]+(?:-[^-]+)?)(?:-(?P<kind>rt))?$'
     settings:
       FLAVOR: Base-RT-Updates
       KGRAFT: '1'
   - build_suffix: kernel-livepatch
-    regex: 'kernel-livepatch-(?P<kernel_version>[^\-]*?-[^\-]*?)-(?P<kind>.*)'
+    regex: 'kernel-livepatch-(?P<kernel_version>[^-]+(?:-[^-]+)?)(?:-(?P<kind>[^-]+))?$'
     settings:
       FLAVOR: Default-qcow-Updates
       KGRAFT: '1'


### PR DESCRIPTION
Motivation:
Recent kernel live patch packages like 'kernel-livepatch-SLE16_Update_2'
did not match the existing regex because it strictly required hyphens after
the prefix.

Design Choices:
Updated the 'regex' for kernel-livepatch additional builds in documentation
and test fixtures to use a more flexible anchored pattern:
'kernel-livepatch-(?P<kernel_version>[^-]+(?:-[^-]+)?)(?:-(?P<kind>[^-]+))?$'.
This correctly matches both the old hyphenated format and the newer
underscore-only format, while maintaining correct group capturing.

Benefits:
Ensures qem-bot correctly identifies and schedules openQA tests for all
current kernel live patch variants.

Manual verification:
Verified running

```
./qem-bot.py -d --dry increment-approve \
  --increment-config metadata/qem-bot/sles1600.yml --reschedule
```

which would output

```
Re-scheduling jobs for
 - SLESv16.0 build PI-224.5@ppc64le of flavor Online-Increments
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.5@ppc64le of flavor …
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.4@ppc64le of flavor …
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.2@ppc64le of flavor …
Re-scheduling jobs for
 - SLESv16.0 build PI-224.5@x86_64 of flavor Online-Increments
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.5@x86_64 of flavor …
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.4@x86_64 of flavor …
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.2@x86_64 of flavor …
Re-scheduling jobs for
 - SLESv16.0 build PI-224.5@s390x of flavor Online-Increments
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.5@s390x of flavor …
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.4@s390x of flavor …
 - SLESv16.0 build PI-224.5-kernel-livepatch-SLE16.Update.2@s390x of flavor …
…
```

Related issue: https://progress.opensuse.org/issues/198728