### PR TITLE
fix: Prevent silent ignoring of failed tests in product increments

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -128,13 +128,12 @@ class IncrementApprover:
         with ThreadPoolExecutor() as executor:
             stats = list(executor.map(fetch_stats, params))
 
-        # Fetch all relevant job details in a single API call to avoid N+1 query problem
         job_ids = [
-            int(ids[0])
+            int(i)
             for stat in stats
             for jobs in stat.values()
             for info in jobs.values()
-            if (ids := info.get("job_ids"))
+            for i in info.get("job_ids", [])
         ]
         job_map = {job["id"]: job for job in self.client.get_jobs_by_ids(job_ids)}
 

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from functools import lru_cache
 from http import HTTPStatus
+from itertools import batched
 from pprint import pformat
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -29,6 +30,9 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger("bot.openqa")
+
+MAX_JOBS_PER_API_REQUEST = 200
+ENRICH_KEYS = ("group", "group_id", "distri", "version", "build")
 
 
 class OpenQAInterface:
@@ -125,16 +129,18 @@ class OpenQAInterface:
         return None
 
     def get_jobs_by_ids(self, job_ids: list[int]) -> list[dict[str, Any]]:
-        """Fetch details for multiple jobs in a single API call."""
+        """Fetch details for multiple jobs in batched API calls."""
         if not job_ids:
             return []
 
-        ids_str = ",".join(map(str, sorted(set(job_ids))))
-        try:
-            return self.openqa.openqa_request("GET", "jobs", {"ids": ids_str}).get("jobs", [])
-        except RequestError:
-            log.exception("openQA API error when fetching multiple jobs")
-        return []
+        results = []
+        for chunk in batched(sorted(set(job_ids)), MAX_JOBS_PER_API_REQUEST, strict=False):
+            try:
+                res = self.openqa.openqa_request("GET", "jobs", {"ids": ",".join(map(str, chunk))})
+                results.extend(res.get("jobs", []))
+            except RequestError:
+                log.exception("openQA API error when fetching multiple jobs")
+        return results
 
     def is_in_devel_group(self, job: dict[str, Any]) -> bool:
         """Check if a job belongs to a development group."""
@@ -178,24 +184,24 @@ class OpenQAInterface:
             log.exception("openQA API error when fetching job group %s", group_id)
         return None
 
-    @staticmethod
-    def enrich_job_info(info: dict[str, Any], job_map: dict[int, dict[str, Any]]) -> dict[str, Any]:
-        """Enrich job information with metadata from the first job ID."""
-        if not (ids := info.get("job_ids")) or not (job := job_map.get(int(ids[0]))):
+    def enrich_job_info(self, info: dict[str, Any], job_map: dict[int, dict[str, Any]]) -> dict[str, Any]:
+        """Enrich job information with metadata, filtering out development jobs."""
+        if not (ids := info.get("job_ids")):
             return info
 
-        return info | {
-            "group": job.get("group"),
-            "group_id": job.get("group_id"),
-            "distri": job.get("distri"),
-            "version": job.get("version"),
-            "build": job.get("build"),
-        }
+        valid_ids = [i for i in ids if (job := job_map.get(int(i))) and not self.is_in_devel_group(job)]
+        target_id = valid_ids[0] if valid_ids else ids[0]
+        target_job = job_map.get(int(target_id))
 
-    @staticmethod
-    def enrich_stats(stat: dict[str, Any], job_map: dict[int, dict[str, Any]]) -> dict[str, Any]:
+        updated_info = info | {"job_ids": valid_ids or ids}
+        if not target_job:
+            return updated_info
+
+        return updated_info | {k: target_job.get(k) for k in ENRICH_KEYS}
+
+    def enrich_stats(self, stat: dict[str, Any], job_map: dict[int, dict[str, Any]]) -> dict[str, Any]:
         """Enrich all jobs in a scheduled product result with metadata."""
         return {
-            status: {name: OpenQAInterface.enrich_job_info(info, job_map) for name, info in jobs.items()}
+            status: {name: self.enrich_job_info(info, job_map) for name, info in jobs.items()}
             for status, jobs in stat.items()
         }

--- a/tests/test_openqaclient.py
+++ b/tests/test_openqaclient.py
@@ -185,6 +185,19 @@ def test_get_job_group_info_error(fake_openqa_url: str, caplog: pytest.LogCaptur
     assert "openQA API error when fetching job group 42" in caplog.text
 
 
+@pytest.fixture
+def fake_job_group_10_api(fake_openqa_url: str) -> None:
+    """Mock openQA job group 10."""
+    responses.add(
+        responses.GET,
+        f"{fake_openqa_url}/api/v1/job_groups/10",
+        json=[{"parent_id": 50}],
+        status=200,
+    )
+
+
+@responses.activate
+@pytest.mark.usefixtures("fake_job_group_10_api")
 def test_enrich_job_info() -> None:
     """Test enrich_job_info with various inputs."""
     job_map = {
@@ -195,26 +208,45 @@ def test_enrich_job_info() -> None:
             "distri": "dist",
             "version": "1.0",
             "build": "123",
-        }
+        },
+        2: {
+            "id": 2,
+            "group": "Devel: Test",
+            "group_id": 11,
+            "distri": "dist",
+            "version": "1.0",
+            "build": "123",
+        },
     }
 
-    # Successful enrichment
-    info = {"job_ids": [1], "other": "data"}
-    enriched = oQAI.enrich_job_info(info, job_map)
+    # Successful enrichment (filters out job 2 because it's in a devel group)
+    info = {"job_ids": [1, 2], "other": "data"}
+    client = oQAI()
+    enriched = client.enrich_job_info(info, job_map)
+    assert enriched["job_ids"] == [1]
     assert enriched["group"] == "Group1"
     assert enriched["group_id"] == 10
     assert enriched["distri"] == "dist"
     assert enriched["other"] == "data"
 
+    # Only devel jobs in job_ids
+    info_devel_only = {"job_ids": [2], "other": "data"}
+    enriched_devel_only = client.enrich_job_info(info_devel_only, job_map)
+    assert enriched_devel_only["job_ids"] == [2]
+    assert enriched_devel_only["group"] == "Devel: Test"
+    assert enriched_devel_only["group_id"] == 11
+
     # Missing job_ids
     info2 = {"other": "data"}
-    assert oQAI.enrich_job_info(info2, job_map) == info2
+    assert client.enrich_job_info(info2, job_map) == info2
 
     # Job ID not in map
-    info3 = {"job_ids": [2]}
-    assert oQAI.enrich_job_info(info3, job_map) == info3
+    info3 = {"job_ids": [3]}
+    assert client.enrich_job_info(info3, job_map) == info3
 
 
+@responses.activate
+@pytest.mark.usefixtures("fake_job_group_10_api")
 def test_enrich_stats() -> None:
     """Test enrich_stats properly traverses the stats structure."""
     job_map = {1: {"id": 1, "group": "G1", "group_id": 10, "distri": "d", "version": "v", "build": "b"}}
@@ -223,6 +255,7 @@ def test_enrich_stats() -> None:
         "failed": {"job2": {"job_ids": [2], "result": "failed"}},
     }
 
-    enriched = oQAI.enrich_stats(stats, job_map)
+    client = oQAI()
+    enriched = client.enrich_stats(stats, job_map)
     assert enriched["passed"]["job1"]["group"] == "G1"
     assert "group" not in enriched["failed"]["job2"]


### PR DESCRIPTION
Motivation:
qem-bot failed to block product increments when a failed test (e.g., job
22862360) was bundled with a development group test in the openQA stats
response. The bot incorrectly assigned the development group metadata to the
entire "failed" bucket.

Design Choices:
Updated `enrich_job_info` to filter out development jobs individually from the
`job_ids` list. Also modified `get_jobs_by_ids` to fetch metadata in chunks to
prevent HTTP 414 URI Too Long errors when querying openQA for all job details.

Benefits:
Ensures legitimate failing tests correctly block product increment approvals
even when they appear alongside ignored development tests in openQA's job stats.
Related issue: https://gitlab.suse.de/qa-maintenance/bot-ng/-/jobs/6919910