### PR TITLE
fix(mergify): prevent endless dependabot PR recreation loops

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "waiting"
@@ -24,6 +26,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "waiting"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,25 +34,13 @@ pull_request_rules:
       - and: *base_checks
       - and:
           - author=dependabot[bot]
-          - "label=waited"
     actions:
       queue:
       merge:
         method: squash
-  - name: Wait for some time before validating merge
-    actions:
-      label:
-        add:
-          - waited
-        remove:
-          - waiting
+  - name: continuously rebase pull requests when it's labeled with `rebase`
     conditions:
-      - and:
-          - updated-at<4 days ago
-          - author=dependabot[bot]
-  - name: continuously rebase pull requests when it's labeled with `rebase` or `waited`
-    conditions:
-      - label~=rebase|waited
+      - label=rebase
     actions:
       rebase:
         bot_account: suse-qe-tools-mergify


### PR DESCRIPTION
Motivation:
Dependabot's daily updates reset Mergify's 4-day wait timer. This causes
the PRs to close and reopen in an endless loop.

Design Choices:
Remove the 4-day wait rule and use Dependabot's built-in 7-day cooldown
instead, which naturally handles supply chain risks.

Benefits:
Stops the endless PR loops while maintaining secure automated updates.

Similar to https://github.com/openSUSE/qem-dashboard/pull/3362