### PR TITLE
fix: filter out None items from submission lists

### DIFF
--- a/openqabot/types/submission.py
+++ b/openqabot/types/submission.py
@@ -39,9 +39,9 @@ class Submission:
         self.type: str = submission.get("type") or config.settings.default_submission_type
         self.url: str | None = submission.get("url")
 
-        self._initialize_channels(submission["channels"])
+        self._initialize_channels([item for item in submission["channels"] if item is not None])
         self._validate_channels()
-        self._initialize_packages(submission["packages"])
+        self._initialize_packages([item for item in submission["packages"] if item is not None])
         self.emu: bool = submission["emu"]
         self.revisions: dict[ArchVer, int] | None = None  # lazy-initialized via revisions_with_fallback()
         self.rev_cache_params: tuple[Any, ...] | None = None


### PR DESCRIPTION
addressing exception : 
```
Traceback (most recent call last):
  File "/builds/qa-maintenance/bot-ng/./qem-bot/qem-bot.py", line 9, in <module>
    main()
    ~~~~^^
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/main.py", line 18, in main
    app()
    ~~~^^
  File "/usr/lib/python3.13/site-packages/typer/main.py", line 1152, in __call__
    raise e
  File "/usr/lib/python3.13/site-packages/typer/main.py", line 1135, in __call__
    return get_command(self)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/typer/core.py", line 794, in main
    return _main(
        self,
    ...<6 lines>...
        **extra,
    )
  File "/usr/lib/python3.13/site-packages/typer/core.py", line 188, in _main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.13/site-packages/click/core.py", line 1902, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.13/site-packages/typer/main.py", line 1514, in wrapper
    return callback(**use_params)
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/args.py", line 325, in updates_run
    bot = OpenQABot(args)
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/openqabot.py", line 31, in __init__
    self.submissions = get_submissions(self.submission_arg)
                       ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/loader/qem.py", line 92, in get_submissions
    return [sub for s in submissions if (sub := Submission.create(s))]
                                                ~~~~~~~~~~~~~~~~~^^^
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/types/submission.py", line 111, in create
    return cls(data)
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/types/submission.py", line 42, in __init__
    self._initialize_channels(submission["channels"])
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/types/submission.py", line 54, in _initialize_channels
    self.channels, self.skipped_products = self._parse_channels(raw_channels)
                                           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/builds/qa-maintenance/bot-ng/qem-bot/openqabot/types/submission.py", line 73, in _parse_channels
    if r.startswith("SUSE:Updates"):
```