### PR TITLE
fix: ensure captured kernel versions start with a digit

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -248,6 +248,8 @@ class IncrementApprover:
             extra_build.append(kind)
 
         if kernel_version := groups.get("kernel_version"):
+            if not kernel_version[0].isdigit():
+                return None
             kernel_version = kernel_version.replace("_", ".")
             extra_build.append(kernel_version)
             extra_params["KERNEL_VERSION"] = kernel_version


### PR DESCRIPTION
Motivation:
Overly broad regexes in metadata can capture non-version strings (like product
names) as kernel versions, leading to invalid openQA job scheduling.

Design Choices:
- Added a safeguard in IncrementApprover._match_additional_build to verify
  that captured kernel_version starts with a digit.
- Returns None immediately if the check fails, effectively skipping the match.

Benefits:
- Prevents scheduling of invalid jobs when configuration patterns are loose.
- Increases robustness of the scheduling logic against external config errors.

Related issue: https://progress.opensuse.org/issues/198728