### PR TITLE
feat: support architecture filtering for additional builds

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -236,6 +236,9 @@ class IncrementApprover:
         build_info: BuildInfo,
     ) -> dict[str, str] | None:
         """Check if an additional build matches a package and return extra parameters."""
+        if (archs := additional_build.get("archs")) and package.arch not in archs:
+            return None
+
         package_name_match = self._match_package_name_and_version(package, additional_build)
         if package_name_match is None:
             return None

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -274,7 +274,7 @@ class IncrementApprover:
         build_info: BuildInfo,
     ) -> dict[str, str] | None:
         """Determine extra build parameters for a specific package."""
-        if re.match(r"^1(?:\..*)?$", package.version):
+        if not package.version or re.match(r"^1(?:\..*)?$", package.version):
             return None
         if "debug" in package.name or package.arch in {"src", "nosrc"}:
             return None

--- a/tests/test_incrementapprover_helpers.py
+++ b/tests/test_incrementapprover_helpers.py
@@ -82,6 +82,28 @@ def test_extra_builds_for_package_filtering(caplog: pytest.LogCaptureFixture) ->
     assert approver.extra_builds_for_package(pkg5, config, build_info) is None
 
 
+def test_extra_builds_arch_filtering(caplog: pytest.LogCaptureFixture) -> None:
+    approver = prepare_approver(caplog)
+    config = approver.config[0]
+    config.additional_builds = [
+        {
+            "build_suffix": "test-build",
+            "regex": ".*",
+            "archs": ["x86_64"],
+            "settings": {"FOO": "BAR"},
+        }
+    ]
+    build_info = BuildInfo("sle", "SLES", "16.0", "flavor", "arch", "1.1")
+
+    # Matching arch
+    pkg_ok = Package("kernel-livepatch", "0", "20240101", "1.1", "x86_64")
+    assert approver.extra_builds_for_package(pkg_ok, config, build_info) is not None
+
+    # Mismatching arch
+    pkg_fail = Package("kernel-livepatch", "0", "20240101", "1.1", "s390x")
+    assert approver.extra_builds_for_package(pkg_fail, config, build_info) is None
+
+
 def test_filter_results(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
     approver = prepare_approver(caplog)
     mocker.patch.object(approver.client, "is_in_devel_group", side_effect=lambda j: j.get("group_id") == 9)


### PR DESCRIPTION
Motivation:
Additional build configurations in product increment YAMLs could specify an
'archs' list, but it was being ignored by the bot. This meant all additional
builds were attempted for all architectures present in the source report,
even if they weren't supported. Also, placeholder packages in noarch source
reports were triggering redundant build attempts.

Design Choices:
Updated `_match_additional_build` in `openqabot/incrementapprover.py` to
respect the 'archs' key if present in the additional build definition.
Added a check to `extra_builds_for_package` to skip packages with empty
version strings (common for placeholders). Added unit tests for the new
architecture filtering logic.

Benefits:
Correctly restricts additional builds (like KLPs) to their supported
architectures and reduces incorrect test scheduling attempts for
placeholder packages.

Related issue: https://progress.opensuse.org/issues/198728