### PR TITLE
fix: propagate SSL verification flag to all requests

### DIFF
--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -98,7 +98,7 @@ class GiteaTrigger:
         """
         log.info("Evaluating PR %s for openQA triggering", pullrequest.number)
         repo_url = generate_repo_url(pullrequest, self.staging_config_qa_labels, self.gitea_project)
-        matched_iso = Crawler(verify=True).get_regex_match_from_url(repo_url, ISO_REGEX)
+        matched_iso = Crawler(verify=not config.settings.insecure).get_regex_match_from_url(repo_url, ISO_REGEX)
 
         if not matched_iso:
             log.warning("No ISO found for %s in %s", pullrequest, repo_url)

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -81,7 +81,9 @@ def get_submissions(submission: str | None = None) -> list[Submission]:
         submissions = [_get_submission(int(s_id), s_type)]
     else:
         submissions = dashboard.get_json(
-            "api/incidents", headers=config_module.settings.dashboard_token_dict, verify=True
+            "api/incidents",
+            headers=config_module.settings.dashboard_token_dict,
+            verify=not config_module.settings.insecure,
         )
 
     if "error" in submissions:

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -39,6 +39,7 @@ class OpenQAInterface:
         self.url: ParseResult = urlparse(config_module.settings.openqa_instance)
         self.dry: bool = config_module.settings.dry
         self.openqa = OpenQA_Client(server=self.url.netloc, scheme=self.url.scheme)
+        self.openqa.session.verify = not config_module.settings.insecure
         self.retries = number_of_retries()
         user_agent = {"User-Agent": "python-OpenQA_Client/qem-bot/1.0.0"}
         self.openqa.session.headers.update(user_agent)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -8,12 +8,13 @@ import pytest
 import requests
 from requests.exceptions import RequestException
 
+from openqabot.config import settings
 from openqabot.loader.crawler import Crawler
 
 
 @pytest.fixture
 def crawler() -> Crawler:
-    return Crawler(verify=True)
+    return Crawler(verify=not settings.insecure)
 
 
 def test_get_regex_match_success(crawler: Crawler, mocker: MagicMock) -> None:
@@ -93,6 +94,6 @@ def test_crawl_json_decode_error(crawler: Crawler, mocker: MagicMock, caplog: py
 
 def test_crawler_init_settings(crawler: Crawler) -> None:
     """Cover __init__ and retry adapter mounting."""
-    assert crawler.verify is True
+    assert crawler.verify is not settings.insecure
     assert "https://" in crawler.retry_session.adapters
     assert "http://" in crawler.retry_session.adapters

--- a/tests/test_loader_qem.py
+++ b/tests/test_loader_qem.py
@@ -74,7 +74,9 @@ def test_get_submissions_simple(mock_get_json: MagicMock) -> None:
 
     assert len(res) == 1
     assert res[0].id == 1
-    mock_get_json.assert_called_once_with("api/incidents", headers=settings.dashboard_token_dict, verify=True)
+    mock_get_json.assert_called_once_with(
+        "api/incidents", headers=settings.dashboard_token_dict, verify=not settings.insecure
+    )
 
 
 def test_get_submissions_on_submission_returns_single_submission(mocker: MockerFixture) -> None:


### PR DESCRIPTION


Updates GiteaTrigger, QEM loader, and OpenQA client to respect the
 configured insecure setting instead of hardcoding verify=True.
