### PR TITLE
feat(requests): improve OBS URL feedback and allow metadata overrides

### DIFF
--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -102,18 +102,25 @@ class Commenter:
         return msg, state
 
     def osc_comment_on_request(
-        self, request_id: str, msg: str, state: str, revisions: dict[str, Any] | None = None
+        self,
+        request_id: str,
+        msg: str,
+        state: str,
+        revisions: dict[str, Any] | None = None,
+        obs_url: str | None = None,
     ) -> None:
         """Comment on an OBS request."""
-        osc.conf.get_config(override_apiurl=config.settings.obs_url)
+        obs_url = obs_url or config.settings.obs_url
+        osc.conf.get_config(override_apiurl=obs_url)
+        commentapi = self.commentapi if obs_url == config.settings.obs_url else CommentAPI(obs_url)
         bot_name = "openqa"
         info: dict[str, Any] = {"state": state}
         if revisions:
             info.update(revisions)
 
         msg = truncate(add_marker(msg, bot_name, info).strip())
-        comments = self.commentapi.get_comments(request_id=request_id)
-        comment, _ = self.commentapi.comment_find(comments, bot_name, info)
+        comments = commentapi.get_comments(request_id=request_id)
+        comment, _ = commentapi.comment_find(comments, bot_name, info)
 
         # To prevent spam, assume same state/result
         # and number of lines in message is a duplicate message
@@ -123,17 +130,17 @@ class Commenter:
 
         if comment is None:
             log.debug("No comment with this state, looking without the state filter")
-            comment, _ = self.commentapi.comment_find(comments, bot_name)
+            comment, _ = commentapi.comment_find(comments, bot_name)
 
         if comment is None:
             log.debug("No previous comment found to replace")
         elif not self.dry:
-            self.commentapi.delete(comment["id"])
+            commentapi.delete(comment["id"])
         else:
             log.info("Dry run: Would delete comment %s", comment["id"])
 
         if not self.dry:
-            self.commentapi.add_comment(comment=msg, request_id=request_id)
+            commentapi.add_comment(comment=msg, request_id=request_id)
         else:
             log.info("Dry run: Would write comment to request %s", request_id)
             log.debug(pformat(msg))

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -206,12 +206,12 @@ class IncrementApprover:
             for res, group in groupby(failed, key=itemgetter("status"))
         ]
 
-    def approve_on_obs(self, reqid: str, msg: str) -> None:
+    def approve_on_obs(self, reqid: str, msg: str, obs_url: str) -> None:
         """Change the review state of a request on OBS to accepted."""
         if self.args.dry:
             return
         osc.core.change_review_state(
-            apiurl=config.settings.obs_url,
+            apiurl=obs_url,
             reqid=reqid,
             newstate="accepted",
             by_group=config.settings.obs_group,
@@ -235,12 +235,12 @@ class IncrementApprover:
         if self.comment and approval_status.builds:
             state = "passed" if not all_reasons else "failed"
             msg = self.commenter.summarize_message(OBSCommentable(reqid), approval_status.builds, approval_status.jobs)
-            self.commenter.osc_comment_on_request(str(reqid), msg, state)
+            self.commenter.osc_comment_on_request(str(reqid), msg, state, obs_url=approval_status.obs_url)
 
         if not all_reasons:
             results_str = "/".join(sorted(ok_results))
             message = f"All {len(approval_status.ok_jobs)} openQA jobs have {results_str}"
-            self.approve_on_obs(str(reqid), message)
+            self.approve_on_obs(str(reqid), message, approval_status.obs_url)
             log.info("Approving %s: %s", id_msg, message)
         else:
             reasons_str = "\n\t".join(all_reasons)
@@ -505,24 +505,28 @@ class IncrementApprover:
             jobs_were_filtered=unfiltered_results != filtered_results,
         )
 
-    def _get_approval_status(self, request: osc.core.Request) -> ApprovalStatus:
+    def _get_approval_status(self, request: osc.core.Request, obs_url: str) -> ApprovalStatus:
         """Get or create the approval status for an OBS request."""
         request_id = request.reqid
         if request_id in self.requests_to_approve:
             return self.requests_to_approve[request_id]
 
-        status = ApprovalStatus(request, set(), [], set(), set(), [])
+        status = ApprovalStatus(request, set(), [], set(), set(), [], obs_url)
         self.requests_to_approve[request_id] = status
         return status
 
     def process_request_for_config(
-        self, request: osc.core.Request | None, config_inc: IncrementConfig, build_infos: set[BuildInfo]
+        self,
+        request: osc.core.Request | None,
+        config_inc: IncrementConfig,
+        build_infos: set[BuildInfo],
+        obs_url: str | None = None,
     ) -> int:
         """Process an OBS request for a specific configuration."""
         if request is None:
             return 0
 
-        approval_status = self._get_approval_status(request)
+        approval_status = self._get_approval_status(request, obs_url or config.settings.obs_url)
         error_count = 0
         found_relevant_build = False
         for build_info in build_infos:
@@ -540,6 +544,8 @@ class IncrementApprover:
     def __call__(self) -> int:
         """Run the increment approval process."""
         error_count = 0
+        # --request-id is an explicit, ad-hoc operator override: the caller is expected to
+        # know which OBS instance hosts that request, so per-config obs_url is not applied here.
         single_request = (
             osc.core.Request.from_api(config.settings.obs_url, self.args.request_id) if self.args.request_id else None
         )
@@ -563,9 +569,10 @@ class IncrementApprover:
                 rep_config.build_regex,
                 self.get_regex_match,
             )
-            request = find_request_on_obs(self.args, rep_config.build_project())
+            resolved_obs_url = rep_config.obs_url or config.settings.obs_url
+            request = find_request_on_obs(self.args, rep_config.build_project(), obs_url=resolved_obs_url)
             for config_inc in configs:
-                error_count += self.process_request_for_config(request, config_inc, build_infos)
+                error_count += self.process_request_for_config(request, config_inc, build_infos, resolved_obs_url)
 
         for request in self.requests_to_approve.values():
             error_count += self.handle_approval(request)

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -57,6 +57,7 @@ class IncrementConfig:
     settings: dict[str, str] = field(default_factory=dict)
     additional_builds: list[dict[str, Any]] = field(default_factory=list)
     reference_repos: dict[str, str] = field(default_factory=dict)
+    obs_url: str | None = None
     # Template for URL construction. Variables: base, project, version, arch, channel, suffix, product.
     build_repo_template: str = ""
     diff_repo_template: str = ""
@@ -160,6 +161,7 @@ class IncrementConfig:
             settings=entry.get("settings", {}),
             additional_builds=entry.get("additional_builds", []),
             reference_repos=entry.get("reference_repos", {}),
+            obs_url=entry.get("obs_url"),
             build_repo_template=entry.get("build_repo_template", ""),
             diff_repo_template=entry.get("diff_repo_template", ""),
         )

--- a/openqabot/requests.py
+++ b/openqabot/requests.py
@@ -19,19 +19,20 @@ log = getLogger("bot.requests")
 
 
 @cache
-def get_obs_request_list(project: str, req_state: tuple) -> list:
+def get_obs_request_list(project: str, req_state: tuple, obs_url: str) -> list:
     """Get a list of requests from OBS."""
-    return osc.core.get_request_list(config.settings.obs_url, project, req_state=req_state)
+    return osc.core.get_request_list(obs_url, project, req_state=req_state)
 
 
-def find_request_in_project(project: str, relevant_states: list[str]) -> osc.core.Request | None:
+def find_request_in_project(project: str, relevant_states: list[str], obs_url: str) -> osc.core.Request | None:
     """Find a relevant OBS request within a project."""
     log.debug(
-        "Checking for product increment requests to be reviewed by %s on %s",
+        "Checking for product increment requests to be reviewed by %s for %s on %s",
         config.settings.obs_group,
         project,
+        obs_url,
     )
-    obs_requests = get_obs_request_list(project, tuple(relevant_states))
+    obs_requests = get_obs_request_list(project, tuple(relevant_states), obs_url)
     filtered_requests = (
         request
         for request in sorted(obs_requests, reverse=True)
@@ -43,7 +44,7 @@ def find_request_in_project(project: str, relevant_states: list[str]) -> osc.cor
 
 @cache
 def _find_request_on_obs_cached(
-    request_id: int | None, *, accepted: bool, build_project: str
+    request_id: int | None, *, accepted: bool, build_project: str, obs_url: str
 ) -> osc.core.Request | None:
     """Find product increment requests on OBS with hashable arguments."""
     relevant_states = ["new", "review"]
@@ -51,14 +52,19 @@ def _find_request_on_obs_cached(
         relevant_states.append("accepted")
 
     if request_id is None:
-        relevant_request = find_request_in_project(build_project, relevant_states)
+        relevant_request = find_request_in_project(build_project, relevant_states, obs_url)
     else:
         log.debug("Checking specified request %i", request_id)
-        relevant_request = osc.core.Request.from_api(config.settings.obs_url, request_id)
+        relevant_request = osc.core.Request.from_api(obs_url, request_id)
 
     if relevant_request is None:
         states_str = "/".join(relevant_states)
-        log.info("Skipping approval: %s: No relevant requests in states %s", build_project, states_str)
+        log.info(
+            "Skipping approval: %s on %s: No relevant requests in states %s",
+            build_project,
+            obs_url,
+            states_str,
+        )
     else:
         log.info("Found product increment request on %s: %s", build_project, relevant_request.id)
         if hasattr(relevant_request.state, "to_xml"):
@@ -66,9 +72,12 @@ def _find_request_on_obs_cached(
     return relevant_request
 
 
-def find_request_on_obs(args: Namespace, build_project: str) -> osc.core.Request | None:
+def find_request_on_obs(args: Namespace, build_project: str, obs_url: str | None = None) -> osc.core.Request | None:
     """Find a relevant product increment request on OBS."""
-    return _find_request_on_obs_cached(args.request_id, accepted=args.accepted, build_project=build_project)
+    resolved_url = obs_url or config.settings.obs_url
+    return _find_request_on_obs_cached(
+        args.request_id, accepted=args.accepted, build_project=build_project, obs_url=resolved_url
+    )
 
 
 find_request_on_obs.cache_clear = _find_request_on_obs_cached.cache_clear  # ty: ignore[unresolved-attribute]

--- a/openqabot/types/increment.py
+++ b/openqabot/types/increment.py
@@ -93,6 +93,7 @@ class ApprovalStatus(NamedTuple):
     processed_jobs: set[tuple[str, str, str, str, str, str]]
     builds: set[BuildIdentifier]
     jobs: list[dict[str, Any]]
+    obs_url: str
 
     def add(
         self,

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -89,7 +89,7 @@ def mock_git_sub() -> MagicMock:
 @pytest.fixture
 def commenter_setup(mocker: MockerFixture) -> dict[str, MagicMock]:
     mock_client = mocker.patch("openqabot.commenter.OpenQAInterface")
-    mocker.patch("openqabot.commenter.osc.conf.get_config")
+    mock_get_config = mocker.patch("openqabot.commenter.osc.conf.get_config")
     mock_comment_api = mocker.patch("openqabot.commenter.CommentAPI")
     mock_gitea = mocker.patch("openqabot.commenter.gitea")
     mocker.patch(
@@ -104,6 +104,7 @@ def commenter_setup(mocker: MockerFixture) -> dict[str, MagicMock]:
 
     return {
         "client": mock_client,
+        "get_config": mock_get_config,
         "comment_api": mock_comment_api,
         "gitea": mock_gitea,
     }
@@ -206,6 +207,23 @@ def test_osc_comment_dry_run(
     c.osc_comment(mock_smelt_sub, "Test message", "passed")
     assert "Would write comment to request" in caplog.text
     assert not comment_api.add_comment.called
+
+
+@pytest.mark.usefixtures("commenter_setup")
+def test_osc_comment_on_request_uses_custom_obs_url(
+    mock_args: Namespace,
+    make_comment_api: Callable,
+    commenter_setup: dict[str, MagicMock],
+) -> None:
+    """A custom obs_url must be used for both the osc config and the CommentAPI, not the global default."""
+    custom_url = "https://api.custom.obs"
+    commenter_setup["comment_api"].return_value = make_comment_api(comment_find_results=[(None, None), (None, None)])
+
+    c = Commenter(mock_args, submissions=[])
+    c.osc_comment_on_request("123", "Test message", "passed", obs_url=custom_url)
+
+    commenter_setup["get_config"].assert_called_once_with(override_apiurl=custom_url)
+    commenter_setup["comment_api"].assert_called_with(custom_url)
 
 
 @pytest.mark.usefixtures("commenter_setup")

--- a/tests/test_incrementapprover_obs.py
+++ b/tests/test_incrementapprover_obs.py
@@ -43,7 +43,10 @@ def test_specified_obs_request_not_found_skips_approval(
     mocker.patch("osc.core.Request.from_api", side_effect=fake_request_from_api)
     run_approver(mocker, caplog, request_id=43)
     assert "Checking specified request 43" in caplog.messages
-    assert "Skipping approval: OBS:PROJECT:TEST: No relevant requests in states new/review/accepted" in caplog.messages
+    expected_msg = (
+        f"Skipping approval: OBS:PROJECT:TEST on {settings.obs_url}: No relevant requests in states new/review/accepted"
+    )
+    assert expected_msg in caplog.messages
 
 
 @responses.activate
@@ -142,7 +145,15 @@ def testhandle_approval_dry(caplog: pytest.LogCaptureFixture, mocker: MockerFixt
         approver = IncrementApprover(args)
         req = mocker.Mock(spec=osc.core.Request)
         req.reqid = 123
-        status = ApprovalStatus(req, ok_jobs={1}, reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[])
+        status = ApprovalStatus(
+            req,
+            ok_jobs={1},
+            reasons_to_disapprove=[],
+            processed_jobs=set(),
+            builds=set(),
+            jobs=[],
+            obs_url="https://api.suse.de",
+        )
         mock_osc_change = mocker.patch("osc.core.change_review_state")
 
         approver.handle_approval(status)
@@ -157,15 +168,33 @@ def testapprove_on_obs_dry(caplog: pytest.LogCaptureFixture, mocker: MockerFixtu
     approver = prepare_approver(caplog)
     approver.args.dry = True
     mock_osc_change = mocker.patch("osc.core.change_review_state")
-    approver.approve_on_obs("123", "msg")
+    approver.approve_on_obs("123", "msg", settings.obs_url)
     mock_osc_change.assert_not_called()
+
+
+def testapprove_on_obs_uses_passed_obs_url(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    """approve_on_obs must use the explicit obs_url, not the global default, e.g. for internal IBS projects."""
+    approver = prepare_approver(caplog)
+    mock_osc_change = mocker.patch("osc.core.change_review_state")
+    custom_url = "https://api.custom.obs"
+    approver.approve_on_obs("123", "msg", custom_url)
+    assert mock_osc_change.call_args.kwargs["apiurl"] == custom_url
+    assert custom_url != settings.obs_url
 
 
 def testhandle_approval_no_jobs_safeguard(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
     approver = prepare_approver(caplog)
     req = mocker.Mock(spec=osc.core.Request)
     req.reqid = 123
-    status = ApprovalStatus(req, ok_jobs=set(), reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[])
+    status = ApprovalStatus(
+        req,
+        ok_jobs=set(),
+        reasons_to_disapprove=[],
+        processed_jobs=set(),
+        builds=set(),
+        jobs=[],
+        obs_url=settings.obs_url,
+    )
 
     approver.handle_approval(status)
     assert "No openQA jobs were found/checked for this request." in caplog.text
@@ -180,3 +209,47 @@ def testfind_request_on_obs_not_accepted(caplog: pytest.LogCaptureFixture, mocke
     mock_get_list = mocker.patch("openqabot.requests.get_obs_request_list", return_value=[])
     find_request_on_obs(approver.args, "project")
     assert mock_get_list.call_args[0][1] == ("new", "review")
+
+
+@responses.activate
+@pytest.mark.usefixtures("fake_product_repo")
+def test_find_request_on_obs_with_custom_obs_url(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    approver = prepare_approver(caplog)
+    mock_get_list = mocker.patch("openqabot.requests.get_obs_request_list", return_value=[])
+    find_request_on_obs(approver.args, "project", obs_url="https://api.custom.obs")
+    assert mock_get_list.call_args[0][0] == "project"
+    assert mock_get_list.call_args[0][2] == "https://api.custom.obs"
+    assert (
+        "Skipping approval: project on https://api.custom.obs: No relevant requests in states new/review/accepted"
+        in caplog.messages
+    )
+
+
+def test_call_passes_resolved_obs_url_to_find_request_on_obs(
+    caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+) -> None:
+    """__call__ must resolve IncrementConfig.obs_url per group and forward it, not just the global default."""
+    approver = prepare_approver(caplog)
+    custom_url = "https://api.custom.obs"
+    approver.config[0].obs_url = custom_url
+    mock_find = mocker.patch("openqabot.incrementapprover.find_request_on_obs", return_value=None)
+    mocker.patch("openqabot.incrementapprover.load_build_info", return_value=set())
+
+    approver()
+
+    assert mock_find.call_args.kwargs["obs_url"] == custom_url
+
+
+def test_process_request_for_config_stores_resolved_obs_url_in_approval_status(
+    caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+) -> None:
+    """The obs_url used to find a request must be carried into its ApprovalStatus for later approval/comment."""
+    approver = prepare_approver(caplog)
+    req = mocker.Mock(spec=osc.core.Request)
+    req.reqid = "999"
+    custom_url = "https://api.custom.obs"
+    mocker.patch.object(approver, "get_package_diff_from_repo", return_value={})
+
+    approver.process_request_for_config(req, approver.config[0], set(), obs_url=custom_url)
+
+    assert approver.requests_to_approve["999"].obs_url == custom_url

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -16,6 +16,7 @@ import osc.core
 import pytest
 import responses
 
+from openqabot.config import settings
 from openqabot.errors import AmbiguousApprovalStatusError
 from openqabot.incrementapprover import IncrementApprover
 from openqabot.loader.config import get_configs_from_path
@@ -235,7 +236,15 @@ def test_evaluate_list_of_openqa_job_results(
     assert ok_jobs == {1, 3}
     assert len(jobs) == 4
 
-    status = ApprovalStatus(fake_osc_request, ok_jobs, [], set(), set(), jobs)
+    status = ApprovalStatus(
+        fake_osc_request,
+        ok_jobs,
+        [],
+        set(),
+        set(),
+        jobs,
+        obs_url=settings.obs_url,
+    )
     approver.handle_approval(status)
 
     f_reason = f"result 'failed':\n - {fake_openqa_url}/tests/2 (testname) in group 'Production'"
@@ -265,7 +274,13 @@ def test_check_unique_jobid_request_pair_ambiguity_found(
 def test_handle_approval_valid_request_id(caplog: pytest.LogCaptureFixture, fake_osc_request: osc.core.Request) -> None:
     approver = prepare_approver(caplog)
     status = ApprovalStatus(
-        fake_osc_request, ok_jobs={1, 2}, reasons_to_disapprove=[], processed_jobs=set(), builds=set(), jobs=[]
+        fake_osc_request,
+        ok_jobs={1, 2},
+        reasons_to_disapprove=[],
+        processed_jobs=set(),
+        builds=set(),
+        jobs=[],
+        obs_url=settings.obs_url,
     )
 
     approver.handle_approval(status)
@@ -284,6 +299,7 @@ def test_handle_approval_disapprove(caplog: pytest.LogCaptureFixture, fake_osc_r
         processed_jobs=set(),
         builds=set(),
         jobs=[],
+        obs_url=settings.obs_url,
     )
 
     approver.handle_approval(status)
@@ -597,6 +613,7 @@ def test_handle_approval_with_comment_flag(
         processed_jobs=set(),
         builds={BuildIdentifier("fake_build", "fake_distri", "fake_version")},
         jobs=[{"build": "fake_build", "distri": "fake_distri", "version": "fake_version", "status": "passed"}],
+        obs_url=settings.obs_url,
     )
 
     approver.handle_approval(status)


### PR DESCRIPTION
Motivation:
When OBS_URL is unset, the bot connects to the wrong instance and logs
a confusing "no requests" message. Additionally, we need a way to prevent
evaluating internal SUSE projects against the public openSUSE API.

Design Choices:
Added obs_url to log messages in openqabot/requests.py for better developer
visibility. Extended IncrementConfig to accept an obs_url field and updated
the fetching logic and tests to respect this override.

Benefits:
Provides clearer log feedback when OBS_URL is misconfigured. Allows
explicitly mapping internal projects to the internal IBS server via metadata
to prevent accidental external queries.