### PR TITLE
fix: resolve gitea-trigger mock integration failures

### DIFF
--- a/openqabot/mock_interceptor.py
+++ b/openqabot/mock_interceptor.py
@@ -45,6 +45,15 @@ def mock_gitea_pr_details() -> None:
     )
 
 
+def mock_gitea_staging_config() -> None:
+    """Mock Gitea staging.config download."""
+    responses.add_callback(
+        responses.GET,
+        re.compile(r".*/raw/branch/.*/staging.config$"),
+        callback=gitea_staging_config_callback,
+    )
+
+
 def mock_smelt_graphql() -> None:
     """Mock SMELT GraphQL API."""
     responses.add_callback(
@@ -120,6 +129,7 @@ def setup_mock_responses() -> None:
 
     mock_gitea_pulls()
     mock_gitea_pr_details()
+    mock_gitea_staging_config()
     mock_smelt_graphql()
     mock_openqa_jobs()
     mock_repomd()
@@ -154,6 +164,18 @@ def gitea_pr_details_callback(request: requests.PreparedRequest) -> tuple[int, d
     if "files" in url:
         return (200, {}, read_fixture("files-124.json"))
     return (404, {}, "{}")
+
+
+def gitea_staging_config_callback(_request: requests.PreparedRequest) -> tuple[int, dict[str, str], str]:
+    """Return Gitea staging.config mock response."""
+    return (
+        200,
+        {},
+        json.dumps({
+            "StagingProject": "openQA:Staging:A",
+            "QA": [{"Name": "SLES", "Label": "label1"}, {"Name": "SLES", "Label": "label2"}],
+        }),
+    )
 
 
 def smelt_graphql_callback(_request: requests.PreparedRequest) -> tuple[int, dict[str, str], str]:

--- a/tests/fixtures/metadata/qem-bot/minimal.yml
+++ b/tests/fixtures/metadata/qem-bot/minimal.yml
@@ -15,3 +15,5 @@ incidents:
         - x86_64
       issues:
         BASE_TEST_ISSUES: Mock:15-SP3
+trigger_config:
+  - distri: sle

--- a/tests/test_mock_interceptor.py
+++ b/tests/test_mock_interceptor.py
@@ -14,6 +14,7 @@ from openqabot.mock_interceptor import (
     MockInterceptorState,
     gitea_pr_details_callback,
     gitea_pulls_callback,
+    gitea_staging_config_callback,
     mock_http_get,
     openqa_jobs_callback,
     patchinfo_callback,
@@ -112,6 +113,14 @@ def test_gitea_pr_details_callback() -> None:
         assert gitea_pr_details_callback(MockRequest("http://test/comments")) == (200, {}, "details_data")
         assert gitea_pr_details_callback(MockRequest("http://test/files")) == (200, {}, "details_data")
         assert gitea_pr_details_callback(MockRequest("http://test/unknown")) == (404, {}, "{}")
+
+
+def test_gitea_staging_config_callback() -> None:
+    """Test Gitea staging.config mock callback."""
+    status, _, data = gitea_staging_config_callback(MockRequest("http://test"))
+    assert status == 200
+    assert "StagingProject" in data
+    assert "QA" in data
 
 
 def test_smelt_graphql_callback() -> None:


### PR DESCRIPTION
Motivation:
Fix ValueError and ConnectionError on the gitea-trigger CLI command during
unstable integration tests.

Design Choices:
Define trigger_config in the integration test fixture minimal.yml, and register
gitea_staging_config_callback to mock staging.config fetch requests under
--fake-data mode.

Benefits:
Ensures gitea-trigger runs successfully in mock environments, satisfying the
unstable bot command integration test coverage target.