### PR TITLE
feat: add --max-workers CLI argument for parallel processing

### DIFF
--- a/openqabot/aggrsync.py
+++ b/openqabot/aggrsync.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from itertools import chain
 from logging import getLogger
 
+from . import config
 from .loader.config import read_products
 from .loader.qem import get_aggregate_settings_data
 from .syncres import SyncRes
@@ -30,7 +31,7 @@ class AggregateResultsSync(SyncRes):
         update_setting = list(chain.from_iterable(get_aggregate_settings_data(product) for product in self.product))
 
         job_results = {}
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
             future_j = {executor.submit(self.client.get_jobs, f): f for f in update_setting}
             for future in as_completed(future_j):
                 job_results[future_j[future]] = future.result()

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     openqa_instance: str = Field(default="https://openqa.suse.de", alias="OPENQA_INSTANCE")
     singlearch: Path = Field(default=Path("/etc/openqabot/singlearch.yml"), alias="QEM_BOT_SINGLEARCH")
     retry: int = Field(default=2, alias="QEM_BOT_RETRY")
+    max_workers: int | None = Field(default=None, alias="QEM_BOT_MAX_WORKERS")
     approve_comment: bool = Field(default=False, alias="QEM_BOT_APPROVE_COMMENT")
 
     # App-specific settings

--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -178,7 +178,7 @@ def get_submission_from_smelt(incident: int) -> dict[str, Any] | None:
 
 def get_submissions(active: set[int]) -> list[dict[str, Any]]:
     """Fetch detailed information for a set of submissions from SMELT in parallel."""
-    with futures.ThreadPoolExecutor() as executor:
+    with futures.ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
         future_sub = [executor.submit(get_submission_from_smelt, inc) for inc in active]
         submissions = (future.result() for future in futures.as_completed(future_sub))
         return [sub for sub in submissions if sub]

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -80,7 +80,7 @@ class OpenQABot:
             else:
                 self.post_qem(job["qem"], job["api"])
 
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=config_module.settings.max_workers) as executor:
             wait([executor.submit(poster, job) for job in post])
         log.info("Bot run completed")
         return 0

--- a/openqabot/subsyncres.py
+++ b/openqabot/subsyncres.py
@@ -7,6 +7,7 @@ from concurrent import futures
 from itertools import chain
 from logging import getLogger
 
+from . import config
 from .loader.qem import get_active_submissions, get_submission_settings_data
 from .syncres import SyncRes
 
@@ -28,7 +29,7 @@ class SubResultsSync(SyncRes):
         log.info("Synchronizing results for %s active submissions...", len(self.active))
         submissions = list(chain.from_iterable(get_submission_settings_data(sub) for sub in self.active))
         full = {}
-        with futures.ThreadPoolExecutor() as executor:
+        with futures.ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
             future_result = {executor.submit(self.client.get_jobs, f): f for f in submissions}
             for future in futures.as_completed(future_result):
                 full[future_result[future]] = future.result()


### PR DESCRIPTION
Motivation:
Different execution environments (local vs. CI/server) have different
concurrency limits and available resources. Providing a way to configure
the maximum number of worker threads allows for fine-tuning performance
and avoiding potential resource exhaustion or API rate limiting.

Design Choices:
Added a global max_workers setting in openqabot/config.py with a
corresponding --max-workers CLI option in openqabot/args.py. Propagated
this setting to all ThreadPoolExecutor instances across the codebase.
If not specified, it defaults to None, letting Python's concurrent.futures
package use its default (typically min(32, os.cpu_count() + 4)).

Benefits:
Users can now limit or increase the concurrency level based on their
needs. This also ensures consistency across all commands that utilize
parallel processing (syncing, triggering, commenting, etc.).