### PR TITLE
feat: support sequential execution of multiple commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,8 @@ test-integration: ## Automatically start environment, run integration tests, and
 
 .PHONY: test-integration-payload
 test-integration-payload: env-dashboard-wait  ## Test qem-bot against a local dashboard instance
-	$(QEM_BOT_BASE_CMD) gitea-sync
-	$(QEM_BOT_BASE_CMD) smelt-sync
-	$(QEM_BOT_BASE_CMD) --dry submissions-run
-	$(QEM_BOT_BASE_CMD) --dry sub-approve
+	$(QEM_BOT_BASE_CMD) gitea-sync smelt-sync
+	$(QEM_BOT_BASE_CMD) --dry submissions-run sub-approve
 
 .PHONY: setup-hooks
 setup-hooks: ## Install pre-commit git hooks

--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ updates information about submissions and related openQA tests.
 
     >>> qem-bot.py --help
 
-    Usage: qem-bot.py [OPTIONS] COMMAND [ARGS]...
+    Usage: qem-bot.py [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
 
     QEM-Dashboard, SMELT, Gitea and openQA connector
 

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -36,6 +36,7 @@ app = typer.Typer(
     help="QEM-Dashboard, SMELT, Gitea and openQA connector",
     no_args_is_help=True,
     add_completion=False,
+    chain=True,
 )
 log = logging.getLogger("bot")
 
@@ -274,7 +275,8 @@ def full_run(
     args.disable_aggregates = False
 
     bot = OpenQABot(args)
-    sys.exit(bot())
+    if (ret := bot()) != 0:
+        sys.exit(ret)
 
 
 @app.command("submissions-run")
@@ -303,7 +305,8 @@ def submissions_run(
     args.disable_aggregates = True
 
     bot = OpenQABot(args)
-    sys.exit(bot())
+    if (ret := bot()) != 0:
+        sys.exit(ret)
 
 
 @app.command("updates-run")
@@ -323,7 +326,8 @@ def updates_run(
     args.disable_submissions = True
 
     bot = OpenQABot(args)
-    sys.exit(bot())
+    if (ret := bot()) != 0:
+        sys.exit(ret)
 
 
 @app.command("smelt-sync")
@@ -333,7 +337,8 @@ def smelt_sync(ctx: typer.Context) -> None:
     _require_token(args)
 
     syncer = SMELTSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("gitea-sync")
@@ -382,7 +387,8 @@ def gitea_sync(  # noqa: PLR0913
     args.skip_initial_sync = skip_initial_sync
 
     syncer = GiteaSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("gitea-trigger")
@@ -423,7 +429,8 @@ def gitea_trigger(  # noqa: PLR0913
     )
 
     syncer = GiteaTrigger(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("sub-approve")
@@ -465,7 +472,8 @@ def sub_approve(  # noqa: PLR0913
     )
 
     approve = Approver(args)
-    sys.exit(approve())
+    if (ret := approve()) != 0:
+        sys.exit(ret)
 
 
 @app.command("sub-comment")
@@ -490,7 +498,8 @@ def sub_comment(
 
     submissions = get_submissions()
     comment = Commenter(args, submissions)
-    sys.exit(comment())
+    if (ret := comment()) != 0:
+        sys.exit(ret)
 
 
 @app.command("sub-sync-results")
@@ -500,7 +509,8 @@ def sub_sync_results(ctx: typer.Context) -> None:
     _require_token(args)
 
     syncer = SubResultsSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("aggr-sync-results")
@@ -510,7 +520,8 @@ def aggr_sync_results(ctx: typer.Context) -> None:
     _require_token(args)
 
     syncer = AggregateResultsSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("increment-approve")
@@ -647,7 +658,8 @@ def increment_approve(  # noqa: PLR0913
     )
 
     approve = IncrementApprover(args)
-    sys.exit(approve())
+    if (ret := approve()) != 0:
+        sys.exit(ret)
 
 
 @app.command("repo-diff")
@@ -667,7 +679,8 @@ def repo_diff(
     args.repo_b = repo_b
 
     repo_diff_obj = RepoDiff(args)
-    sys.exit(repo_diff_obj())
+    if (ret := repo_diff_obj()) != 0:
+        sys.exit(ret)
 
 
 @app.command("amqp")
@@ -686,4 +699,5 @@ def amqp_cmd(
         args.url = config_module.settings.amqp_url
 
     amqp_obj = AMQP(args)
-    sys.exit(amqp_obj())
+    if (ret := amqp_obj()) != 0:
+        sys.exit(ret)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -345,3 +345,63 @@ def test_main_fake_data(mocker: MockerFixture, tmp_path: Path) -> None:
     result = runner.invoke(app, ["--fake-data", "--token", "foo", "--configs", str(tmp_path), "full-run"])
     assert result.exit_code == 0
     setup_mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("cmd", "mock_path"),
+    [
+        ("full-run", "openqabot.args.OpenQABot"),
+        ("submissions-run", "openqabot.args.OpenQABot"),
+        ("updates-run", "openqabot.args.OpenQABot"),
+        ("smelt-sync", "openqabot.args.SMELTSync"),
+        ("gitea-sync", "openqabot.args.GiteaSync"),
+        ("gitea-trigger", "openqabot.args.GiteaTrigger"),
+        ("sub-approve", "openqabot.args.Approver"),
+        ("sub-comment", "openqabot.args.Commenter"),
+        ("sub-sync-results", "openqabot.args.SubResultsSync"),
+        ("aggr-sync-results", "openqabot.args.AggregateResultsSync"),
+        ("increment-approve", "openqabot.args.IncrementApprover"),
+        ("repo-diff", "openqabot.args.RepoDiff"),
+        ("amqp", "openqabot.args.AMQP"),
+    ],
+)
+def test_command_failure_exits(mocker: MockerFixture, tmp_path: Path, cmd: str, mock_path: str) -> None:
+    """Test that each command correctly exits with 1 when it fails."""
+    if cmd == "sub-comment":
+        mocker.patch("openqabot.args.get_submissions", return_value=[])
+
+    config_file = tmp_path / "trigger.yml"
+    config_file.write_text("trigger_config: []")
+
+    mock_obj = mocker.patch(mock_path)
+    mock_obj.return_value.return_value = 1
+
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), cmd])
+    assert result.exit_code == 1
+    mock_obj.assert_called_once()
+
+
+def test_command_chaining_success(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test executing multiple commands sequentially when they all succeed."""
+    bot = mocker.patch("openqabot.args.OpenQABot")
+    bot.return_value.return_value = 0
+    syncer = mocker.patch("openqabot.args.SMELTSync")
+    syncer.return_value.return_value = 0
+
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "full-run", "smelt-sync"])
+    assert result.exit_code == 0
+    bot.assert_called_once()
+    syncer.assert_called_once()
+
+
+def test_command_chaining_fail_fast(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test executing multiple commands sequentially halts on first failure."""
+    bot = mocker.patch("openqabot.args.OpenQABot")
+    bot.return_value.return_value = 1
+    syncer = mocker.patch("openqabot.args.SMELTSync")
+    syncer.return_value.return_value = 0
+
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "full-run", "smelt-sync"])
+    assert result.exit_code == 1
+    bot.assert_called_once()
+    syncer.assert_not_called()


### PR DESCRIPTION
Motivation:
Running each CLI subcommand in separate CI pipelines incurs massive
environment and container image download overhead. Supporting multiple
commands sequentially in a single run drastically reduces setup runtime.

Design Choices:
Configure Typer with chain=True on the main app to support command chaining.
Refactor each subcommand to exit with sys.exit only on non-zero return codes,
allowing successful commands to return naturally and proceed down the chain.

Benefits:
Saves substantial GitLab CI pipeline runtime and container registry bandwidth.
Preserves existing fast-fail error propagation across sequential commands.