### PR TITLE
feat: improve link formatting in OBS comments

### DIFF
--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -95,7 +95,7 @@ class Commenter:
         log.debug("Determined comment state for %s: %s", sub, state)
 
         builds = {BuildIdentifier.from_job(j) for j in jobs if "build" in j}
-        msg = self.summarize_message(builds, jobs)
+        msg = self.summarize_message(sub, builds, jobs)
         if not msg:
             raise EmptyCommentError(sub)
 
@@ -186,9 +186,11 @@ class Commenter:
         else:
             gitea.patch_json(f"repos/{repo}/issues/comments/{comment['id']}", self.gitea_token, {"body": msg})
 
-    def summarize_message(self, builds: set[BuildIdentifier], jobs: list[dict[str, Any]]) -> str:
+    def summarize_message(
+        self, sub: CommentableProtocol, builds: set[BuildIdentifier], jobs: list[dict[str, Any]]
+    ) -> str:
         """Create markdown containing openQA badges."""
-        badge_msg = self._generate_badge_section(builds)
+        badge_msg = self._generate_badge_section(sub, builds)
 
         if not config.settings.enable_detailed_comments:
             return badge_msg
@@ -197,9 +199,9 @@ class Commenter:
         if not job_groups:
             return badge_msg
 
-        return badge_msg + "\n\n" + self._generate_detail_section(job_groups, sorted(builds))
+        return badge_msg + "\n\n" + self._generate_detail_section(sub, job_groups, sorted(builds))
 
-    def _generate_badge_section(self, builds: set[BuildIdentifier]) -> str:
+    def _generate_badge_section(self, sub: CommentableProtocol, builds: set[BuildIdentifier]) -> str:
         """Generate markdown for openQA badges."""
         base_url = self.client.openqa.baseurl
         badge_msg = ""
@@ -210,10 +212,12 @@ class Commenter:
             query = urlencode(params, safe="*")
             badge_url = f"{base_url}/tests/overview/badge?{query}"
             link_url = f"{base_url}/tests/overview?{query}"
-            badge_msg += f"[![{label} Results]({badge_url})]({link_url})\n"
+            badge_msg += sub.format_link(f"{label} Results", link_url, badge_url) + "\n"
         return badge_msg.strip()
 
-    def _generate_detail_section(self, job_groups: list[dict[str, Any]], sorted_builds: list[BuildIdentifier]) -> str:
+    def _generate_detail_section(
+        self, sub: CommentableProtocol, job_groups: list[dict[str, Any]], sorted_builds: list[BuildIdentifier]
+    ) -> str:
         """Generate markdown for detailed failure information."""
         max_entries = config.settings.max_detailed_comment_entries
         display_groups = job_groups[:max_entries]
@@ -223,7 +227,7 @@ class Commenter:
         base_url = self.client.openqa.baseurl
 
         table_rows = [
-            f"| [![{g['name']} Test Results]({g['badge_url']})]({g['overview_url']}) | "
+            f"| {sub.format_link(g['name'] + ' Test Results', g['overview_url'], g['badge_url'])} | "
             f"{g['contact'] or f'No contact provided: {fallback}'} |"
             for g in display_groups
         ]

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -31,6 +31,7 @@ from .loader.incrementconfig import TEMPLATE_VARS, GroupKey, IncrementConfig
 from .repodiff import Package, RepoDiff
 from .requests import find_request_on_obs
 from .types.increment import ApprovalStatus, BuildIdentifier, BuildInfo
+from .types.pullrequest import OBSCommentable
 from .utils import merge_dicts, unique_dicts
 
 if TYPE_CHECKING:
@@ -233,7 +234,7 @@ class IncrementApprover:
 
         if self.comment and approval_status.builds:
             state = "passed" if not all_reasons else "failed"
-            msg = self.commenter.summarize_message(approval_status.builds, approval_status.jobs)
+            msg = self.commenter.summarize_message(OBSCommentable(reqid), approval_status.builds, approval_status.jobs)
             self.commenter.osc_comment_on_request(str(reqid), msg, state)
 
         if not all_reasons:

--- a/openqabot/types/pullrequest.py
+++ b/openqabot/types/pullrequest.py
@@ -22,6 +22,38 @@ class CommentableProtocol(Protocol):
         """The URL of the pull request."""
         ...
 
+    @property
+    def is_gitea(self) -> bool:
+        """Check if representing a Gitea pull request."""
+        ...
+
+    def format_link(self, label: str, url: str, image_url: str | None = None) -> str:
+        """Format a link with an optional image badge."""
+        ...
+
+
+class OBSCommentable:
+    """Implement CommentableProtocol for OBS requests/incidents."""
+
+    def __init__(self, obj_id: int | str | None, url: str | None = None) -> None:
+        """Initialize OBSCommentable."""
+        self.id = int(obj_id) if obj_id is not None else 0
+        self.url = url
+
+    @property
+    def is_gitea(self) -> bool:
+        """Check if representing a Gitea pull request."""
+        return False
+
+    def format_link(  # noqa: PLR6301 - Interface compatibility requires format_link to be a non-static method
+        self,
+        label: str,
+        url: str,
+        image_url: str | None = None,  # noqa: ARG002  - Interface compatibility
+    ) -> str:
+        """Format a link with an optional image badge."""
+        return f"[{label}]({url})"
+
 
 @dataclass
 class PullRequest:
@@ -41,6 +73,17 @@ class PullRequest:
     def id(self) -> int:
         """Alias for number for consistency with Submission."""
         return self.number
+
+    @property
+    def is_gitea(self) -> bool:
+        """Check if representing a Gitea pull request."""
+        return True
+
+    def format_link(self, label: str, url: str, image_url: str | None = None) -> str:  # noqa: PLR6301 - Interface compatibility requires format_link to be a non-static method
+        """Format a link with an optional image badge."""
+        if image_url:
+            return f"[![{label}]({image_url})]({url})"
+        return f"[{label}]({url})"
 
     def generate_webhook_id(self) -> str:
         """Generate a webhook identifier for this pull request."""

--- a/openqabot/types/submission.py
+++ b/openqabot/types/submission.py
@@ -49,6 +49,17 @@ class Submission:
         self._logged_skipped: bool = False
         self.livepatch: bool = self.is_livepatch(self.packages)
 
+    @property
+    def is_gitea(self) -> bool:
+        """Check if the submission is from Gitea."""
+        return self.type == "git"
+
+    def format_link(self, label: str, url: str, image_url: str | None = None) -> str:
+        """Format a link with an optional image badge."""
+        if self.is_gitea and image_url:
+            return f"[![{label}]({image_url})]({url})"
+        return f"[{label}]({url})"
+
     def _initialize_channels(self, raw_channels: list[str]) -> None:
         """Initialize channels and skipped products from raw channel data."""
         self.channels, self.skipped_products = self._parse_channels(raw_channels)

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -14,6 +14,7 @@ import pytest
 from openqabot.commenter import Commenter
 from openqabot.errors import EmptyCommentError, NoResultsError
 from openqabot.types.increment import BuildIdentifier
+from openqabot.types.pullrequest import OBSCommentable
 from openqabot.types.submission import Submission
 from openqabot.types.types import ArchVer
 
@@ -336,14 +337,28 @@ def test_summarize_message(
     mocker.patch("openqabot.config.settings.allow_development_groups", new=None)
     c = Commenter(mock_args, submissions=[])
     builds = [BuildIdentifier("1.1", "sle", "15"), BuildIdentifier("1.2", "", "")]
-    result = c.summarize_message(set(builds), [])
+    sub_gitea = MagicMock(is_gitea=True)
+    sub_gitea.format_link = lambda label, url, image_url=None: (
+        f"[![{label}]({image_url})]({url})" if image_url else f"[{label}]({url})"
+    )
+    result_gitea = c.summarize_message(sub_gitea, set(builds), [])
     assert (
         "https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*&label=Build+1.1"
-        in result
+        in result_gitea
     )
     assert (
         "https://openqa.opensuse.org/tests/overview/badge?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2"
-        in result
+        in result_gitea
+    )
+
+    result_obs = c.summarize_message(OBSCommentable(124), set(builds), [])
+    assert (
+        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*&label=Build+1.1)"
+        in result_obs
+    )
+    assert (
+        "[Build 1.2 Results](https://openqa.opensuse.org/tests/overview?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2)"
+        in result_obs
     )
 
 
@@ -357,11 +372,22 @@ def test_summarize_message_allow_devel(
     mocker.patch("openqabot.config.settings.allow_development_groups", new="1")
     c = Commenter(mock_args, submissions=[])
     builds = [BuildIdentifier("1.1", "opensuse", "Tumbleweed")]
-    result = c.summarize_message({builds[0]}, [])
-    assert "not_group_glob" not in result
+    sub_gitea = MagicMock(is_gitea=True)
+    sub_gitea.format_link = lambda label, url, image_url=None: (
+        f"[![{label}]({image_url})]({url})" if image_url else f"[{label}]({url})"
+    )
+    result_gitea = c.summarize_message(sub_gitea, {builds[0]}, [])
+    assert "not_group_glob" not in result_gitea
     assert (
         "https://openqa.opensuse.org/tests/overview/badge?build=1.1&distri=opensuse&version=Tumbleweed&label=Build+1.1"
-        in result
+        in result_gitea
+    )
+
+    result_obs = c.summarize_message(OBSCommentable(124), {builds[0]}, [])
+    assert "not_group_glob" not in result_obs
+    assert (
+        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&distri=opensuse&version=Tumbleweed&label=Build+1.1)"
+        in result_obs
     )
 
 
@@ -643,7 +669,7 @@ def test_generate_comment_raw_openqa_jobs(mock_args: Namespace) -> None:
         {"id": 2, "state": "running", "build": "1"},
     ]
     # Should postpone due to running job
-    assert c.generate_comment(MagicMock(), raw_jobs) is None
+    assert c.generate_comment(OBSCommentable(124), raw_jobs) is None
 
     # All done
     raw_jobs_done = [
@@ -651,7 +677,7 @@ def test_generate_comment_raw_openqa_jobs(mock_args: Namespace) -> None:
         {"id": 2, "state": "done", "result": "softfailed", "build": "1"},
     ]
     c.client.openqa.baseurl = "https://openqa"
-    res = c.generate_comment(MagicMock(), raw_jobs_done)
+    res = c.generate_comment(OBSCommentable(124), raw_jobs_done)
     assert res is not None
     msg, state = res
     assert state == "passed"
@@ -789,8 +815,9 @@ def test_summarize_message_detailed_comments(
     mocker.patch("openqabot.config.settings.allow_development_groups", new=allow_devel)
     detailed_comment_mocks["client"].return_value.get_job_group_info.return_value = group_info
     c = Commenter(mock_args, submissions=[])
+
     builds = {BuildIdentifier.from_job(j) for j in jobs if "build" in j}
-    result = c.summarize_message(builds, jobs)
+    result = c.summarize_message(OBSCommentable(124), builds, jobs)
     for text in expected_contains:
         assert text in result
     for text in expected_not_contains:
@@ -814,7 +841,18 @@ def test_summarize_message_detailed_comments_duplicate_group(
         {"build": "1.1", "status": "failed", "group_id": 42},
     ]
     builds = {BuildIdentifier.from_job(j) for j in jobs if "build" in j}
-    result = c.summarize_message(builds, jobs)
-    assert "Functional" in result
-    assert result.count("![Functional Test Results]") == 1
-    assert "label=Functional" in result
+
+    sub_gitea = MagicMock(is_gitea=True)
+    sub_gitea.format_link = lambda label, url, image_url=None: (
+        f"[![{label}]({image_url})]({url})" if image_url else f"[{label}]({url})"
+    )
+
+    result_gitea = c.summarize_message(sub_gitea, builds, jobs)
+    assert "Functional" in result_gitea
+    assert result_gitea.count("![Functional Test Results]") == 1
+    assert "label=Functional" in result_gitea
+
+    result_obs = c.summarize_message(OBSCommentable(124), builds, jobs)
+    assert "Functional" in result_obs
+    assert result_obs.count("[Functional Test Results]") == 1
+    assert "label=Functional" not in result_obs

--- a/tests/test_pullrequest.py
+++ b/tests/test_pullrequest.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from openqabot.types.pullrequest import PullRequest
+from openqabot.types.pullrequest import OBSCommentable, PullRequest
 
 
 def test_pull_request_has_labels() -> None:
@@ -64,6 +64,19 @@ def test_pull_request_id_property() -> None:
     )
     assert pr.id == 124
     assert pr.generate_webhook_id() == "gitea:pr:124"
+    assert pr.is_gitea is True
+    assert pr.format_link("Label", "http://url", "http://img") == "[![Label](http://img)](http://url)"
+    assert pr.format_link("Label", "http://url") == "[Label](http://url)"
+
+
+def test_obs_commentable() -> None:
+    """Verify that OBSCommentable correctly implements CommentableProtocol."""
+    obs = OBSCommentable(12345, "http://obs/12345")
+    assert obs.id == 12345
+    assert obs.url == "http://obs/12345"
+    assert obs.is_gitea is False
+    assert obs.format_link("Label", "http://url", "http://img") == "[Label](http://url)"
+    assert obs.format_link("Label", "http://url") == "[Label](http://url)"
 
 
 def test_create_from_json_invalid_data(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -73,6 +73,13 @@ def test_sub_normal() -> None:
     assert repr(sub) == "<Submission: smelt:SUSE:Maintenance:24618:274060>"
     assert sub.id == 24618
     assert sub.rrid == "SUSE:Maintenance:24618:274060"
+    assert sub.is_gitea is False
+    assert sub.format_link("Label", "http://url", "http://img") == "[Label](http://url)"
+    assert sub.format_link("Label", "http://url") == "[Label](http://url)"
+    sub_git = Submission({**test_data, "type": "git"})
+    assert sub_git.is_gitea is True
+    assert sub_git.format_link("Label", "http://url", "http://img") == "[![Label](http://img)](http://url)"
+    assert sub_git.format_link("Label", "http://url") == "[Label](http://url)"
     assert sub.channels == [
         Repos(product="SLE-Module-Public-Cloud", version="15-SP4", arch="x86_64"),
         Repos(product="SLE-Module-Public-Cloud", version="15-SP4", arch="aarch64"),


### PR DESCRIPTION
Motivation:
OBS's Markdown engine sanitizes all HTML, causing openQA badge image tags to
render as ugly, raw XML/HTML tags. We need clean, clickable text links instead.

Design Choices:
- Added keyword-only 'is_gitea' flag to comment-generation functions
- Render Markdown badges for Gitea and plain text links for OBS
- Updated commenter and gitea-trigger tests to assert correct output formats

Benefits:
- Highly polished, human-readable test summary comments in OBS request history
- Retains rich visual status badge presentation inside Gitea pull requests

Related issue: https://progress.opensuse.org/issues/197903