### PR TITLE
feat: Prevent jobs for submissions to be treated as consecutive builds

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -105,6 +105,7 @@ incidents:
          - KEYTWO
          - KEYTHREE
       override_priority: 100
+      versioned_by_submission: false
       params_expand:
         FOO: foo
         BAR: bar
@@ -126,6 +127,7 @@ incidents:
 * `aggregate_job` - optional, boolean value, by default is `true`. When set to `false` it indicates this FLAVOR doesn't need an aggregate job for approval.
 * `aggregate_check_true` and `aggregate_check_false` - optional, list of keywords, used only with `aggregate_job: false`. Conditions to finely tune the need for Aggregate jobs for approval. Keywords are keys of variables used by job.
 * `override_priority` - optional, integer. Overrides the default priority of the job. (default = 50, with modifiers for `*Minimal`, EMU and staging Incidents)
+* `versioned_by_submission` - optional, boolean. Whether to include the submission type and ID in the `VERSION`.
 * `packages` - optional, list of package names (or first part of pkg name). The incident must contain a package from this list to be scheduled into openQA.
 * `excluded_packages` - optional, list of package names, opposite of `packages`. If the Incident contains a package in this list, it isn't scheduled.
 * `params_expand` - flavor specific settings. Merged with `settings` dictionary. `params_expand` values take precedence over `settings`. `DISTRI` and `VERSION` cannot be configured with `params_expand`.

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -185,7 +185,9 @@ class Submissions(BaseConf):
             **self.settings,
             "ARCH": arch,
             "FLAVOR": flavor,
-            "VERSION": f"{self.settings['VERSION']}:{sub.type}-{sub.id}",
+            "VERSION": f"{self.settings['VERSION']}:{sub.type}-{sub.id}"
+            if ctx.data.get("versioned_by_submission", False)
+            else self.settings["VERSION"],
             "DISTRI": self.settings["DISTRI"],
             "INCIDENT_ID": sub.id,
             "REPOHASH": revs,

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -185,7 +185,7 @@ class Submissions(BaseConf):
             **self.settings,
             "ARCH": arch,
             "FLAVOR": flavor,
-            "VERSION": self.settings["VERSION"],
+            "VERSION": f"{self.settings['VERSION']}:{'inc' if sub.type == 'smelt' else 'PR'}-{sub.id}",
             "DISTRI": self.settings["DISTRI"],
             "INCIDENT_ID": sub.id,
             "REPOHASH": revs,

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -185,7 +185,7 @@ class Submissions(BaseConf):
             **self.settings,
             "ARCH": arch,
             "FLAVOR": flavor,
-            "VERSION": f"{self.settings['VERSION']}:{'inc' if sub.type == 'smelt' else 'PR'}-{sub.id}",
+            "VERSION": f"{self.settings['VERSION']}:{sub.type}-{sub.id}",
             "DISTRI": self.settings["DISTRI"],
             "INCIDENT_ID": sub.id,
             "REPOHASH": revs,

--- a/tests/test_submissions_call.py
+++ b/tests/test_submissions_call.py
@@ -256,7 +256,7 @@ def test_submissions_call_with_params_expand_distri_version() -> None:
         ignore_onetime=False,
     )
     assert len(res) == 1
-    assert res[0]["openqa"]["VERSION"] == "1.2.3"
+    assert res[0]["openqa"]["VERSION"] == "1.2.3:inc-0"
     assert res[0]["openqa"]["DISTRI"] == "IM_A_DISTRI"
     assert res[0]["openqa"]["SOMETHING"] == "flavor win"
 

--- a/tests/test_submissions_call.py
+++ b/tests/test_submissions_call.py
@@ -256,7 +256,7 @@ def test_submissions_call_with_params_expand_distri_version() -> None:
         ignore_onetime=False,
     )
     assert len(res) == 1
-    assert res[0]["openqa"]["VERSION"] == "1.2.3:inc-0"
+    assert res[0]["openqa"]["VERSION"] == "1.2.3:smelt-0"
     assert res[0]["openqa"]["DISTRI"] == "IM_A_DISTRI"
     assert res[0]["openqa"]["SOMETHING"] == "flavor win"
 

--- a/tests/test_submissions_call.py
+++ b/tests/test_submissions_call.py
@@ -256,7 +256,7 @@ def test_submissions_call_with_params_expand_distri_version() -> None:
         ignore_onetime=False,
     )
     assert len(res) == 1
-    assert res[0]["openqa"]["VERSION"] == "1.2.3:smelt-0"
+    assert res[0]["openqa"]["VERSION"] == "1.2.3"
     assert res[0]["openqa"]["DISTRI"] == "IM_A_DISTRI"
     assert res[0]["openqa"]["SOMETHING"] == "flavor win"
 

--- a/tests/test_submissions_gitea.py
+++ b/tests/test_submissions_gitea.py
@@ -39,7 +39,7 @@ def _assert_gitea_settings(
         "INCIDENT_ID": sub_id,
         "INCIDENT_REPO": f"{expected_repo}-{arch}/",
         "REPOHASH": repo_hash,
-        "VERSION": product_ver,
+        "VERSION": f"{product_ver}:PR-{sub_id}",
     }
 
     for s in [result["openqa"], qem["settings"]]:

--- a/tests/test_submissions_gitea.py
+++ b/tests/test_submissions_gitea.py
@@ -59,7 +59,7 @@ def test_gitea_submissions() -> None:
     settings = {"VERSION": product_ver, "DISTRI": "sles"}
     issues = {"BASE_TEST_ISSUES": "SLFO:1.1.99#15.99"}
     flavor = "AAA"
-    test_config = {"FLAVOR": {flavor: {"archs": archs, "issues": issues}}}
+    test_config = {"FLAVOR": {flavor: {"archs": archs, "issues": issues, "versioned_by_submission": True}}}
 
     # create a Git-based submission
     sub = MockSubmission(type="git")

--- a/tests/test_submissions_gitea.py
+++ b/tests/test_submissions_gitea.py
@@ -39,7 +39,7 @@ def _assert_gitea_settings(
         "INCIDENT_ID": sub_id,
         "INCIDENT_REPO": f"{expected_repo}-{arch}/",
         "REPOHASH": repo_hash,
-        "VERSION": f"{product_ver}:PR-{sub_id}",
+        "VERSION": f"{product_ver}:git-{sub_id}",
     }
 
     for s in [result["openqa"], qem["settings"]]:


### PR DESCRIPTION
* Append the incident ID or PR number to the `VERSION` when scheduling jobs for submissions
* Note that job templates need to be adjusted making use of https://github.com/os-autoinst/openQA/pull/7489
* Note that tests need to be adjusted, e.g. https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/25684

Related ticket: https://progress.opensuse.org/issues/200991