### PR TITLE
fix(gitea): handle JSONDecodeError when token is missing

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -603,11 +603,15 @@ def get_gitea_staging_config(token: dict[str, str]) -> dict:
     """
     response = retried_requests.get(
         config.settings.gitea_staging_config_url,
-        verify=False,
+        verify=not config.settings.insecure,
         headers=token,
     )
     response.raise_for_status()
-    return response.json()
+    try:
+        return response.json()
+    except (json.JSONDecodeError, requests.exceptions.JSONDecodeError) as e:
+        msg = f"Failed to decode staging config JSON from {response.url}. Is the Gitea token missing or invalid?"
+        raise ValueError(msg) from e
 
 
 def generate_repo_url(pullrequest: PullRequest, staging_config_qa_labels: dict[str, str], project: str) -> str:

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -242,6 +243,23 @@ def test_generate_repo_url_two_label_match(labeled_pr: PullRequest) -> None:
 def test_get_gitea_staging_config(mocked_response: dict[str, str | list]) -> None:
     conf = gitea.get_gitea_staging_config({"token": "token"})
     assert conf == mocked_response
+
+
+def test_get_gitea_staging_config_decode_error(mocker: MockerFixture) -> None:
+    mock_get = mocker.patch("openqabot.loader.gitea.retried_requests.get")
+    mock_response = MagicMock()
+    mock_response.url = "https://src.suse.de/staging.config"
+    mock_response.json.side_effect = requests.exceptions.JSONDecodeError("msg", "doc", 0)
+    mock_get.return_value = mock_response
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Failed to decode staging config JSON from https://src.suse.de/staging.config. "
+            "Is the Gitea token missing or invalid?"
+        ),
+    ):
+        gitea.get_gitea_staging_config({"token": "token"})
 
 
 @pytest.fixture


### PR DESCRIPTION
Motivation:
Without a token, Gitea redirects API requests to a login HTML page which
returns a 200 OK status but causes a JSONDecodeError when parsing.

Design Choices:
Caught JSONDecodeError exceptions during the staging config fetch and raised
a helpful ValueError suggesting a missing or invalid token.

Manual verification:
Called `./qem-bot.py --dry gitea-trigger` and observed that the better
error message shows up.

Benefits:
Users receive a clear, actionable error message instead of an obscure JSON
parsing failure when running without a valid Gitea token.