### PR TITLE
ci(dependabot): decrease frequency for none critical updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,16 +13,26 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    groups:
-      dev-dependencies:
-        patterns:
-          - "*"
-        update-types:
-          - "major"
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "waiting"
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: scope
+    allow:
+      - dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
     open-pull-requests-limit: 5
     labels:


### PR DESCRIPTION


Packages involved in code analysis and package development
are not so sensetive for frequent updates. To lower
burden on PR reviewers we can instruct dependabot
to produce PR less frequent only for this type of
packages.
