### PR TITLE
perf(approver): parallelize submission filtering and approval

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import operator
 import re
 import string
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from enum import Enum, auto
 from functools import lru_cache
@@ -149,7 +150,10 @@ class Approver:
         )
 
         overall_result = True
-        submissions_to_approve = [sub for sub in subreqs if self.approvable(sub)]
+        with ThreadPoolExecutor() as executor:
+            approvable_flags = list(executor.map(self.approvable, subreqs))
+
+        submissions_to_approve = [sub for sub, ok in zip(subreqs, approvable_flags, strict=True) if ok]
 
         log.info("Submissions to approve:")
         for sub in submissions_to_approve:
@@ -157,8 +161,9 @@ class Approver:
 
         if not self.dry:
             osc.conf.get_config(override_apiurl=config.settings.obs_url)
-            for sub in submissions_to_approve:
-                overall_result &= self.approve(sub)
+            with ThreadPoolExecutor() as executor:
+                for result in executor.map(self.approve, submissions_to_approve):
+                    overall_result &= result
 
         log.info("Submission approval process finished")
 

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -151,7 +151,7 @@ class Approver:
 
         overall_result = True
         with ThreadPoolExecutor() as executor:
-            approvable_flags = list(executor.map(self.approvable, subreqs))
+            approvable_flags = list(executor.map(self.approvable, subreqs, timeout=config.settings.url_timeout))
 
         submissions_to_approve = [sub for sub, ok in zip(subreqs, approvable_flags, strict=True) if ok]
 
@@ -162,7 +162,7 @@ class Approver:
         if not self.dry:
             osc.conf.get_config(override_apiurl=config.settings.obs_url)
             with ThreadPoolExecutor() as executor:
-                for result in executor.map(self.approve, submissions_to_approve):
+                for result in executor.map(self.approve, submissions_to_approve, timeout=config.settings.url_timeout):
                     overall_result &= result
 
         log.info("Submission approval process finished")


### PR DESCRIPTION
Motivation:
Approving multiple submissions is currently a sequential process. Each
submission requires multiple network requests to check openQA results
and aggregate statuses during the filtering phase, followed by further
network requests to OBS or Gitea during the approval phase.

Design Choices:
Introduce `concurrent.futures.ThreadPoolExecutor` to handle both the
`approvable` check and the `approve` call concurrently across all
submissions. Using `strict=True` in `zip` ensures alignment between
input submissions and their evaluation results.

Benefits:
Significantly reduces the time spent in the approval loop when multiple
incidents or pull requests are processed, especially when network
latency is high.

Together with the previous comments this brings the runtime for one
sub-approve cycle down from 135907±5291.28 ms to 20724±384.48 ms which
is a big 84% improvement (speedup 6.6x).