### PR TITLE
Revert "ci(mergify): let dependabot rebase its own PRs"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -49,23 +49,9 @@ pull_request_rules:
       - and:
           - updated-at<4 days ago
           - author=dependabot[bot]
-  - name: ask dependabot to rebase its own pull requests
+  - name: continuously rebase pull requests when it's labeled with `rebase` or `waited`
     conditions:
-      - author=dependabot[bot]
-      - -label=rebase-requested
-      - "#commits-behind>=1"
+      - label~=rebase|waited
     actions:
-      comment:
-        message: "@dependabot rebase"
-      label:
-        add:
-          - rebase-requested
-  - name: clear rebase-requested label once dependabot has rebased
-    conditions:
-      - label=rebase-requested
-      - author=dependabot[bot]
-      - "#commits-behind=0"
-    actions:
-      label:
-        remove:
-          - rebase-requested
+      rebase:
+        bot_account: suse-qe-tools-mergify


### PR DESCRIPTION
This reverts commit 46d1898944c23b3bf2c723965368ecdb1ffffc2a which was
wrongly assuming that dependabot would be asked to rebase its own PRs
which was not the case. Now we see problems as in
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25500
where unauthorized mergify asks dependabot to rebase which dependabot
refuses.