### PR TITLE
build: pin dev dependencies and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/openqabot/loader/amqp_listener.py
+++ b/openqabot/loader/amqp_listener.py
@@ -42,7 +42,7 @@ class AMQPListener:
             self.channel.exchange_declare(exchange="pubsub", exchange_type="topic", passive=True, durable=True)
 
             result = self.channel.queue_declare("", exclusive=True)
-            queue_name = result.method.queue
+            queue_name = str(result.method.queue)
 
             for key in self.routing_keys:
                 self.channel.queue_bind(exchange="pubsub", queue=queue_name, routing_key=key)
@@ -59,7 +59,12 @@ class AMQPListener:
         self, _ch: BlockingChannel, method: Basic.Deliver, _properties: BasicProperties, body: bytes
     ) -> None:
         message = json.loads(body)
-        routing_key = method.routing_key if method.routing_key is not None else ""
+        routing_key = method.routing_key
+        if isinstance(routing_key, bytes):
+            routing_key = routing_key.decode("utf-8")
+        elif routing_key is None:
+            routing_key = ""
+
         self.handler(message, routing_key)
 
     def stop(self) -> None:

--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol
 
 from ruamel.yaml import YAML, YAMLError
 from ruamel.yaml.constructor import ConstructorError, SafeConstructor
@@ -22,6 +22,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def get_yml_list(path: Path) -> list[Path]:
+    """Create a list of YAML filenames from a directory or a single file path."""
+    return [f for ext in ("yml", "yaml") for f in path.glob("*." + ext)] if path.is_dir() else [path]
+
+
 log = getLogger("bot.loader.config")
 
 
@@ -31,15 +36,7 @@ class ConfigWithSettings(Protocol):
     settings: dict[str, Any]
 
 
-T = TypeVar("T", bound="ConfigWithSettings")
-
-
-def get_yml_list(path: Path) -> list[Path]:
-    """Create a list of YAML filenames from a directory or a single file path."""
-    return [f for ext in ("yml", "yaml") for f in path.glob("*." + ext)] if path.is_dir() else [path]
-
-
-def _load_one_config(
+def _load_one_config[T: ConfigWithSettings](
     file_path: Path,
     yaml_reader: YAML,
     config_key: str,
@@ -77,7 +74,7 @@ def _load_one_config(
         log.info("%s's configuration skipped: Could not load '%s': %s", config_key, file_path, e)
 
 
-def get_configs_from_path(
+def get_configs_from_path[T: ConfigWithSettings](
     path: Path,
     config_key: str,
     loader_func: Callable[[Any], T],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "qem-bot"
 dynamic = ["version"]
 description = "Tool for scheduling maintenance tests on openQA based on [SMELT](https://tools.io.suse.de/smelt) incidents and Gitea PRs."
 readme = "Readme.md"
-requires-python = ">=3.11"
+requires-python = "~=3.13.0"
 license = "MIT"
 authors = [
     { name = "SUSE LLC" },
@@ -26,6 +26,7 @@ dependencies = [
     "pydantic-settings",
     "python-dotenv",
     "typer",
+    "urllib3",
 ]
 
 [project.urls]
@@ -36,22 +37,22 @@ qem-bot = "openqabot.main:main"
 
 [dependency-groups]
 dev = [
-    "pytest",
-    "pytest-cov",
-    "pytest-xdist",
-    "pyupgrade",
-    "coverage",
-    "responses>=0.21.0",
-    "urllib3",
-    "ruff",
-    "pytest-mock",
-    "vulture",
-    "ty>=0.0.21",
-    "pre-commit",
-    "gitlint",
+    "pytest==9.0.3",
+    "pytest-cov==7.1.0",
+    "pytest-xdist==3.8.0",
+    "pyupgrade==3.21.2",
+    "coverage==7.13.5",
+    "responses==0.26.0",
+    "ruff==0.15.12",
+    "pytest-mock==3.15.1",
+    "vulture==2.16",
+    "ty==0.0.34",
+    "pre-commit==4.6.0",
+    "gitlint==0.19.1",
 ]
 
 [tool.coverage.run]
+source = ["openqabot"]
 branch = true
 
 [tool.coverage.report]

--- a/tests/test_amqp_listener.py
+++ b/tests/test_amqp_listener.py
@@ -43,6 +43,26 @@ def test_listener_full_workflow(mocker: MagicMock) -> None:
     assert received_data[0] == ({"foo": "bar"}, "test.key")
 
 
+def test_on_message_routing_key_types() -> None:
+    received_data = []
+
+    def fake_handler(msg: Any, key: str) -> None:
+        received_data.append((msg, key))
+
+    listener = AMQPListener(url="url", routing_keys=[], handler=fake_handler)
+    fake_body = json.dumps({"foo": "bar"}).encode("utf-8")
+
+    # Test routing_key as bytes
+    fake_method_bytes = MagicMock(routing_key=b"bytes.key")
+    listener._on_message(None, fake_method_bytes, None, fake_body)  # ty: ignore[invalid-argument-type]  # noqa: SLF001
+    assert received_data[0] == ({"foo": "bar"}, "bytes.key")
+
+    # Test routing_key as None
+    fake_method_none = MagicMock(routing_key=None)
+    listener._on_message(None, fake_method_none, None, fake_body)  # ty: ignore[invalid-argument-type]  # noqa: SLF001
+    assert received_data[1] == ({"foo": "bar"}, "")
+
+
 def test_listen_no_url(caplog: pytest.LogCaptureFixture) -> None:
     listener = AMQPListener(url="", routing_keys=[], handler=lambda _, __: None)
     listener.listen()

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -46,7 +46,7 @@ test_data = {
 
 
 @pytest.fixture
-def mock_good(mocker: MockerFixture) -> Generator[None, None, None]:
+def mock_good(mocker: MockerFixture) -> Generator[None]:
     def fake(*_args: Any, **_kwargs: Any) -> int:
         return 12345
 
@@ -54,7 +54,7 @@ def mock_good(mocker: MockerFixture) -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def mock_ex(mocker: MockerFixture) -> Generator[None, None, None]:
+def mock_ex(mocker: MockerFixture) -> Generator[None]:
     def fake(*_args: Any, **_kwargs: Any) -> NoReturn:
         raise NoRepoFoundError
 

--- a/tests/test_submissions_call.py
+++ b/tests/test_submissions_call.py
@@ -90,7 +90,7 @@ def test_submissions_call_with_issues() -> None:
 
 
 @pytest.fixture
-def request_mock(mocker: MockerFixture) -> Generator[None, None, None]:
+def request_mock(mocker: MockerFixture) -> Generator[None]:
     class MockResponse:
         # mock json() method always returns a specific testing dictionary
         @staticmethod

--- a/tests/test_subsyncres.py
+++ b/tests/test_subsyncres.py
@@ -20,7 +20,7 @@ openqa_url = (
 
 
 @pytest.fixture
-def get_a_s(mocker: MockerFixture) -> Generator[None, None, None]:
+def get_a_s(mocker: MockerFixture) -> Generator[None]:
     return mocker.patch("openqabot.subsyncres.get_active_submissions", return_value=[100])
 
 


### PR DESCRIPTION


- Pin all development dependencies to exact versions in pyproject.toml to
  ensure reproducible CI environments.
- Add urllib3 to main dependencies to ensure availability.
- Add .github/dependabot.yml to automate and group development
   dependency updates weekly.
