### PR TITLE
fix(mergify): correct rules for target branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,20 +28,14 @@ pull_request_rules:
     conditions:
       - and: *base_checks
       - and:
-        # mergify config checks needs at least two rules in "and" so we repeat
-        # one from the base checks
-        - base=main
-        - "label=merge-fast"
+          - "label=merge-fast"
     actions: *merge
   - name: automatic merge for dependabot updates
     conditions:
       - and: *base_checks
       - and:
-        # mergify config checks needs at least two rules in "and" so we repeat
-        # one from the base checks
-        - base=main
-        - author=dependabot[bot]
-        - "label=waited"
+          - author=dependabot[bot]
+          - "label=waited"
     actions:
       queue:
       merge:


### PR DESCRIPTION
Fixes a regression introduced in 3086bd0f which wrongly copied a rule from
qem-dashboard which has a different default target branch.