### PR TITLE
feat: fail explicitly when no configs were loaded

### DIFF
--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -52,6 +52,9 @@ class GiteaTrigger:
         self.config_list: list[TriggerConfig] = get_configs_from_path(
             args.configs, "trigger_config", TriggerConfig.from_config_entry
         )
+        if not self.config_list:
+            error_msg = "No configs were found"
+            raise ValueError(error_msg)
         self.gitea_project: Any = args.gitea_project
         self.pr_number: int = args.pr_number
         self.openqa: OpenQAInterface = OpenQAInterface()

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -57,7 +57,20 @@ def _fake_get_gitea_staging_config(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-def trigger(mock_args: Namespace, mocker: MockerFixture, _fake_get_gitea_staging_config: MockerFixture) -> GiteaTrigger:
+def _fake_get_configs_from_path(mocker: MockerFixture, mock_trigger_config: TriggerConfig) -> None:
+    mocker.patch(
+        "openqabot.giteatrigger.get_configs_from_path",
+        return_value=[mock_trigger_config],
+    )
+
+
+@pytest.fixture
+def trigger(
+    mock_args: Namespace,
+    mocker: MockerFixture,
+    _fake_get_gitea_staging_config: MockerFixture,
+    _fake_get_configs_from_path: None,
+) -> GiteaTrigger:
     """Initialize GiteaTrigger with mocked external integrations."""
     mocker.patch("openqabot.giteatrigger.OpenQAInterface")
     mocker.patch("openqabot.giteatrigger.Commenter")
@@ -217,7 +230,7 @@ def test_trigger_call_execution(trigger: GiteaTrigger, mocker: MockerFixture) ->
     mock_check.assert_called_once_with(mock_pr, mocker.ANY)
 
 
-@pytest.mark.usefixtures("_fake_get_gitea_staging_config")
+@pytest.mark.usefixtures("_fake_get_gitea_staging_config", "_fake_get_configs_from_path")
 def test_get_prs_by_label_specific_number(mock_args: Namespace, mocker: MockerFixture) -> None:
     """Cover user provides a specific PR number via CLI."""
     mock_args.pr_number = 1337
@@ -386,3 +399,12 @@ def test_is_openqa_triggering_needed_with_results(trigger: GiteaTrigger, mock_tr
     cast("MagicMock", trigger.openqa.get_scheduled_product_stats).return_value = {"job": "done"}
     mock_iso = MagicMock()
     assert trigger.is_openqa_triggering_needed(mock_iso, mock_trigger_config) is False
+
+
+def test_trigger_init_no_configs(mock_args: Namespace, mocker: MockerFixture) -> None:
+    """Verify that ValueError is raised if no configs are found."""
+    mocker.patch("openqabot.giteatrigger.get_configs_from_path", return_value=[])
+    mocker.patch("openqabot.loader.gitea.make_token_header")
+
+    with pytest.raises(ValueError, match="No configs were found"):
+        GiteaTrigger(mock_args)

--- a/tests/test_utils_configs.py
+++ b/tests/test_utils_configs.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from openqabot.loader.config import get_configs_from_path
 
 
@@ -77,3 +79,26 @@ trigger_config:
     assert len(configs) == 1
     assert configs[0].distri == "sle"
     assert configs[0].settings == {"GLOBAL": "value", "LOCAL": "local_value"}
+
+
+def test_get_configs_from_path_yaml_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test get_configs_from_path with a YAML error."""
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("invalid: yaml: :")
+
+    with caplog.at_level("INFO", logger="bot.loader.config"):
+        configs = get_configs_from_path(config_file, "trigger_config", MockConfig.from_config_entry)
+
+    assert configs == []
+    assert "configuration skipped: could not load" in caplog.text.lower()
+
+
+def test_get_configs_from_path_not_found(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test get_configs_from_path with a non-existent file."""
+    config_file = tmp_path / "non_existent.yml"
+
+    with caplog.at_level("INFO", logger="bot.loader.config"):
+        configs = get_configs_from_path(config_file, "trigger_config", MockConfig.from_config_entry)
+
+    assert configs == []
+    assert "configuration skipped: could not load" in caplog.text.lower()


### PR DESCRIPTION


if we point qem-bot to folder with some yamls but
there will be no yamls with trigger_config section
we will end up with fake succesful run. It is more
clear to just fail in that case.
