### PR TITLE
feat: improve increment approval disapproval reason output

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -10,8 +10,9 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum, auto
 from functools import lru_cache
-from itertools import chain
+from itertools import chain, groupby
 from logging import getLogger
+from operator import itemgetter
 from pprint import pformat
 from typing import TYPE_CHECKING, Any
 
@@ -20,7 +21,7 @@ import osc.core
 
 from openqabot import config
 from openqabot.config import OBSOLETE_PARAMS
-from openqabot.openqa import OpenQAInterface
+from openqabot.openqa import ENRICH_KEYS, OpenQAInterface
 from openqabot.pc_helper import apply_public_cloud_settings
 
 from .commenter import Commenter
@@ -168,34 +169,41 @@ class IncrementApprover:
         self,
         results: OpenQAResult,
         ok_jobs: set[int],
-        not_ok_jobs: dict[str, set[str]],
         jobs: list[dict[str, Any]],
         request: osc.core.Request,
     ) -> None:
-        """Evaluate openQA job results and sort them into ok and not_ok sets."""
+        """Evaluate openQA job results, collecting ok job ids and job metadata."""
         for result, info in chain.from_iterable(results.get(s, {}).items() for s in final_states):
             ids = info["job_ids"]
-            common = {k: info.get(k) for k in ("group_id", "build", "distri", "version")}
+            common = {k: info.get(k) for k in ENRICH_KEYS}
             jobs.extend({**common, "id": j, "status": result} for j in ids)
-            (ok_jobs if result in ok_results else not_ok_jobs[result]).update(ids)
+            if result in ok_results:
+                ok_jobs.update(ids)
             self.check_unique_jobid_request_pair(ids, request)
 
     def evaluate_list_of_openqa_job_results(
         self, list_of_results: OpenQAResults, request: osc.core.Request
-    ) -> tuple[set[int], list[str], list[dict[str, Any]]]:
+    ) -> tuple[set[int], list[dict[str, Any]]]:
         """Evaluate a list of openQA job results."""
-        ok_jobs = set()  # keep track of ok jobs
-        not_ok_jobs = defaultdict(set)  # keep track of not ok jobs
+        ok_jobs: set[int] = set()
         jobs: list[dict[str, Any]] = []
-        openqa_url = self.client.url.geturl()
         for results in list_of_results:
-            self.evaluate_openqa_job_results(results, ok_jobs, not_ok_jobs, jobs, request)
-        reasons_to_disapprove = [
-            f"The following openQA jobs ended up with result '{result}':\n"
-            + "\n".join(f" - {openqa_url}/tests/{i}" for i in job_ids)
-            for result, job_ids in not_ok_jobs.items()
+            self.evaluate_openqa_job_results(results, ok_jobs, jobs, request)
+        return (ok_jobs, jobs)
+
+    def _generate_job_reasons(self, jobs: list[dict[str, Any]]) -> list[str]:
+        """Generate disapproval reasons grouped by non-ok openQA result."""
+        openqa_url = self.client.url.geturl()
+        failed = sorted((j for j in jobs if j["status"] not in ok_results), key=itemgetter("status", "id"))
+        return [
+            f"The following openQA jobs ended up with result '{res}':\n"
+            + "\n".join(
+                f" - {openqa_url}/tests/{j['id']} ({j.get('name') or 'Unknown'}) "
+                f"in group '{j.get('group') or 'Unknown'}'"
+                for j in group
+            )
+            for res, group in groupby(failed, key=itemgetter("status"))
         ]
-        return (ok_jobs, reasons_to_disapprove, jobs)
 
     def approve_on_obs(self, reqid: str, msg: str) -> None:
         """Change the review state of a request on OBS to accepted."""
@@ -215,24 +223,26 @@ class IncrementApprover:
         reqid = approval_status.request.reqid
         id_msg = f"OBS request {config.settings.obs_web_url}/request/show/{reqid}"
 
+        all_reasons = reasons_to_disapprove + self._generate_job_reasons(approval_status.jobs)
+
         # Safeguard: only block if NO jobs were ever identified for this request.
         # If processed_jobs is set but ok_jobs is empty, it means all jobs were filtered
         # (e.g. development groups) and approval should proceed if there are no other blockers.
-        if not reasons_to_disapprove and not approval_status.ok_jobs and not approval_status.processed_jobs:
-            reasons_to_disapprove.append("No openQA jobs were found/checked for this request.")
+        if not all_reasons and not approval_status.ok_jobs and not approval_status.processed_jobs:
+            all_reasons.append("No openQA jobs were found/checked for this request.")
 
         if self.comment and approval_status.builds:
-            state = "passed" if not reasons_to_disapprove else "failed"
+            state = "passed" if not all_reasons else "failed"
             msg = self.commenter.summarize_message(approval_status.builds, approval_status.jobs)
             self.commenter.osc_comment_on_request(str(reqid), msg, state)
 
-        if not reasons_to_disapprove:
+        if not all_reasons:
             results_str = "/".join(sorted(ok_results))
             message = f"All {len(approval_status.ok_jobs)} openQA jobs have {results_str}"
             self.approve_on_obs(str(reqid), message)
             log.info("Approving %s: %s", id_msg, message)
         else:
-            reasons_str = "\n\t".join(reasons_to_disapprove)
+            reasons_str = "\n\t".join(all_reasons)
             end_str = f"End of reasons for not approving {id_msg}"
             log.info("Not approving %s for the following reasons:\n\t%s\n%s", id_msg, reasons_str, end_str)
         return 0
@@ -481,9 +491,9 @@ class IncrementApprover:
 
         openqa_jobs_ready = self.check_openqa_jobs(filtered_results, build_info, params)
         if openqa_jobs_ready is JobState.FINISHED:
-            ok_jobs, reasons, jobs = self.evaluate_list_of_openqa_job_results(filtered_results, request)
+            ok_jobs, jobs = self.evaluate_list_of_openqa_job_results(filtered_results, request)
             builds = {BuildIdentifier.from_params(p) for p in params if "BUILD" in p}
-            approval_status.add(ok_jobs, reasons, builds, jobs)
+            approval_status.add(ok_jobs, [], builds, jobs)
             return 0
 
         return self._handle_not_ready_jobs(

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 log = logging.getLogger("bot.openqa")
 
 MAX_JOBS_PER_API_REQUEST = 200
-ENRICH_KEYS = ("group", "group_id", "distri", "version", "build")
+ENRICH_KEYS = ("group_id", "group", "build", "distri", "version", "flavor", "arch", "name")
 
 
 class OpenQAInterface:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -256,7 +256,18 @@ def prepare_approver(
             side_effect=lambda job_id: {"id": job_id, "group": "Production", "group_id": 1}
         )
         approver.client.get_jobs_by_ids = MagicMock(
-            side_effect=lambda ids: [{"id": jid, "group": "Production", "group_id": 1} for jid in ids]
+            side_effect=lambda ids: [
+                {
+                    "id": jid,
+                    "group": "Production",
+                    "group_id": 1,
+                    "name": "testname",
+                    "flavor": "flavor",
+                    "arch": "arch",
+                    "build": "build",
+                }
+                for jid in ids
+            ]
         )
         approver.client.is_devel_group = MagicMock(return_value=False)
         return approver

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -70,7 +70,8 @@ def test_skipping_with_failing_openqa_jobs_for_one_config(
     increment_approver()
     last_message = caplog.messages[-1]
     assert "have passed" not in last_message
-    assert f"ended up with result 'failed':\n - {fake_openqa_url}/tests/21" in last_message
+    reason = f"result 'failed':\n - {fake_openqa_url}/tests/21 (testname) in group 'Production'"
+    assert reason in last_message
 
 
 @responses.activate
@@ -104,6 +105,7 @@ def test_skipping_with_no_openqa_jobs_verifying_that_expected_scheduled_products
 def test_skipping_with_only_jobs_of_additional_builds_present(
     caplog: pytest.LogCaptureFixture,
     fake_only_jobs_of_additional_builds_with_param_matching: list[responses.Response],
+    fake_openqa_url: str,
 ) -> None:
     increment_approver = prepare_approver_with_additional_config(caplog)
     increment_approver()
@@ -116,7 +118,9 @@ def test_skipping_with_only_jobs_of_additional_builds_present(
         "Not approving OBS request https://build.suse.de/request/show/42 for the following reasons:"
         in caplog.messages[-1]
     )
-    assert re.search(R".*openQA jobs.*with result 'failed':\n - http://instance.qa/tests/21", caplog.messages[-1])
+    r_url = re.escape(f"{fake_openqa_url}/tests/21")
+    reason = f"openQA jobs.*with result 'failed':\n - {r_url} \\(testname\\) in group 'Production'"
+    assert re.search(reason, caplog.messages[-1])
 
 
 @responses.activate
@@ -218,15 +222,26 @@ def test_evaluate_list_of_openqa_job_results(
     caplog: pytest.LogCaptureFixture, fake_osc_request: osc.core.Request, fake_openqa_url: str
 ) -> None:
     approver = prepare_approver(caplog)
+    passed = {"job_ids": [1], "name": "testname", "group": "Production"}
+    failed = {"job_ids": [2], "name": "testname", "group": "Production"}
+    softfailed = {"job_ids": [3], "name": "testname", "group": "Production"}
+    incomplete = {"job_ids": [4], "name": "testname", "group": "Production"}
+
     results = [
-        {"done": {"passed": {"job_ids": [1]}, "failed": {"job_ids": [2]}}},
-        {"done": {"softfailed": {"job_ids": [3]}, "incomplete": {"job_ids": [4]}}},
+        {"done": {"passed": passed, "failed": failed}},
+        {"done": {"softfailed": softfailed, "incomplete": incomplete}},
     ]
-    ok_jobs, reasons, jobs = approver.evaluate_list_of_openqa_job_results(results, fake_osc_request)
+    ok_jobs, jobs = approver.evaluate_list_of_openqa_job_results(results, fake_osc_request)
     assert ok_jobs == {1, 3}
     assert len(jobs) == 4
-    assert any(f"result 'failed':\n - {fake_openqa_url}/tests/2" in r for r in reasons)
-    assert any(f"result 'incomplete':\n - {fake_openqa_url}/tests/4" in r for r in reasons)
+
+    status = ApprovalStatus(fake_osc_request, ok_jobs, [], set(), set(), jobs)
+    approver.handle_approval(status)
+
+    f_reason = f"result 'failed':\n - {fake_openqa_url}/tests/2 (testname) in group 'Production'"
+    i_reason = f"result 'incomplete':\n - {fake_openqa_url}/tests/4 (testname) in group 'Production'"
+    assert f_reason in caplog.text
+    assert i_reason in caplog.text
 
 
 def test_check_unique_jobid_request_pair_all_jobs_unique(


### PR DESCRIPTION
Motivation:
The previous output of `increment-approve` was repetitive and lacked
sufficient detail about failed openQA jobs. It showed multiple identical
headers and plain URLs without context.

Design Choices:
- Grouped disapproval reasons by result across all builds for a request.
- Enriched job information with full name and job group name.
- Simplified the individual job line to show only the URL, name, and group.

Example output:
    The following openQA jobs ended up with result 'failed':
 - https://openqa.suse.de/tests/22061185 (sle-16.0-Azure-...) \
in group 'Public Cloud Azure'

Benefits:
Users now get a concise, grouped list of failing tests with meaningful
names and group context, making it easier to identify blockers.

Related issue: https://progress.opensuse.org/issues/201990