### PR TITLE
fix: handle 'None' in submissions + fix 'gitea_project' poo(200943)

### DIFF
--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
     token: str | None = Field(default=None, alias="QEM_BOT_TOKEN")
     gitea_token: str | None = Field(default=None, alias="QEM_BOT_GITEA_TOKEN")
     gitea_pr_label: str | None = Field(default=None, alias="PR_LABEL")
-    gitea_project: str | None = Field(default="SLFO", alias="GITEA_PROJECT")
+    gitea_project: str | None = Field(default="products/SLFO", alias="GITEA_PROJECT")
     gitea_branch_name: str | None = Field(default="slfo-main", alias="GITEA_BRANCH_NAME")
     openqa_instance: str = Field(default="https://openqa.suse.de", alias="OPENQA_INSTANCE")
     singlearch: Path = Field(default=Path("/etc/openqabot/singlearch.yml"), alias="QEM_BOT_SINGLEARCH")

--- a/openqabot/types/submission.py
+++ b/openqabot/types/submission.py
@@ -39,9 +39,9 @@ class Submission:
         self.type: str = submission.get("type") or config.settings.default_submission_type
         self.url: str | None = submission.get("url")
 
-        self._initialize_channels(submission["channels"])
+        self._initialize_channels([item for item in submission.get("channels") or [] if item is not None])
         self._validate_channels()
-        self._initialize_packages(submission["packages"])
+        self._initialize_packages([item for item in submission.get("packages") or [] if item is not None])
         self.emu: bool = submission["emu"]
         self.revisions: dict[ArchVer, int] | None = None  # lazy-initialized via revisions_with_fallback()
         self.rev_cache_params: tuple[Any, ...] | None = None

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -125,6 +125,18 @@ def test_sub_nochannels2() -> None:
         Submission(bad_data)
 
 
+@pytest.mark.usefixtures("mock_good")
+def test_sub_null_elements_ignored() -> None:
+    data = deepcopy(test_data)
+    data["channels"].append(None)  # ty: ignore
+    data["packages"].append(None)  # ty: ignore
+    sub = Submission(data)
+    # The null elements should just be ignored, and valid ones remain
+    assert Repos(product="openSUSE-SLE", version="15.4", arch="x86_64") in sub.channels
+    assert "some" in sub.packages
+    assert None not in sub.packages
+
+
 def test_sub_create(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
 


### PR DESCRIPTION
* fix: align 'gitea_project' default with CLI arguments
* fix: handle 'None' in submission channels gracefully
