### PR TITLE
ci(dependabot): remove updates grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,12 +13,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    groups:
-      dev-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -31,7 +25,3 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    groups:
-      all-actions:
-        patterns:
-          - "*"


### PR DESCRIPTION


Initially idea of grouping was to avoid spamming but it appears that amount of
spam remains the same just concentrated in single PR instead of several.
Also single PR for several updates makes overall dependency management more complicated
