### PR TITLE
refactor(loader/gitea): remove unnecessary handling of "no bot-user"

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -259,37 +259,25 @@ def review_pr(  # noqa: PLR0913
 ) -> None:
     """Post a review or comment on a Gitea PR."""
     bot_user = config.settings.git_review_bot_user
-    if bot_user:
-        review_url = comments_url(repo_name, pr_number)
-        review_cmd, commit_str = _approval_identifiers(bot_user, commit_id, approve=approve)
-        review_data = {"body": f"{review_cmd}\n{msg}\n{commit_str}"}
-    else:
-        review_url = reviews_url(repo_name, pr_number)
-        review_data = {
-            "body": msg,
-            "comments": [],
-            "commit_id": commit_id,
-            "event": "APPROVED" if approve else "REQUEST_CHANGES",
-        }
+    if not bot_user:
+        error_msg = "git_review_bot_user is required to post a review or comment"
+        raise ValueError(error_msg)
+    review_url = comments_url(repo_name, pr_number)
+    review_cmd, commit_str = _approval_identifiers(bot_user, commit_id, approve=approve)
+    review_data = {"body": f"{review_cmd}\n{msg}\n{commit_str}"}
     post_json(review_url, token, review_data)
 
 
 def _is_already_approved(token: dict[str, str], repo_name: str, pr_number: int, commit_id: str) -> bool:
     bot_user = config.settings.git_review_bot_user
+    if not bot_user:
+        error_msg = "git_review_bot_user is required to check Gitea approvals"
+        raise ValueError(error_msg)
 
-    if bot_user:
-        comments = iter_gitea_items(comments_url(repo_name, pr_number), token)
-        if any(_is_bot_approval_comment(c, bot_user, commit_id) for c in comments):
-            log.info("PR %s already approved via comment for commit %s", pr_number, commit_id)
-            return True
-    else:
-        reviews = iter_gitea_items(reviews_url(repo_name, pr_number), token)
-        if any(
-            (r.get("commit_id"), r.get("state")) == (commit_id, "APPROVED") and is_review_requested_by(r)
-            for r in reviews
-        ):
-            log.info("PR %s already approved for commit %s", pr_number, commit_id)
-            return True
+    comments = iter_gitea_items(comments_url(repo_name, pr_number), token)
+    if any(_is_bot_approval_comment(c, bot_user, commit_id) for c in comments):
+        log.info("PR %s already approved via comment for commit %s", pr_number, commit_id)
+        return True
 
     return False
 

--- a/tests/test_approve_obs.py
+++ b/tests/test_approve_obs.py
@@ -10,10 +10,8 @@ from urllib.error import HTTPError
 import pytest
 import responses
 from pytest_mock import MockerFixture
-from responses import matchers
 
 from openqabot.approver import Approver
-from openqabot.config import settings
 
 from .helpers import (
     args,
@@ -50,35 +48,11 @@ def f_osconf(mocker: MockerFixture) -> Any:
     return mocker.patch("osc.conf.get_config")
 
 
-@pytest.fixture
-def fake_responses_for_creating_pr_review() -> None:
-    responses.add(
-        responses.GET,
-        "https://src.suse.de/api/v1/repos/products/SLFO/pulls/5/reviews",
-        json=[],
-    )
-    responses.add(
-        responses.POST,
-        "https://src.suse.de/api/v1/repos/products/SLFO/pulls/5/reviews",
-        json={},
-        match=[
-            matchers.json_params_matcher(
-                {
-                    "body": f"Request accepted for 'qam-openqa' based on data in {settings.qem_dashboard_url}",
-                    "commit_id": "18bfa2a23fb7985d5d0cc356474a96a19d91d2d8652442badf7f13bc07cd1f3d",
-                    "comments": [],
-                    "event": "APPROVED",
-                },
-            ),
-        ],
-    )
-
-
 @responses.activate
 @with_fake_qem("NoResultsError isn't raised")
-@pytest.mark.usefixtures("fake_two_passed_jobs", "fake_responses_for_creating_pr_review", "f_osconf")
+@pytest.mark.usefixtures("fake_two_passed_jobs", "f_osconf")
 def test_403_response(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
-    mocker.patch("openqabot.config.settings.git_review_bot", "")
+    mocker.patch("openqabot.approver.approve_pr", return_value=True)
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     mocker.patch("osc.core.change_review_state", side_effect=ObsHTTPError(403, "Not allowed", "sd", None))
     assert Approver(args)() == 0
@@ -89,6 +63,7 @@ def test_403_response(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -
 @with_fake_qem("NoResultsError isn't raised")
 @pytest.mark.usefixtures("fake_two_passed_jobs", "f_osconf")
 def test_404_response(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    mocker.patch("openqabot.approver.approve_pr", return_value=True)
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     mocker.patch(
         "osc.core.change_review_state", side_effect=ObsHTTPError(404, "Not Found", None, io.BytesIO(b"review state"))
@@ -101,6 +76,7 @@ def test_404_response(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -
 @with_fake_qem("NoResultsError isn't raised")
 @pytest.mark.usefixtures("fake_two_passed_jobs", "f_osconf")
 def test_500_response(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    mocker.patch("openqabot.approver.approve_pr", return_value=True)
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     mocker.patch("osc.core.change_review_state", side_effect=ObsHTTPError(500, "Not allowed", "sd", None))
     assert Approver(args)() == 1
@@ -111,6 +87,7 @@ def test_500_response(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -
 @with_fake_qem("NoResultsError isn't raised")
 @pytest.mark.usefixtures("fake_two_passed_jobs", "f_osconf")
 def test_osc_unknown_exception(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    mocker.patch("openqabot.approver.approve_pr", return_value=True)
     caplog.set_level(logging.DEBUG, logger="bot.approver")
     mocker.patch("osc.core.change_review_state", side_effect=ArbitraryObsError)
     assert Approver(args)() == 1
@@ -121,12 +98,11 @@ def test_osc_unknown_exception(caplog: pytest.LogCaptureFixture, mocker: MockerF
 @with_fake_qem("NoResultsError isn't raised")
 @pytest.mark.usefixtures("fake_two_passed_jobs", "f_osconf")
 def test_osc_all_pass(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
-    mocker.patch("openqabot.config.settings.git_review_bot", "")
     caplog.set_level(logging.DEBUG, logger="bot.approver")
 
     mocker.patch("openqabot.approver.dashboard.get_json", return_value=[{"job_id": 100000, "status": "passed"}])
     mocker.patch("osc.core.change_review_state")
-    mock_review_pr = mocker.patch("openqabot.approver.approve_pr")
+    mock_review_pr = mocker.patch("openqabot.approver.approve_pr", return_value=True)
 
     assert Approver(args)() == 0
     expected = [

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -270,17 +270,6 @@ def test_reviewing_pr() -> None:
     review_pr({"token": "foo"}, "orga/repo", 42, "accepted", "12345", approve=True)
 
 
-@responses.activate
-def test_reviewing_pr_no_bot_user(mocker: MockerFixture) -> None:
-    # Patch the property on the class so it affects the existing 'settings' instance
-    mocker.patch("openqabot.config.Settings.git_review_bot_user", new_callable=mocker.PropertyMock, return_value=None)
-    url = "https://src.suse.de/api/v1/repos/orga/repo/pulls/42/reviews"
-    responses.post(url, json={"status": "ok"})
-    review_pr({"token": "foo"}, "orga/repo", 42, "accepted", "12345", approve=True)
-    assert len(responses.calls) > 0
-    assert responses.calls[0].request.url == url
-
-
 def test_computing_repo_url() -> None:
     repos = Repos("product", "1.2", "x86_64")
 

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -234,37 +234,28 @@ def mock_settings(mocker: MockerFixture) -> MagicMock:
 @pytest.mark.parametrize(
     ("bot_user", "api_response", "expected_log", "should_call_review"),
     [
-        # Case 1: Already approved via official review
-        (
-            None,
-            [{"commit_id": "sha123", "state": "APPROVED", "user": {"login": "openqa"}}],
-            "PR 123 already approved for commit sha123",
-            False,
-        ),
-        # Case 2: Not yet approved (no reviews)
-        (None, [], None, True),
-        # Case 3: Already approved via bot comment
+        # Case 1: Already approved via bot comment
         (
             "bot",
             [{"body": "@bot: approved\nTested commit: sha123", "user": {"login": "bot"}}],
             "PR 123 already approved via comment for commit sha123",
             False,
         ),
-        # Case 4: Comment matches but author is wrong (spoofing attempt)
+        # Case 2: Comment matches but author is wrong (spoofing attempt)
         (
             "bot",
             [{"body": "@bot: approved\nTested commit: sha123", "user": {"login": "imposter"}}],
             None,
             True,
         ),
-        # Case 5: Already approved via bot comment using obs_group name
+        # Case 3: Already approved via bot comment using obs_group name
         (
             "bot-review",
             [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "openqa"}}],
             "PR 123 already approved via comment for commit sha123",
             False,
         ),
-        # Case 6: No bot comments found
+        # Case 4: No bot comments found
         ("bot", [], None, True),
     ],
 )
@@ -355,3 +346,24 @@ def test_approve_pr_exception(
 
     assert res is False
     assert "Gitea API error: Failed to approve PR 123" in caplog.text
+
+
+def test_approve_pr_no_bot_user(
+    mock_settings: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_settings.git_review_bot_user = None
+    caplog.set_level(logging.ERROR, logger="bot.loader.gitea")
+
+    res = gitea.approve_pr({}, "repo", 123, "sha123", "msg")
+
+    assert res is False
+    assert "Gitea API error: Failed to approve PR 123" in caplog.text
+
+
+def test_review_pr_no_bot_user(
+    mock_settings: MagicMock,
+) -> None:
+    mock_settings.git_review_bot_user = None
+    with pytest.raises(ValueError, match="git_review_bot_user is required to post a review or comment"):
+        gitea.review_pr({}, "repo", 123, "msg", "sha123")


### PR DESCRIPTION
Motivation:
Removing unreachable Gitea approval logic simplifies the code path when no
bot-user is defined, since the bot requires Gitea credentials to operate.

Design Choices:
- Replace brittle assertions with clear ValueError checks.
- Simplify Gitea approval checks to assume bot-user configuration is present.
- Mock Gitea approvals in OBS tests to avoid false-negative log noise.

Benefits:
- Cleaner and more maintainable approval codebase.
- Improved error validation and complete test coverage with decoupled mocks.