### PR TITLE
ci(mergify): fix sporadically missing codecov checks blocking merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -57,9 +57,3 @@ pull_request_rules:
     actions:
       rebase:
         bot_account: suse-qe-tools-mergify
-  - name: ask to resolve conflict
-    conditions:
-      - conflict
-    actions:
-      comment:
-        message: This pull request is now in conflicts. Could you fix it? 🙏

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,8 +14,6 @@ pull_request_rules:
         - "#check-failure=0"
         - "#check-pending=0"
         - linear-history
-        - check-success=codecov/project
-        - check-success=codecov/patch
       - and:
         - "#approved-reviews-by>=2"
         - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
As full statement+branch coverage is ensured by "make test" already we do
not need to wait for codecov checks. This also helps in cases when codecov
checks are missing or only appearing very late.