### PR TITLE
refactor: improve maintainability of KLP matching logic

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -239,25 +239,24 @@ class IncrementApprover:
         if (archs := additional_build.get("archs")) and package.arch not in archs:
             return None
 
-        package_name_match = self._match_package_name_and_version(package, additional_build)
-        if package_name_match is None:
+        if not (package_name_match := self._match_package_name_and_version(package, additional_build)):
             return None
 
         groups = package_name_match.groupdict()
-        extra_build = [f"PI-{build_info.build}", additional_build["build_suffix"]]
-        extra_params: dict[str, str] = {}
+        kernel_version = (groups.get("kernel_version") or "").replace("_", ".")
 
-        if kind := groups.get("kind"):
-            extra_build.append(kind)
+        buildname_parts = [
+            f"PI-{build_info.build}",
+            additional_build["build_suffix"],
+            groups.get("kind"),
+            kernel_version,
+        ]
 
-        if kernel_version := groups.get("kernel_version"):
-            kernel_version = kernel_version.replace("_", ".")
-            extra_build.append(kernel_version)
-            extra_params["KERNEL_VERSION"] = kernel_version
+        params = {"BUILD": "-".join(str(part) for part in buildname_parts if part)}
+        if kernel_version:
+            params["KERNEL_VERSION"] = kernel_version
 
-        extra_params["BUILD"] = "-".join(extra_build)
-        extra_params.update(additional_build["settings"])
-        return extra_params
+        return params | additional_build["settings"]
 
     def _match_package_name_and_version(self, package: Package, additional_build: dict[str, Any]) -> re.Match | None:
         """Match package name and version against regexes."""
@@ -277,15 +276,17 @@ class IncrementApprover:
         build_info: BuildInfo,
     ) -> dict[str, str] | None:
         """Determine extra build parameters for a specific package."""
-        if not package.version or re.match(r"^1(?:\..*)?$", package.version):
-            return None
-        if "debug" in package.name or package.arch in {"src", "nosrc"}:
+        if package.is_placeholder or package.is_initial_version or package.is_debug_asset:
             return None
 
-        for additional_build in config_inc.additional_builds:
-            if (res := self._match_additional_build(package, additional_build, build_info)) is not None:
-                return res
-        return None
+        return next(
+            (
+                res
+                for additional_build in config_inc.additional_builds
+                if (res := self._match_additional_build(package, additional_build, build_info)) is not None
+            ),
+            None,
+        )
 
     def extra_builds_for_additional_builds(
         self,

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -41,6 +41,21 @@ class Package(NamedTuple):
     rel: str
     arch: str
 
+    @property
+    def is_initial_version(self) -> bool:
+        """Check if package is an initial version."""
+        return bool(self.version and re.match(r"^1(?:\..*)?$", self.version))
+
+    @property
+    def is_placeholder(self) -> bool:
+        """Check if package version is a placeholder (empty)."""
+        return not self.version
+
+    @property
+    def is_debug_asset(self) -> bool:
+        """Check if package is a debug asset."""
+        return "debug" in self.name or self.arch in {"src", "nosrc"}
+
 
 class RepoDiff:
     """Repository diff computation."""

--- a/tests/test_incrementapprover_helpers.py
+++ b/tests/test_incrementapprover_helpers.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import responses
@@ -47,61 +47,69 @@ def test_schedule_jobs_fail(caplog: pytest.LogCaptureFixture, mocker: MockerFixt
     assert res == 1
 
 
-def test_extra_builds_for_package_filtering(caplog: pytest.LogCaptureFixture) -> None:
+@pytest.mark.parametrize(
+    ("pkg", "additional_builds", "expected_build"),
+    [
+        # Initial version exclusion
+        (Package("kernel-livepatch", "0", "1", "1.1", "x86_64"), [{"regex": ".*", "build_suffix": "test"}], None),
+        # Normal match
+        (
+            Package("kernel-livepatch", "0", "20240101", "1.1", "x86_64"),
+            [{"regex": ".*", "build_suffix": "test"}],
+            "PI-1.1-test",
+        ),
+        # Debug package exclusion
+        (
+            Package("kernel-livepatch-debuginfo", "0", "20240101", "1.1", "x86_64"),
+            [{"regex": ".*", "build_suffix": "test"}],
+            None,
+        ),
+        # src arch exclusion
+        (Package("kernel-livepatch", "0", "20240101", "1.1", "src"), [{"regex": ".*", "build_suffix": "test"}], None),
+        # nosrc arch exclusion
+        (Package("kernel-livepatch", "0", "20240101", "1.1", "nosrc"), [{"regex": ".*", "build_suffix": "test"}], None),
+        # Arch filtering - matching
+        (
+            Package("kernel-livepatch", "0", "20240101", "1.1", "x86_64"),
+            [{"regex": ".*", "build_suffix": "test", "archs": ["x86_64"]}],
+            "PI-1.1-test",
+        ),
+        # Arch filtering - mismatch
+        (
+            Package("kernel-livepatch", "0", "20240101", "1.1", "s390x"),
+            [{"regex": ".*", "build_suffix": "test", "archs": ["x86_64"]}],
+            None,
+        ),
+        # Placeholder (empty version)
+        (Package("kernel-livepatch", "0", "", "1.1", "x86_64"), [{"regex": ".*", "build_suffix": "test"}], None),
+        # With settings already present
+        (
+            Package("kernel-livepatch", "0", "20240101", "1.1", "x86_64"),
+            [{"regex": ".*", "build_suffix": "test", "settings": {"BAR": "BAZ"}}],
+            "PI-1.1-test",
+        ),
+    ],
+)
+def test_extra_builds_for_package_parametrized(
+    caplog: pytest.LogCaptureFixture,
+    pkg: Package,
+    additional_builds: list[dict[str, Any]],
+    expected_build: str | None,
+) -> None:
     approver = prepare_approver(caplog)
     config = approver.config[0]
-    config.additional_builds = [
-        {
-            "build_suffix": "test-build",
-            "package_name_regex": ".*",
-            "settings": {"FOO": "BAR"},
-        }
-    ]
+    for b in additional_builds:
+        if "settings" not in b:
+            b["settings"] = {}
+    config.additional_builds = additional_builds
     build_info = BuildInfo("sle", "SLES", "16.0", "flavor", "arch", "1.1")
 
-    # Initial livepatch (version 1)
-    pkg1 = Package("kernel-livepatch-6.4.0-150600.10", "0", "1", "1.1", "x86_64")
-    assert approver.extra_builds_for_package(pkg1, config, build_info) is None
-
-    # Non-initial livepatch (version > 1)
-    pkg2 = Package("kernel-livepatch-6.4.0-150600.10", "0", "20240101", "1.1", "x86_64")
-    res = approver.extra_builds_for_package(pkg2, config, build_info)
-    assert res is not None
-    assert res["BUILD"] == "PI-1.1-test-build"
-
-    # debuginfo package
-    pkg3 = Package("kernel-livepatch-debuginfo", "0", "20240101", "1.1", "x86_64")
-    assert approver.extra_builds_for_package(pkg3, config, build_info) is None
-
-    # src architecture
-    pkg4 = Package("kernel-livepatch", "0", "20240101", "1.1", "src")
-    assert approver.extra_builds_for_package(pkg4, config, build_info) is None
-
-    # nosrc architecture
-    pkg5 = Package("kernel-livepatch", "0", "20240101", "1.1", "nosrc")
-    assert approver.extra_builds_for_package(pkg5, config, build_info) is None
-
-
-def test_extra_builds_arch_filtering(caplog: pytest.LogCaptureFixture) -> None:
-    approver = prepare_approver(caplog)
-    config = approver.config[0]
-    config.additional_builds = [
-        {
-            "build_suffix": "test-build",
-            "regex": ".*",
-            "archs": ["x86_64"],
-            "settings": {"FOO": "BAR"},
-        }
-    ]
-    build_info = BuildInfo("sle", "SLES", "16.0", "flavor", "arch", "1.1")
-
-    # Matching arch
-    pkg_ok = Package("kernel-livepatch", "0", "20240101", "1.1", "x86_64")
-    assert approver.extra_builds_for_package(pkg_ok, config, build_info) is not None
-
-    # Mismatching arch
-    pkg_fail = Package("kernel-livepatch", "0", "20240101", "1.1", "s390x")
-    assert approver.extra_builds_for_package(pkg_fail, config, build_info) is None
+    res = approver.extra_builds_for_package(pkg, config, build_info)
+    if expected_build is None:
+        assert res is None
+    else:
+        assert res is not None
+        assert res["BUILD"] == expected_build
 
 
 def test_filter_results(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:


### PR DESCRIPTION
Motivation:
The previous implementation of KLP matching was procedural and relied on
"magic" hardcoded rules. This created technical debt and made the code
difficult to reason about or extend.

Design Choices:
Extracted hardcoded business rules into descriptive, named predicates
(`_is_initial_version`, `_is_placeholder`, `_is_debug_asset`). Refactored
`_match_additional_build` to use a functional pipeline for constructing the
openQA `BUILD` string, replacing sequential `if` blocks. Consolidated
duplicated tests into a single parametrized, data-driven test suite.

Benefits:
Achieves higher maintainability and readability. The intent of exclusion
rules is now explicit, and the test suite is significantly more concise and
easier to maintain.

Related issue: https://progress.opensuse.org/issues/198728

Before:
* #516