### PR TITLE
feat(config): centralize settings in config.yml

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,17 +58,17 @@ updates information about submissions and related openQA tests.
     │                                                  database                    │
     │                                                  [env var: OPENQA_INSTANCE]  │
     │                                                  [default:                   │
-    │                                                  https://openqa.suse.de]     │
+    │                                                  (https://openqa.suse.de)]   │
     │ --singlearch       -s                   PATH     Yaml config with list of    │
     │                                                  singlearch packages for     │
     │                                                  submissions run             │
     │                                                  [env var:                   │
     │                                                  QEM_BOT_SINGLEARCH]         │
     │                                                  [default:                   │
-    │                                                  /etc/openqabot/singlearch.… │
+    │                                                  (/etc/openqabot/singlearch… │
     │ --retry            -r                   INTEGER  Number of retries           │
     │                                                  [env var: QEM_BOT_RETRY]    │
-    │                                                  [default: 2]                │
+    │                                                  [default: (2)]              │
     │ --help                                           Show this message and exit. │
     ╰──────────────────────────────────────────────────────────────────────────────╯
     ╭─ Commands ───────────────────────────────────────────────────────────────────╮

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -8,7 +8,7 @@ import logging
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Annotated
+from typing import Annotated, Any
 
 import responses
 import typer
@@ -101,6 +101,21 @@ max_detailed_comment_entries_option = Annotated[
 ]
 
 
+def _default(field: str) -> object:
+    """Return a Settings field default so CLI help mirrors config.py."""
+    return config_module.Settings.model_fields[field].get_default(call_default_factory=True)
+
+
+def _apply_cli_overrides(
+    settings: config_module.Settings,
+    overrides: dict[str, Any],
+) -> None:
+    """Override settings with CLI options that were explicitly provided."""
+    for name, value in overrides.items():
+        if value is not None and value is not False:
+            setattr(settings, name, value)
+
+
 def _apply_detailed_comment_options(
     args: SimpleNamespace,
     *,
@@ -184,33 +199,41 @@ def main(  # noqa: PLR0913
         typer.Option("-g", "--gitea-token", envvar="QEM_BOT_GITEA_TOKEN", help="Token for Gitea api"),
     ] = None,
     openqa_instance: Annotated[
-        str,
+        str | None,
         typer.Option(
             "-i",
             "--openqa-instance",
             envvar="OPENQA_INSTANCE",
             help="The openQA instance to use\n Other instances than OSD do not update dashboard database",
+            show_default=str(_default("openqa_instance")),
         ),
-    ] = "https://openqa.suse.de",
+    ] = None,
     singlearch: Annotated[
-        Path,
+        Path | None,
         typer.Option(
             "-s",
             "--singlearch",
             envvar="QEM_BOT_SINGLEARCH",
             help="Yaml config with list of singlearch packages for submissions run",
+            show_default=str(_default("singlearch")),
         ),
-    ] = Path("/etc/openqabot/singlearch.yml"),
-    retry: Annotated[int, typer.Option("-r", "--retry", envvar="QEM_BOT_RETRY", help="Number of retries")] = 2,
+    ] = None,
+    retry: Annotated[
+        int | None,
+        typer.Option(
+            "-r",
+            "--retry",
+            envvar="QEM_BOT_RETRY",
+            help="Number of retries",
+            show_default=str(_default("retry")),
+        ),
+    ] = None,
 ) -> None:
     """QEM-Dashboard, SMELT, Gitea and openQA connector."""
     # Configure logging
     log_obj = create_logger("bot")
     if debug:
         log_obj.setLevel(logging.DEBUG)
-
-    # Update global configuration
-    config_module.settings.insecure = insecure
 
     # Check if help is in the arguments
     if any(arg in sys.argv for arg in ctx.help_option_names):
@@ -219,6 +242,23 @@ def main(  # noqa: PLR0913
     if not configs.exists():
         log.error("Configuration error: %s does not exist", configs)
         sys.exit(1)
+
+    # Settings precedence: config.yml < explicit CLI options; env/.env already
+    # applied at Settings construction. settings stays the single source of truth.
+    settings = config_module.settings
+    settings.load_config_yml(configs if configs.is_dir() else configs.parent)
+    _apply_cli_overrides(
+        settings,
+        {
+            "dry": dry,
+            "insecure": insecure,
+            "openqa_instance": openqa_instance,
+            "token": token,
+            "gitea_token": gitea_token,
+            "singlearch": singlearch,
+            "retry": retry,
+        },
+    )
 
     if fake_data:
         setup_mock_responses()
@@ -229,23 +269,19 @@ def main(  # noqa: PLR0913
 
         ctx.call_on_close(teardown_mocks)
 
-    # Store global options in context
+    # Expose the resolved settings to subcommands via the context
     ctx.obj = SimpleNamespace(
         configs=configs,
-        dry=dry,
+        dry=settings.dry,
         fake_data=fake_data,
         dump_data=dump_data,
         debug=debug,
-        insecure=insecure,
-        token=token,
-        gitea_token=gitea_token,
-        singlearch=singlearch,
-        retry=retry,
+        insecure=settings.insecure,
+        token=settings.token,
+        gitea_token=settings.gitea_token,
+        singlearch=settings.singlearch,
+        retry=settings.retry,
     )
-
-    config_module.settings.openqa_instance = openqa_instance
-    config_module.settings.dry = dry
-    config_module.settings.token = token
 
 
 @app.command()

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -8,13 +8,17 @@ Most of these constants can be overridden by environment variables.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
 
 import osc.conf
+import yaml
 from pydantic import Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, SettingsConfigDict, YamlConfigSettingsSource
+
+_log = logging.getLogger("bot")
 
 
 def get_default_obs_url() -> str:
@@ -37,6 +41,26 @@ class Settings(BaseSettings):
         This explicit constructor helps type checkers like 'ty' recognize valid parameters.
         """
         super().__init__(*args, **kwargs)
+
+    def load_config_yml(self, configs_dir: Path) -> None:
+        """Apply overrides from config.yml in configs_dir onto this instance.
+
+        Uses pydantic-settings' native YAML source so parsing, aliasing and type
+        coercion match the rest of the settings; missing or malformed files are
+        logged and ignored.
+        """
+        config_yml = configs_dir / "config.yml"
+        if not config_yml.is_file():
+            return
+        try:
+            data = YamlConfigSettingsSource(self.__class__, yaml_file=config_yml)()
+        except (OSError, ValueError, yaml.YAMLError):
+            _log.exception("Failed to load %s", config_yml)
+            return
+        by_alias = {f.alias: n for n, f in self.__class__.model_fields.items() if f.alias}
+        for key, value in data.items():
+            if name := by_alias.get(key, key if key in self.__class__.model_fields else None):
+                setattr(self, name, value)
 
     # Global options
     configs: Path = Field(default=Path("/etc/openqabot"), alias="QEM_BOT_CONFIGS")

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -14,6 +14,7 @@ import typer
 from typer.testing import CliRunner
 
 from openqabot.args import app, main
+from openqabot.config import settings
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -345,3 +346,40 @@ def test_main_fake_data(mocker: MockerFixture, tmp_path: Path) -> None:
     result = runner.invoke(app, ["--fake-data", "--token", "foo", "--configs", str(tmp_path), "full-run"])
     assert result.exit_code == 0
     setup_mock.assert_called_once()
+
+
+def test_config_yml_feeds_settings_and_context(mocker: MockerFixture, tmp_path: Path) -> None:
+    """config.yml values reach settings and the subcommand context; error handling covered in test_config."""
+    (tmp_path / "config.yml").write_text("OPENQA_INSTANCE: https://yaml.openqa.org\nQEM_BOT_RETRY: 7\n")
+    bot = mocker.patch("openqabot.args.OpenQABot")
+    bot.return_value.return_value = 0
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "full-run"])
+    assert result.exit_code == 0
+    assert settings.openqa_instance == "https://yaml.openqa.org"
+    assert settings.retry == 7
+    assert bot.call_args[0][0].retry == 7
+
+
+def test_cli_options_override_config_yml(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Explicit CLI options take precedence over config.yml and update settings."""
+    (tmp_path / "config.yml").write_text("OPENQA_INSTANCE: https://yaml.openqa.org\n")
+    bot = mocker.patch("openqabot.args.OpenQABot")
+    bot.return_value.return_value = 0
+    result = runner.invoke(
+        app,
+        [
+            "--token",
+            "foo",
+            "--configs",
+            str(tmp_path),
+            "--insecure",
+            "--dry",
+            "-i",
+            "https://override.openqa",
+            "full-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert settings.insecure is True
+    assert settings.dry is True
+    assert settings.openqa_instance == "https://override.openqa"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,3 +105,34 @@ def test_insecure_setting() -> None:
 
     settings = Settings(QEM_BOT_INSECURE=False)
     assert settings.insecure is False
+
+
+def test_load_config_yml_applies_aliases_and_names(tmp_path: Path) -> None:
+    """config.yml overrides settings via aliases and field names with type coercion."""
+    (tmp_path / "config.yml").write_text(
+        "openqa_instance: https://custom.openqa\nOBS_URL: https://custom.obs\nQEM_BOT_RETRY: '5'\nUNKNOWN: x\n"
+    )
+    settings = Settings()
+    settings.load_config_yml(tmp_path)
+    assert settings.openqa_instance == "https://custom.openqa"
+    assert settings.obs_url == "https://custom.obs"
+    assert settings.retry == 5
+
+
+def test_load_config_yml_missing_file_is_noop(tmp_path: Path) -> None:
+    """A missing config.yml leaves defaults untouched."""
+    settings = Settings()
+    settings.load_config_yml(tmp_path)
+    assert settings.retry == Settings().retry
+
+
+@pytest.mark.parametrize(
+    ("content", "reason"),
+    [("- a\n- b\n", "non-dict"), ("bad: [unclosed", "invalid syntax")],
+)
+def test_load_config_yml_malformed_is_ignored(tmp_path: Path, content: str, reason: str) -> None:
+    """Malformed config.yml is logged and ignored, keeping defaults."""
+    (tmp_path / "config.yml").write_text(content)
+    settings = Settings()
+    settings.load_config_yml(tmp_path)
+    assert settings.retry == Settings().retry, reason


### PR DESCRIPTION
Motivation:
Avoid duplication of configuration parameters like obs_url in metadata files.

Design Choices:
Implement update_from_dict on Settings and load config.yml in args.py using
ruamel.yaml. Clean up duplicated Typer defaults in args.py to ensure correct
fallback priority.

Benefits:
Simplifies the metadata repository and enforces clean configuration fallback.