### PR TITLE
fix: regression from ec9ecad0, prevent dry run QEM writes

### DIFF
--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -52,6 +52,10 @@ class OpenQABot:
             log.warning("Skipping dashboard update: No valid openQA configuration found for data: %s", data)
             return
 
+        if self.dry:
+            log.info("Dry run: Would update QEM Dashboard for %s with data: %s", api, data)
+            return
+
         res = dashboard.put(api, headers=config_module.settings.dashboard_token_dict, json=data)
         res_id = res.json().get("id", "unknown")
         log.info("Dashboard update successful for %s: Status %s, Database ID %s", api, res.status_code, res_id)

--- a/tests/test_openqabot.py
+++ b/tests/test_openqabot.py
@@ -247,3 +247,17 @@ def test_post_qem_success(mocked_openqa_bot: Namespace, mocker: MockerFixture) -
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == f"{QEM_DASHBOARD}{test_api}"
+
+
+@responses.activate
+@pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
+def test_post_qem_dry(mocked_openqa_bot: Namespace, mocker: MockerFixture) -> None:
+    bot = OpenQABot(mocked_openqa_bot)
+    bot.dry = True
+    bot.openqa = mocker.Mock(spec=OpenQAInterface)
+    test_api = "api/jobs/incident/1"
+    test_data = {"status": "passed", "job_id": 999}
+
+    bot.post_qem(test_data, test_api)
+
+    assert len(responses.calls) == 0


### PR DESCRIPTION
Motivation:
During dry runs, the bot skipped posting openQA jobs but still posted
incident settings to the QEM Dashboard, creating a "phantom schedule".
This fixes a regression introduced by commit ec9ecad0 which removed
the early dry-run return from the main loop.

Design Choices:
Added a check for self.dry inside post_qem to log the action and return
early instead of making a PUT request to the dashboard.

Benefits:
Ensures dry runs are completely side-effect free and prevents submissions
from getting stuck in a half-scheduled state without running tests.

Related issue: https://progress.opensuse.org/issues/202824
