### PR TITLE
fix(gitlint): allow also "deps-dev" dependabot updates

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -9,5 +9,5 @@ regex=^https?:\/\/\S+$
 
 [ignore-by-title]
 # Dependabot creates non-conventional commits we need to accept
-regex=^chore\(deps\): Bump
+regex=^chore\(deps.*\): Bump
 ignore=all


### PR DESCRIPTION
This fixes issues when gitlint fails on dependabot updates in the group of
"deps-dev"