### PR TITLE
fix: update ruff to 0.15.17 and fix new RUF076 violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pyupgrade==3.21.2",
     "coverage==7.14.1",
     "responses==0.26.1",
-    "ruff==0.15.16",
+    "ruff==0.15.17",
     "pytest-mock==3.15.1",
     "vulture==2.16",
     "ty==0.0.44",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,13 +69,13 @@ def fake_responses_for_unblocking_submissions_via_openqa_comments(
         )
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: RUF076 - pytest autouse required to ensure all tests run with fake openQA URL
 def fake_openqa_url() -> str:
     settings.openqa_instance = "http://instance.qa"
     return settings.openqa_instance
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: RUF076 - pytest autouse required to ensure all tests run with fake openQA job stat URL
 def fake_openqa_url_job_stat(fake_openqa_url: str) -> str:
     settings.openqa_instance = "http://instance.qa"
     return f"{fake_openqa_url}/api/v1/isos/job_stats"
@@ -123,7 +123,7 @@ def make_approver(submission: int = 0, *, mocker: MockerFixture | None = None, c
     return instance()
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: RUF076 - pytest autouse required to clear cache automatically before every test
 def _auto_clear_cache() -> None:
     clear_cache()
 
@@ -136,7 +136,7 @@ def _session_settings() -> dict[str, Any]:
         return {key: getattr(defaults, key) for key in Settings.model_fields}
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: RUF076 - pytest autouse required to reset singleton settings for every test
 def _reset_settings(mocker: MockerFixture, _session_settings: dict[str, Any]) -> None:
     # Maintain consistent environment and reset singleton settings for every test
     mocker.patch.dict(os.environ, {"OBS_URL": _session_settings["obs_url"]})
@@ -144,7 +144,7 @@ def _reset_settings(mocker: MockerFixture, _session_settings: dict[str, Any]) ->
         setattr(config_module.settings, key, value)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: RUF076 - pytest autouse required to mock load_dotenv automatically for all tests
 def _mock_load_dotenv(mocker: MockerFixture) -> None:
     mocker.patch("openqabot.main.load_dotenv")
 
@@ -261,7 +261,7 @@ def fakeget_package_diff(mocker: MockerFixture) -> None:
     mocker.patch("openqabot.incrementapprover.IncrementApprover.get_package_diff", return_value=package_diff)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: RUF076 - pytest autouse required to mock osc automatically for all tests
 def mock_osc(mocker: MockerFixture) -> None:
     # Clear caches to ensure isolation between tests
 

--- a/tests/test_mock_interceptor.py
+++ b/tests/test_mock_interceptor.py
@@ -32,7 +32,7 @@ class MockRequest(requests.PreparedRequest):
         self.url = url
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)  # noqa: RUF076 - pytest autouse required to reset mock state automatically before each test
 def reset_mock_state() -> Any:
     """Reset mock state before each test.
 


### PR DESCRIPTION
Bump ruff to 0.15.17 and add targeted pytest autouse exclusions.

Obsoletes:
* #565