### PR TITLE
feat: enable detailed comments by default

### DIFF
--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -91,7 +91,7 @@ class Settings(BaseSettings):
     # How long to wait for http(s) call in seconds
     url_timeout: int = 60
     # Detailed comments settings
-    enable_detailed_comments: bool = Field(default=False, alias="QEM_ENABLE_DETAILED_COMMENTS")
+    enable_detailed_comments: bool = Field(default=True, alias="QEM_ENABLE_DETAILED_COMMENTS")
     fallback_contact: str = Field(default="Contact openQA test maintainers", alias="QEM_FALLBACK_CONTACT")
     generic_tool_issues_contact: str = Field(
         default="Contact qem-bot maintainers for generic questions", alias="QEM_GENERIC_TOOL_ISSUES_CONTACT"


### PR DESCRIPTION
Motivation:
Detailed comments provide useful job group context and maintainer contacts
for failures. After a stabilization period, these should be enabled by
default to provide better feedback on failed tests without requiring
manual opt-in via CLI flags.

Design Choices:
- Updated the default value of enable_detailed_comments to True in the
  Settings class in openqabot/config.py.
- This affects all commands using the Commenter (sub-approve,
  gitea-trigger, sub-comment, and increment-approve).

Benefits:
- Enhanced failure reporting by default.
- Improved user experience for developers and maintainers interacting with
  automated comments.