### PR TITLE
fix(approver): revert map-level timeout

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -151,7 +151,7 @@ class Approver:
 
         overall_result = True
         with ThreadPoolExecutor() as executor:
-            approvable_flags = list(executor.map(self.approvable, subreqs, timeout=config.settings.url_timeout))
+            approvable_flags = list(executor.map(self.approvable, subreqs))
 
         submissions_to_approve = [sub for sub, ok in zip(subreqs, approvable_flags, strict=True) if ok]
 
@@ -162,7 +162,7 @@ class Approver:
         if not self.dry:
             osc.conf.get_config(override_apiurl=config.settings.obs_url)
             with ThreadPoolExecutor() as executor:
-                for result in executor.map(self.approve, submissions_to_approve, timeout=config.settings.url_timeout):
+                for result in executor.map(self.approve, submissions_to_approve):
                     overall_result &= result
 
         log.info("Submission approval process finished")


### PR DESCRIPTION
Motivation:
The global timeout parameter on ThreadPoolExecutor.map acting on
submissions_to_approve was acting as a cumulative deadline. This caused the
entire queue approval to raise TimeoutError and abort when remote hosts were
slow or many requests were processed.

Design Choices:
Revert commit 0d1c75fd which introduced timeout in executor.map. Individual
request timeouts can be handled more robustly at the request session level.

Benefits:
Prevents global pipeline failures and allows existing retry mechanism to handle
spurious network issues per request, ensuring that valid approvals can proceed.