### PR TITLE
feat: Report submission rejection reason to dashboard

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -32,6 +32,7 @@ from .loader.qem import (
     get_single_submission,
     get_submission_settings,
     get_submissions_approver,
+    update_incident_reason,
 )
 
 if TYPE_CHECKING:
@@ -149,6 +150,8 @@ class Approver:
         log.info(reason, ms2str(sub))
         if self.comment and sub.submission:
             self.commenter.comment_on_submission(sub.submission)
+        if not self.dry:
+            update_incident_reason(sub.sub, reason % ms2str(sub))
         return False
 
     def approvable(self, sub: SubReq) -> bool:
@@ -162,8 +165,7 @@ class Approver:
             a_jobs = get_aggregate_settings(sub.sub, submission_type=sub.type)
         except NoResultsError as e:
             if any(s.with_aggregate for s in s_jobs):
-                log.info("Required aggregate tests missing for %s", ms2str(sub))
-                return False
+                return self._reject(sub, "Required aggregate tests missing for %s")
             log.debug("Aggregate tests optional and not found: %s", e)
             a_jobs = []
 
@@ -174,6 +176,9 @@ class Approver:
             a_jobs, "api/jobs/update/", sub.sub, submission_type=sub.type
         ):
             return self._reject(sub, "%s has at least one not-ok job in aggregate tests")
+
+        if not self.dry:
+            update_incident_reason(sub.sub, None)
 
         # everything is green --> add submission to approve list
         return True

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -318,3 +318,21 @@ def update_job(job_id: int, data: dict[str, Any]) -> None:
 
     except requests.exceptions.RequestException:
         log.exception("QEM Dashboard API request failed")
+
+
+def update_incident_reason(incident_number: int, reason: str | None) -> None:
+    """Update the rejection reason for a submission on the dashboard."""
+    try:
+        result = dashboard.patch(
+            f"api/incidents/{incident_number}/rejection_reason",
+            headers=config_module.settings.dashboard_token_dict,
+            json={"rejection_reason": reason},
+        )
+        if result.status_code != HTTPStatus.OK:
+            log.error(
+                "Dashboard API error: Could not update rejection reason for incident %s: %s",
+                incident_number,
+                result.text,
+            )
+    except requests.exceptions.RequestException:
+        log.exception("QEM Dashboard API request failed")

--- a/tests/test_approve_helpers.py
+++ b/tests/test_approve_helpers.py
@@ -12,7 +12,7 @@ import pytest
 from openqa_client.exceptions import RequestError
 
 from openqabot.approver import Approver
-from openqabot.loader.qem import JobAggr
+from openqabot.loader.qem import JobAggr, SubReq
 
 from .helpers import args, make_approver_args
 
@@ -99,7 +99,35 @@ def test_was_ok_before_no_suitable_older_jobs(
     assert any(log_message in m for m in caplog.messages)
 
 
-def test_get_submission_result_empty_jobs() -> None:
+def test_reject_calls_update_incident_reason(mocker: MockerFixture) -> None:
+    approver = Approver(make_approver_args())
+    approver.dry = False
+    mock_update = mocker.patch("openqabot.approver.update_incident_reason")
+    sub = SubReq(1, 2)
+    assert approver._reject(sub, "Reason %s") is False  # noqa: SLF001
+    mock_update.assert_called_once_with(1, "Reason SUSE:Maintenance:1:2")
+
+
+def test_reject_dry_run_skips_update_incident_reason(mocker: MockerFixture) -> None:
+    approver = Approver(make_approver_args())
+    approver.dry = True
+    mock_update = mocker.patch("openqabot.approver.update_incident_reason")
+    sub = SubReq(1, 2)
+    assert approver._reject(sub, "Reason %s") is False  # noqa: SLF001
+    mock_update.assert_not_called()
+
+
+def test_approvable_clears_reason(mocker: MockerFixture) -> None:
+    approver = Approver(make_approver_args())
+    approver.dry = False
+    mock_update = mocker.patch("openqabot.approver.update_incident_reason")
+    mocker.patch("openqabot.approver.get_submission_settings", return_value=[])
+    mocker.patch("openqabot.approver.get_aggregate_settings", return_value=[])
+    mocker.patch.object(approver, "get_submission_result", return_value=True)
+
+    sub = SubReq(1, 2)
+    assert approver.approvable(sub) is True
+    mock_update.assert_called_once_with(1, None)
     approver_instance = Approver(args)
     assert approver_instance.get_submission_result([], "api/", 1) is False
 

--- a/tests/test_loader_qem.py
+++ b/tests/test_loader_qem.py
@@ -28,6 +28,7 @@ from openqabot.loader.qem import (
     get_submissions,
     get_submissions_approver,
     post_job,
+    update_incident_reason,
     update_job,
     update_submissions,
 )
@@ -427,6 +428,30 @@ def test_update_job_request_exception(mock_patch: MagicMock, caplog: pytest.LogC
     caplog.set_level(logging.ERROR)
     mock_patch.side_effect = requests.exceptions.RequestException
     update_job(1, {})
+    assert "QEM Dashboard API request failed" in caplog.text
+
+
+def test_update_incident_reason_success(mock_patch: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.ERROR)
+    mock_patch.return_value.status_code = 200
+
+    update_incident_reason(1, "reason")
+    assert "error" not in caplog.text
+
+
+def test_update_incident_reason_unsuccessful(mock_patch: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
+    mock_patch.return_value.status_code = 400
+    mock_patch.return_value.text = "Error message"
+    caplog.set_level(logging.ERROR)
+
+    update_incident_reason(1, "reason")
+    assert "Error message" in caplog.text
+
+
+def test_update_incident_reason_request_exception(mock_patch: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.ERROR)
+    mock_patch.side_effect = requests.exceptions.RequestException
+    update_incident_reason(1, "reason")
     assert "QEM Dashboard API request failed" in caplog.text
 
 


### PR DESCRIPTION
Motivation
Previously, qem-bot would log rejection reasons locally, but they were
not visible on the dashboard. This made it difficult for users to understand
why a submission wasn't being approved.

Design Choices
Implemented `update_incident_reason` in the QEM loader to send PATCH requests
to the new dashboard endpoint.
Updated the Approver to call `update_incident_reason` with the formatted
rejection reason when a submission is not approvable.
Ensured the rejection reason is cleared (set to None) when a submission
becomes fully approvable.

Benefits
The dashboard now reflects the actual state of the bot's evaluation,
providing clear feedback to users about missing tests or job failures.

Needs:
* https://github.com/openSUSE/qem-dashboard/pull/3300