### PR TITLE
feat: extend detailed comments to increment-approve

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -607,6 +607,10 @@ def increment_approve(  # noqa: PLR0913
         ),
     ] = None,
     comment: comment_option = True,
+    enable_detailed_comments: enable_detailed_comments_option = None,
+    fallback_contact: fallback_contact_option = None,
+    generic_tool_issues_contact: generic_tool_issues_contact_option = None,
+    max_detailed_comment_entries: max_detailed_comment_entries_option = None,
 ) -> None:
     """Approve the most recent product increment for an OBS project if tests passed."""
     args = ctx.obj
@@ -627,6 +631,14 @@ def increment_approve(  # noqa: PLR0913
     args.product_regex = product_regex
     args.increment_config = increment_config
     args.comment = comment
+
+    _apply_detailed_comment_options(
+        args,
+        enable_detailed_comments=enable_detailed_comments,
+        fallback_contact=fallback_contact,
+        generic_tool_issues_contact=generic_tool_issues_contact,
+        max_detailed_comment_entries=max_detailed_comment_entries,
+    )
 
     approve = IncrementApprover(args)
     sys.exit(approve())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ ignore = [
 max-complexity = 9
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["PLR2004", "ANN401", "PLR0913", "S101", "S105", "S106", "PLR0917", "D103"]
+"tests/*" = ["PLR2004", "ANN401", "PLR0913", "S101", "S105", "S106", "PLR0917", "D103", "RUF102"]
 
 [tool.ruff.format]
 # Enable reformatting of code snippets in docstrings.

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -163,6 +163,35 @@ def test_increment_approve(mocker: MockerFixture, tmp_path: Path) -> None:
     approve.assert_called_once()
 
 
+def test_increment_approve_with_detailed_args(mocker: MockerFixture, tmp_path: Path) -> None:
+    approve = mocker.patch("openqabot.args.IncrementApprover")
+    approve.return_value.return_value = 0
+    result = runner.invoke(
+        app,
+        [
+            "--token",
+            "foo",
+            "--configs",
+            str(tmp_path),
+            "increment-approve",
+            "--enable-detailed-comments",
+            "--fallback-contact",
+            "Test Contact",
+            "--generic-tool-issues-contact",
+            "@test",
+            "--max-detailed-comment-entries",
+            "5",
+        ],
+    )
+    assert result.exit_code == 0
+    approve.assert_called_once()
+    args = approve.call_args[0][0]
+    assert args.enable_detailed_comments is True
+    assert args.fallback_contact == "Test Contact"
+    assert args.generic_tool_issues_contact == "@test"
+    assert args.max_detailed_comment_entries == 5
+
+
 def test_repo_diff(mocker: MockerFixture, tmp_path: Path) -> None:
     repo_diff = mocker.patch("openqabot.args.RepoDiff")
     repo_diff.return_value.return_value = 0


### PR DESCRIPTION
Motivation:
Detailed comments provide useful job group context and maintainer contacts
for failures. These should be available when using the 'increment-approve'
command which has commenting functionality.

Design Choices:
- Use existing Annotated types for typer options in openqabot/args.py
- Call _apply_detailed_comment_options in increment_approve command
- Added test case to verify options are correctly passed to the approver

Benefits:
- Consistent behavior across all approval and commenting commands
- Easier maintenance and troubleshooting of failed increments with
  provided contact info