### PR TITLE
fix: Use ISO_1_URL and ISO_1 in giteatrigger to load the correct asset

### DIFF
--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -112,7 +112,8 @@ class GiteaTrigger:
 
         if self.is_openqa_triggering_needed(matched_iso, trigger_config):
             openqa_settings = {
-                "ISO_URL": f"{repo_url}/{matched_iso_regex.group(0)}",
+                "ISO_1_URL": f"{repo_url}/{matched_iso_regex.group(0)}",
+                "ISO_1": f"{matched_iso_regex.group(0)}",
                 "_GITEA_PR": str(pullrequest.number),
                 "VERSION": matched_iso.version,
                 "FLAVOR": trigger_config.flavor,

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -95,7 +95,8 @@ def test_check_pullrequest_triggers_job(
     assert settings["FLAVOR"] == "Online-Staging"
     assert settings["VERSION"] == "15.5:PR-123"
     assert settings["BUILD"] == "PR-123-1.1:SLES-15.5"
-    assert settings["ISO_URL"] == "http://fake.url//SLES-15.5-Online-x86_64-Build1.1.install.iso"
+    assert settings["ISO_1_URL"] == "http://fake.url//SLES-15.5-Online-x86_64-Build1.1.install.iso"
+    assert settings["ISO_1"] == "SLES-15.5-Online-x86_64-Build1.1.install.iso"
 
 
 def test_is_openqatriggering_needed_false(


### PR DESCRIPTION
According to the documentation [1], when giving a ISO variable
from a URL, you need to specify the URL and the ISO name that will
be stored locally and used by the openQA jobs. 
The variable ISO_1_URL need to go together with ISO_1.       

[1] https://open.qa/docs/#_specifying_assets_required_by_a_job