### PR TITLE
fix: correct a bug in submission priority setup

### DIFF
--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -198,7 +198,7 @@ class Submissions(BaseConf):
             **({"RRID": sub.rrid} if sub.rrid else {}),
         }
 
-    def get_priority(self, ctx: SubContext) -> int | None:  # noqa: PLR6301
+    def get_priority(self, ctx: SubContext) -> int:  # noqa: PLR6301
         """Calculate job priority for a submission."""
         sub, flavor, data = ctx.sub, ctx.flavor, ctx.data
         if "override_priority" in data:
@@ -268,8 +268,7 @@ class Submissions(BaseConf):
         repos = {c for c in all_repos if c.product_version == version} or all_repos
         settings["INCIDENT_REPO"] = ",".join(sorted(self.make_repo_url(ctx.sub, chan) for chan in repos))
 
-        if prio := self.get_priority(ctx):
-            settings["_PRIORITY"] = prio
+        settings["_PRIORITY"] = self.get_priority(ctx)
 
         if not self.apply_params_expand(settings, ctx.data, ctx.flavor):
             return None

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -201,15 +201,15 @@ class Submissions(BaseConf):
     def get_priority(self, ctx: SubContext) -> int | None:  # noqa: PLR6301
         """Calculate job priority for a submission."""
         sub, flavor, data = ctx.sub, ctx.flavor, ctx.data
-        if delta_prio := data.get("override_priority", 0):
-            delta_prio -= 50
+        if "override_priority" in data:
+            delta_prio = data["override_priority"] - 50
         else:
             delta_prio = 5 if flavor.endswith("Minimal") else 10
             if sub.emu:
                 delta_prio = -20
-            if sub.priority:
+            if sub.priority is not None:
                 delta_prio -= sub.priority // settings.priority_scale
-        return settings.base_prio + delta_prio if delta_prio else None
+        return settings.base_prio + delta_prio
 
     def apply_params_expand(self, settings: dict[str, Any], data: dict[str, Any], flavor: str) -> bool:  # noqa: PLR6301
         """Apply 'params_expand' settings from metadata."""

--- a/tests/test_submissions_handle.py
+++ b/tests/test_submissions_handle.py
@@ -506,15 +506,17 @@ def test_process_sub_context_norepfound(mocker: MockerFixture) -> None:
     [
         ({"emu": True, "staging": False}, {}, 30),
         ({"staging": False, "emu": False}, {}, 60),
-        ({"staging": False, "emu": False}, {"override_priority": 50}, None),
+        ({"staging": False, "emu": False}, {"override_priority": 50}, 50),
         ({}, {"override_priority": 100}, 100),
         ({"staging": False}, {"flavor": "Minimal"}, 55),
         ({"staging": False, "priority": 100}, {}, 55),
         ({"staging": False, "emu": True, "priority": 100}, {}, 25),
+        ({"priority": 200}, {}, 50),
+        ({}, {"override_priority": 0}, 0),
     ],
 )
 def test_handle_submission_priority_logic(
-    mocker: MockerFixture, inc_kwargs: dict, flavor_kwargs: dict, expected_prio: int | None
+    mocker: MockerFixture, inc_kwargs: dict, flavor_kwargs: dict, expected_prio: int
 ) -> None:
     flavor = flavor_kwargs.pop("flavor", "AAA")
     sub = MockSubmission(id=1, channels=[Repos("SLES", "15-SP3", "x86_64")], rev_fallback_value=123, **inc_kwargs)
@@ -527,10 +529,7 @@ def test_handle_submission_priority_logic(
     mocker.patch.object(submissions_obj, "is_scheduled_job", return_value=False)
     result = submissions_obj.handle_submission(ctx, cfg)
     assert result is not None
-    if expected_prio is None:
-        assert "_PRIORITY" not in result["openqa"]
-    else:
-        assert result["openqa"]["_PRIORITY"] == expected_prio
+    assert result["openqa"]["_PRIORITY"] == expected_prio
 
 
 def test_handle_submission_pc_tools_image_success(mocker: MockerFixture) -> None:


### PR DESCRIPTION
- If override_priority as been set to 0 explicitely, delta_prio stays set to 0 instead of the intended
-50, then the job end-up with the default priority of 60 instead of 0.

- Currently if the priority in smelt is between 200 and 219, then 200 // returns 10,
to which we substract 10 then delta_prio returns 0 and the
method returns none, so the job theoritically gets the default Openqa prio of 50. the current
change makes the method return 50 (base_prio) which has the same end
result, but I find this clearer.