### PR TITLE
fix: remove python label for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
 
     labels:
       - "dependencies"
-      - "python"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION


Since we are running 100% python package this label
does not make much sense
