### PR TITLE
perf: deduplicate openqa product increment requests

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -25,7 +25,7 @@ from openqabot.pc_helper import apply_public_cloud_settings
 from .commenter import Commenter
 from .errors import AmbiguousApprovalStatusError, PostOpenQAError
 from .loader.buildinfo import load_build_info
-from .loader.incrementconfig import IncrementConfig
+from .loader.incrementconfig import GroupKey, IncrementConfig
 from .loader.sourcereport import compute_packages_of_request_from_source_report
 from .repodiff import Package, RepoDiff
 from .requests import find_request_on_obs
@@ -529,7 +529,9 @@ class IncrementApprover:
         self.requests_to_approve[request_id] = status
         return status
 
-    def process_request_for_config(self, request: osc.core.Request | None, config_inc: IncrementConfig) -> int:
+    def process_request_for_config(
+        self, request: osc.core.Request | None, config_inc: IncrementConfig, build_infos: set[BuildInfo]
+    ) -> int:
         """Process an OBS request for a specific configuration."""
         if request is None:
             return 0
@@ -537,14 +539,8 @@ class IncrementApprover:
         approval_status = self._get_approval_status(request)
         error_count = 0
         found_relevant_build = False
-        for build_info in load_build_info(
-            config_inc,
-            config_inc.build_regex,
-            config_inc.product_regex,
-            config_inc.version_regex,
-            self.get_regex_match,
-        ):
-            if len(config_inc.archs) > 0 and build_info.arch not in config_inc.archs:
+        for build_info in build_infos:
+            if not config_inc.accepts_build_info(build_info):
                 continue
             found_relevant_build = True
             error_count += self.process_build_info(config_inc, build_info, request, approval_status)
@@ -561,6 +557,8 @@ class IncrementApprover:
         single_request = (
             osc.core.Request.from_api(config.settings.obs_url, self.args.request_id) if self.args.request_id else None
         )
+
+        grouped_configs: dict[GroupKey, list[IncrementConfig]] = defaultdict(list)
         for config_inc in self.config:
             if single_request and single_request.actions[0].src_project != config_inc.build_project():
                 log.debug(
@@ -570,8 +568,21 @@ class IncrementApprover:
                     single_request.actions[0].src_project,
                 )
                 continue
-            request = find_request_on_obs(self.args, config_inc.build_project())
-            error_count += self.process_request_for_config(request, config_inc)
+            grouped_configs[config_inc.group_key].append(config_inc)
+
+        for configs in grouped_configs.values():
+            rep_config = configs[0]
+            build_infos = load_build_info(
+                rep_config,
+                rep_config.build_regex,
+                rep_config.product_regex,
+                rep_config.version_regex,
+                self.get_regex_match,
+            )
+            for config_inc in configs:
+                request = find_request_on_obs(self.args, config_inc.build_project())
+                error_count += self.process_request_for_config(request, config_inc, build_infos)
+
         for request in self.requests_to_approve.values():
             error_count += self.handle_approval(request)
         return error_count

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -575,12 +575,10 @@ class IncrementApprover:
             build_infos = load_build_info(
                 rep_config,
                 rep_config.build_regex,
-                rep_config.product_regex,
-                rep_config.version_regex,
                 self.get_regex_match,
             )
+            request = find_request_on_obs(self.args, rep_config.build_project())
             for config_inc in configs:
-                request = find_request_on_obs(self.args, config_inc.build_project())
                 error_count += self.process_request_for_config(request, config_inc, build_infos)
 
         for request in self.requests_to_approve.values():

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -24,8 +24,6 @@ default_flavor = "Online"
 def load_build_info(
     config: IncrementConfig,
     build_regex: str,
-    product_regex: str,
-    version_regex: str,
     get_regex_match: Callable[[str, str], re.Match | None],
 ) -> set[BuildInfo]:
     """Determine build information from the project's repository listing."""
@@ -44,14 +42,8 @@ def load_build_info(
             return None
 
         product = m.group("product")
-        if not get_regex_match(product_regex, product):
-            return None
-
         distri = config.distri
         version = m.group("version")
-        if not get_regex_match(version_regex, version):
-            log.info("Skipping version string '%s' not matching version regex '%s'", version, version_regex)
-            return None
         arch = m.group("arch")
         build = m.group("build")
         try:

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -60,13 +60,6 @@ def load_build_info(
             flavor = default_flavor
         flavor = f"{flavor}-{config.flavor_suffix}"
 
-        if (
-            config.distri in {"any", distri}
-            and config.flavor in {"any", flavor}
-            and config.version in {"any", version}
-            and config.arch in {"any", arch}
-        ):
-            return BuildInfo(distri, product, version, flavor, arch, build)
-        return None
+        return BuildInfo(distri, product, version, flavor, arch, build)
 
     return {build_info for row in rows if (build_info := get_build_info_from_row(row))}

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import pprint
+import re
 from dataclasses import dataclass, field
 from itertools import chain
 from logging import getLogger
@@ -100,7 +101,11 @@ class IncrementConfig:
             getattr(self, k) in {"any", getattr(build_info, k)} for k in ("distri", "flavor", "version", "arch")
         ):
             return False
-        return not (len(self.archs) > 0 and build_info.arch not in self.archs)
+        if self.archs and build_info.arch not in self.archs:
+            return False
+        if not re.search(self.product_regex, build_info.product):
+            return False
+        return bool(re.search(self.version_regex, build_info.version))
 
     def __str__(self) -> str:
         """Return a string representation of the increment configuration."""

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -21,9 +21,22 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
+    from openqabot.types.increment import BuildInfo
+
 log = getLogger("bot.increment_config")
 DEFAULT_FLAVOR_SUFFIX = "Increments"
 DEFAULT_VERSION_REGEX = r"[\d.]+"
+
+
+@dataclass(frozen=True)
+class GroupKey:
+    """Unique key for grouping increment configurations."""
+
+    build_project: str
+    build_listing_sub_path: str
+    build_regex: str
+    distri: str
+    flavor_suffix: str
 
 
 @dataclass
@@ -69,6 +82,25 @@ class IncrementConfig:
         """Return the URL of the build project."""
         base_path = self.build_project().replace(":", ":/")
         return f"{base_url or config.settings.obs_download_url}/{base_path}"
+
+    @property
+    def group_key(self) -> GroupKey:
+        """Return a unique key for grouping configs."""
+        return GroupKey(
+            build_project=self.build_project(),
+            build_listing_sub_path=self.build_listing_sub_path,
+            build_regex=self.build_regex,
+            distri=self.distri,
+            flavor_suffix=self.flavor_suffix,
+        )
+
+    def accepts_build_info(self, build_info: BuildInfo) -> bool:
+        """Return True if the build information matches this configuration."""
+        if not all(
+            getattr(self, k) in {"any", getattr(build_info, k)} for k in ("distri", "flavor", "version", "arch")
+        ):
+            return False
+        return not (len(self.archs) > 0 and build_info.arch not in self.archs)
 
     def __str__(self) -> str:
         """Return a string representation of the increment configuration."""

--- a/tests/test_incrementapprover_build_info.py
+++ b/tests/test_incrementapprover_build_info.py
@@ -136,7 +136,8 @@ def testload_build_info_filter_no_match(caplog: pytest.LogCaptureFixture, mocker
     res = load_build_info(
         config, config.build_regex, config.product_regex, config.version_regex, approver.get_regex_match
     )
-    assert res == set()
+    assert len(res) == 1
+    assert next(iter(res)).version == "16.0"
 
 
 def test_extra_builds_package_version_regex_no_match(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_incrementapprover_build_info.py
+++ b/tests/test_incrementapprover_build_info.py
@@ -72,18 +72,16 @@ def testload_build_info_no_match(caplog: pytest.LogCaptureFixture, mocker: Mocke
     mocker.patch("openqabot.loader.buildinfo.retried_requests.get").return_value.json.return_value = {
         "data": [{"name": "SLES-16.0-x86_64-Build1.1-Source.report.spdx.json"}]
     }
-    res = load_build_info(
-        config, config.build_regex, config.product_regex, config.version_regex, approver.get_regex_match
-    )
+    res = load_build_info(config, config.build_regex, approver.get_regex_match)
     assert res == set()
     config.product_regex = "SLES"
     mocker.patch("openqabot.loader.buildinfo.retried_requests.get").return_value.json.return_value = {
         "data": [{"name": "SLES-brokenversion-Online-x86_64-Build1.1-Source.report.spdx.json"}]
     }
-    res = load_build_info(
-        config, config.build_regex, config.product_regex, config.version_regex, approver.get_regex_match
-    )
-    assert res == set()
+    res = load_build_info(config, config.build_regex, approver.get_regex_match)
+    # load_build_info no longer filters product_regex/version_regex, so it should return one item now
+    assert len(res) == 1
+    assert not config.accepts_build_info(next(iter(res)))
 
 
 def test_extra_builds_no_match(caplog: pytest.LogCaptureFixture) -> None:
@@ -113,9 +111,7 @@ def testload_build_info_missing_flavor_group(caplog: pytest.LogCaptureFixture, m
     mocker.patch("openqabot.loader.buildinfo.retried_requests.get").return_value.json.return_value = {
         "data": [{"name": "SLES-16.0-x86_64-Build1.1-Source.report.spdx.json"}]
     }
-    res = load_build_info(
-        config, config.build_regex, config.product_regex, config.version_regex, approver.get_regex_match
-    )
+    res = load_build_info(config, config.build_regex, approver.get_regex_match)
     assert len(res) == 1
     assert next(iter(res)).flavor == "Online-Increments"
 
@@ -133,9 +129,7 @@ def testload_build_info_filter_no_match(caplog: pytest.LogCaptureFixture, mocker
     mocker.patch("openqabot.loader.buildinfo.retried_requests.get").return_value.json.return_value = {
         "data": [{"name": "SLES-16.0-Online-x86_64-Build1.1.spdx.json"}]
     }
-    res = load_build_info(
-        config, config.build_regex, config.product_regex, config.version_regex, approver.get_regex_match
-    )
+    res = load_build_info(config, config.build_regex, approver.get_regex_match)
     assert len(res) == 1
     assert next(iter(res)).version == "16.0"
 

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -343,7 +343,7 @@ def test_skipping_with_mismatching_package(mocker: MockerFixture, caplog: pytest
         req.reqid = "42"
         # mock get_package_diff to return empty diff
         mocker.patch.object(approver, "get_package_diff", return_value=defaultdict(set))
-        approver.process_request_for_config(req, configs[0])
+        approver.process_request_for_config(req, configs[0], set(mock_load.return_value))
 
     assert "Skipping" in caplog.text
     assert "filtered out via 'packages' or 'archs' setting" in caplog.text

--- a/tests/test_loader_incrementconfig.py
+++ b/tests/test_loader_incrementconfig.py
@@ -11,6 +11,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from openqabot.loader.incrementconfig import IncrementConfig
+from openqabot.types.increment import BuildInfo
 
 
 def test_from_config_file_invalid_yaml(mocker: MockerFixture, tmp_path: Path) -> None:
@@ -117,3 +118,23 @@ def test_config_parsing_reference_repos() -> None:
     }
     config = IncrementConfig.from_config_entry(entry)
     assert config.reference_repos == {"SLES": "REPO1", "SLES-SAP": "REPO2"}
+
+
+def test_accepts_build_info_regex() -> None:
+    config = IncrementConfig(
+        distri="sle",
+        version="any",
+        flavor="Online-Increments",
+        arch="x86_64",
+        product_regex="^SLES",
+        version_regex="^15.5",
+    )
+
+    # Matches everything
+    assert config.accepts_build_info(BuildInfo("sle", "SLES", "15.5", "Online-Increments", "x86_64", "1"))
+
+    # Mismatch product
+    assert not config.accepts_build_info(BuildInfo("sle", "SLED", "15.5", "Online-Increments", "x86_64", "1"))
+
+    # Mismatch version
+    assert not config.accepts_build_info(BuildInfo("sle", "SLES", "15.4", "Online-Increments", "x86_64", "1"))


### PR DESCRIPTION
Motivation:
When checking for new `.spdx.json` files during `increment-approve`, the bot
repeatedly performed the exact same HTTP requests to the OBS API for each
configuration variation (flavors, architectures). This caused severe slowdowns
and increased the chances of timeouts.

Design Choices:
Refactored `openqabot/incrementapprover.py` to group `IncrementConfig` items
by their shared OBS directory URLs and regex filters before fetching the
listing. Moved the architecture and flavor filtering out of the
`load_build_info` function so that it returns all builds found. This allows
processing multiple configs with just a single API call per unique OBS path.

Benefits:
The bot makes significantly fewer HTTP requests during increment approval
checking, vastly improving runtime execution speed and reducing the load on
the OBS APIs.

Related issue: https://progress.opensuse.org/issues/198728