### PR TITLE
fix: require tests for all flavors to pass for PR approval

### DIFF
--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -196,9 +196,13 @@ class GiteaTrigger:
 
         any_triggered = any(outcome.triggered for outcome in outcomes)
         covered_data = [outcome.data for outcome in outcomes if outcome.data is not None]
+        approve = len(outcomes) == len(applicable_configs)
+
+        if not approve:
+            log.info("Approval blocked for PR %s: unevaluated configs", pullrequest.number)
 
         if self.comment and covered_data and not any_triggered:
-            self.comment_on_pr(pullrequest, covered_data)
+            self.comment_on_pr(pullrequest, covered_data, approve=approve)
 
     def _evaluate_config(self, pullrequest: PullRequest, trigger_config: TriggerConfig) -> EvaluationResult | None:
         """Trigger openQA for one config, or return its coverage Data."""
@@ -252,7 +256,7 @@ class GiteaTrigger:
         # No image_regex configured, use ISO parameters
         return {"ISO_1_URL": f"{repo_url}/{iso_name}", "ISO_1": iso_name}
 
-    def comment_on_pr(self, pullrequest: PullRequest, data_list: list[Data]) -> None:
+    def comment_on_pr(self, pullrequest: PullRequest, data_list: list[Data], *, approve: bool = True) -> None:
         """Comment on PR if openQA results are available."""
         try:
             # build first so an existing job "build" overrides it (setdefault semantics)
@@ -263,7 +267,7 @@ class GiteaTrigger:
 
         if res := self.commenter.generate_comment(pullrequest, all_jobs):
             self.commenter.gitea_comment(pullrequest, *res)
-            if res[1] == "passed":
+            if res[1] == "passed" and approve:
                 if self.dry:
                     log.info("Dry run: Would approve PR %s", pullrequest.number)
                 else:

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -3,6 +3,7 @@
 """Trigger testing for PR(s) with certain label."""
 
 from argparse import Namespace
+from dataclasses import dataclass
 from logging import getLogger
 from typing import Any, cast
 
@@ -35,6 +36,14 @@ ISO_REGEX = (
     r"(?P<product>SLES)-(?P<version>[\d\.]+)-Online-"
     r"(?P<arch>x86_64)-Build(?P<build>[0-9\.]+)\.install.iso$"
 )
+
+
+@dataclass
+class EvaluationResult:
+    """Result of evaluating a pull request config."""
+
+    triggered: bool
+    data: Data | None = None
 
 
 class GiteaTrigger:
@@ -105,14 +114,14 @@ class GiteaTrigger:
 
     def _get_matched_iso(
         self, pullrequest: PullRequest, trigger_config: TriggerConfig, repo_url: str
-    ) -> tuple[IsoMatch | None, str | None]:
+    ) -> tuple[IsoMatch, str | None]:
         """Extract version and build info into an IsoMatch and its raw filename."""
         if self.is_maintenance:
             try:
                 staged_update_name = self.repodiff.get_staged_update_name(repo_url)
-            except NoResultsError:
-                log.warning("No staged update name found for PR %s in %s", pullrequest.number, repo_url)
-                return None, None
+            except NoResultsError as e:
+                err_msg = f"No staged update name found for PR {pullrequest.number} in {repo_url}"
+                raise NoResultsError(err_msg) from e
             matched_iso = IsoMatch(
                 trigger_config.project,
                 trigger_config.get_branch_version(),
@@ -124,7 +133,9 @@ class GiteaTrigger:
             repo_url, ISO_REGEX
         ):
             return IsoMatch.from_regex_match(matched_iso_regex, pullrequest.number), matched_iso_regex.group(0)
-        return None, None
+
+        err_msg = f"No ISO found for PR {pullrequest.number} in {repo_url}"
+        raise NoResultsError(err_msg)
 
     def _build_openqa_settings(
         self,
@@ -157,8 +168,8 @@ class GiteaTrigger:
 
         return settings
 
-    def check_pullrequest(self, pullrequest: PullRequest, trigger_config: TriggerConfig) -> None:
-        """Evaluate a pull request and triggers openQA tests if new artifacts are available.
+    def check_pullrequest(self, pullrequest: PullRequest) -> None:
+        """Evaluate a pull request and trigger openQA tests if new artifacts are available.
 
         The method constructs the repository URL, extracts the build version from
         the available ISO artifacts using regex, and checks if this specific
@@ -167,30 +178,52 @@ class GiteaTrigger:
 
         Args:
             pullrequest (PullRequest): The pull request object to validate and test.
-            trigger_config (TriggerConfig): The triggering configuration.
 
         """
-        if self._should_skip_pr(pullrequest, trigger_config):
+        applicable_configs = [
+            tc
+            for tc in self.config_list
+            if tc.project == pullrequest.project and not self._should_skip_pr(pullrequest, tc)
+        ]
+        if not applicable_configs:
+            log.debug("No applicable configs found for PR %s in project %s", pullrequest.number, pullrequest.project)
             return
 
-        log.info("Evaluating PR %s for openQA triggering with config: %s", pullrequest.number, trigger_config)
+        log.info("Evaluating PR %s for openQA triggering", pullrequest.number)
+
+        outcomes = [res for tc in applicable_configs if (res := self._evaluate_config(pullrequest, tc)) is not None]
+
+        any_triggered = any(outcome.triggered for outcome in outcomes)
+        covered_data = [outcome.data for outcome in outcomes if outcome.data is not None]
+
+        if self.comment and covered_data and not any_triggered:
+            self.comment_on_pr(pullrequest, covered_data)
+
+    def _evaluate_config(self, pullrequest: PullRequest, trigger_config: TriggerConfig) -> EvaluationResult | None:
+        """Trigger openQA for one config, or return its coverage Data."""
         repo_url = trigger_config.generate_obs_repo_url(
             pullrequest.number, config.settings.obs_download_url, is_maintenance=self.is_maintenance
         )
-
-        matched_iso, iso_name = self._get_matched_iso(pullrequest, trigger_config, repo_url)
-        if not matched_iso:
-            return
+        try:
+            matched_iso, iso_name = self._get_matched_iso(pullrequest, trigger_config, repo_url)
+        except NoResultsError as e:
+            log.warning(str(e))
+            return None
 
         if self.is_openqa_triggering_needed(matched_iso, trigger_config):
             openqa_settings = self._build_openqa_settings(pullrequest, trigger_config, matched_iso, repo_url, iso_name)
             self.openqa.post_job(openqa_settings)
             log.info("Triggered openQA tests for PR %s on %s", pullrequest.number, matched_iso.arch)
-        else:
-            log.info("openQA tests for PR %s (build %s) are already covered", pullrequest.number, matched_iso.build)
-            if self.comment:
-                data = Data.from_trigger_config_and_matched_iso(trigger_config, matched_iso, pullrequest.number)
-                self.comment_on_pr(pullrequest, data)
+            return EvaluationResult(triggered=True)
+
+        log.info(
+            "openQA tests for PR %s (build %s, flavor %s) are already covered",
+            pullrequest.number,
+            matched_iso.build,
+            trigger_config.flavor,
+        )
+        data = Data.from_trigger_config_and_matched_iso(trigger_config, matched_iso, pullrequest.number)
+        return EvaluationResult(triggered=False, data=data)
 
     @staticmethod
     def generate_medium_vars(
@@ -218,17 +251,16 @@ class GiteaTrigger:
         # No image_regex configured, use ISO parameters
         return {"ISO_1_URL": f"{repo_url}/{iso_name}", "ISO_1": iso_name}
 
-    def comment_on_pr(self, pullrequest: PullRequest, data: Data) -> None:
+    def comment_on_pr(self, pullrequest: PullRequest, data_list: list[Data]) -> None:
         """Comment on PR if openQA results are available."""
         try:
-            jobs = self.openqa.get_jobs(data)
-            for j in jobs:
-                j.setdefault("build", data.build)
+            # build first so an existing job "build" overrides it (setdefault semantics)
+            all_jobs = [{"build": data.build, **job} for data in data_list for job in self.openqa.get_jobs(data)]
         except (requests.exceptions.RequestException, RequestError):
-            log.exception("Failed to fetch jobs for PR %s", pullrequest.number)
+            log.exception("Failed to fetch jobs for PR %s; aborting approval", pullrequest.number)
             return
 
-        if res := self.commenter.generate_comment(pullrequest, jobs):
+        if res := self.commenter.generate_comment(pullrequest, all_jobs):
             self.commenter.gitea_comment(pullrequest, *res)
             if res[1] == "passed":
                 if self.dry:
@@ -313,7 +345,10 @@ class GiteaTrigger:
         """
         for trigger_config in self.config_list:
             self.load_prs_for_project(trigger_config.project)
-            for pr in self.prs[trigger_config.project]:
-                self.check_pullrequest(pr, trigger_config)
+        distinct_prs = list(
+            {(pr.project, pr.number): pr for tc in self.config_list for pr in self.prs.get(tc.project, [])}.values()
+        )
+        for pr in distinct_prs:
+            self.check_pullrequest(pr)
 
         return 0

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -47,6 +47,29 @@ class EvaluationResult:
     data: Data | None = None
 
 
+@dataclass
+class EvaluationSummary:
+    """Summary of evaluating all applicable configs for a pull request."""
+
+    outcomes: list[EvaluationResult]
+    total_configs: int
+
+    @property
+    def any_triggered(self) -> bool:
+        """Check if any configuration triggered a new openQA job."""
+        return any(outcome.triggered for outcome in self.outcomes)
+
+    @property
+    def covered_data(self) -> list[Data]:
+        """Collect all existing/covered test results."""
+        return [outcome.data for outcome in self.outcomes if outcome.data is not None]
+
+    @property
+    def approve(self) -> bool:
+        """Check if all applicable configurations were successfully processed."""
+        return len(self.outcomes) == self.total_configs
+
+
 class GiteaTrigger:
     """Trigger testing for PR(s) with certain label."""
 
@@ -193,16 +216,13 @@ class GiteaTrigger:
         log.info("Evaluating PR %s for openQA triggering", pullrequest.number)
 
         outcomes = [res for tc in applicable_configs if (res := self._evaluate_config(pullrequest, tc)) is not None]
+        summary = EvaluationSummary(outcomes, len(applicable_configs))
 
-        any_triggered = any(outcome.triggered for outcome in outcomes)
-        covered_data = [outcome.data for outcome in outcomes if outcome.data is not None]
-        approve = len(outcomes) == len(applicable_configs)
-
-        if not approve:
+        if not summary.approve:
             log.info("Approval blocked for PR %s: unevaluated configs", pullrequest.number)
 
-        if self.comment and covered_data and not any_triggered:
-            self.comment_on_pr(pullrequest, covered_data, approve=approve)
+        if self.comment and summary.covered_data and not summary.any_triggered:
+            self.comment_on_pr(pullrequest, summary.covered_data, approve=summary.approve)
 
     def _evaluate_config(self, pullrequest: PullRequest, trigger_config: TriggerConfig) -> EvaluationResult | None:
         """Trigger openQA for one config, or return its coverage Data."""

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -4,6 +4,7 @@
 
 from argparse import Namespace
 from dataclasses import dataclass
+from itertools import chain
 from logging import getLogger
 from typing import Any, cast
 
@@ -345,10 +346,7 @@ class GiteaTrigger:
         """
         for trigger_config in self.config_list:
             self.load_prs_for_project(trigger_config.project)
-        distinct_prs = list(
-            {(pr.project, pr.number): pr for tc in self.config_list for pr in self.prs.get(tc.project, [])}.values()
-        )
-        for pr in distinct_prs:
+        for pr in chain.from_iterable(self.prs.values()):
             self.check_pullrequest(pr)
 
         return 0

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -15,6 +15,7 @@ from openqa_client.exceptions import RequestError
 from pytest_mock import MockerFixture
 
 from openqabot import config
+from openqabot.commenter import Commenter
 from openqabot.errors import NoResultsError
 from openqabot.giteatrigger import GiteaTrigger
 from openqabot.loader.triggerconfig import TriggerConfig
@@ -88,8 +89,9 @@ def test_check_pullrequest_triggers_job(
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=True)
     mock_pr = MagicMock(number=123)
+    mock_pr.project = mock_trigger_config.project
     mock_pr.branch = mock_trigger_config.branch
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_called_once()
     args, _ = cast("MagicMock", trigger.openqa.post_job).call_args
@@ -136,9 +138,11 @@ def test_check_pullrequest_with_image_regex(trigger: GiteaTrigger, mocker: Mocke
         "openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/product/iso"
     )
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=True)
+    trigger.config_list = [trigger_config_with_image]
     mock_pr = MagicMock(number=456)
+    mock_pr.project = trigger_config_with_image.project
     mock_pr.branch = trigger_config_with_image.branch
-    trigger.check_pullrequest(mock_pr, trigger_config_with_image)
+    trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_called_once()
     args, _ = cast("MagicMock", trigger.openqa.post_job).call_args
@@ -188,9 +192,11 @@ def test_check_pullrequest_with_image_regex_not_found(
         "openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/product/iso"
     )
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=True)
+    trigger.config_list = [trigger_config_with_image]
     mock_pr = MagicMock(number=789)
+    mock_pr.project = trigger_config_with_image.project
     mock_pr.branch = trigger_config_with_image.branch
-    trigger.check_pullrequest(mock_pr, trigger_config_with_image)
+    trigger.check_pullrequest(mock_pr)
 
     # Verify warning was logged
     assert "No image found matching regex" in caplog.text
@@ -224,7 +230,10 @@ def test_is_openqatriggering_needed_false(
 
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=False)
-    trigger.check_pullrequest(MagicMock(number=123), mock_trigger_config)
+    mock_pr = MagicMock(number=123)
+    mock_pr.project = mock_trigger_config.project
+    mock_pr.branch = mock_trigger_config.branch
+    trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_not_called()
 
@@ -285,8 +294,9 @@ def test_check_pullrequest_dry_run(
     mock_crawler.return_value.get_regex_match_from_url.return_value = mock_match
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
     mock_pr = MagicMock(number=456)
+    mock_pr.project = mock_trigger_config.project
     mock_pr.branch = mock_trigger_config.branch
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
     cast("MagicMock", trigger.openqa.openqa.openqa_request).assert_not_called()
 
 
@@ -299,8 +309,9 @@ def test_check_pullrequest_no_iso_found(
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
 
     mock_pr = MagicMock(number=789)
+    mock_pr.project = mock_trigger_config.project
     mock_pr.branch = mock_trigger_config.branch
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_not_called()
 
@@ -328,7 +339,46 @@ def test_trigger_call_execution(
     result = trigger()
     assert result == 0
     mock_load.assert_called_once_with(mock_trigger_config.project)
-    mock_check.assert_called_once_with(mock_pr, mock_trigger_config)
+    mock_check.assert_called_once_with(mock_pr)
+
+
+def test_trigger_call_execution_duplicate_prs(trigger: GiteaTrigger, mocker: MockerFixture) -> None:
+    """Cover __call__ duplicate PR filtering logic."""
+    mocker.patch.object(trigger, "load_prs_for_project")
+    mock_check = mocker.patch.object(trigger, "check_pullrequest")
+    mock_pr = MagicMock()
+    mock_pr.number = 123
+
+    config1 = TriggerConfig(distri="sle", flavor="Online-Staging")
+    config2 = TriggerConfig(distri="sle", flavor="Other-Staging")
+    config1.project = "SLFO"
+    config2.project = "SLFO"
+    trigger.prs = {"SLFO": [mock_pr]}
+    trigger.config_list = [config1, config2]
+
+    result = trigger()
+    assert result == 0
+    mock_check.assert_called_once_with(mock_pr)
+
+
+def test_check_pullrequest_mixed_trigger_and_covered_skips_comment(
+    trigger: GiteaTrigger, mocker: MockerFixture
+) -> None:
+    """When any flavor is (re)triggered, no approval/comment happens even if others are covered."""
+    trigger.comment = True
+    config_trigger = TriggerConfig(distri="sle", flavor="A")
+    config_covered = TriggerConfig(distri="sle", flavor="B")
+    config_trigger.project = config_covered.project = "SLFO"
+    trigger.config_list = [config_trigger, config_covered]
+    mock_iso = MagicMock(arch="x86_64", build="b", flavor="A")
+    mocker.patch.object(trigger, "_should_skip_pr", return_value=False)
+    mocker.patch.object(trigger, "_get_matched_iso", return_value=(mock_iso, "iso"))
+    mocker.patch.object(trigger, "is_openqa_triggering_needed", side_effect=[True, False])
+    mock_comment = mocker.patch.object(trigger, "comment_on_pr")
+    mock_pr = MagicMock(number=1)
+    mock_pr.project = "SLFO"
+    trigger.check_pullrequest(mock_pr)
+    mock_comment.assert_not_called()
 
 
 @pytest.mark.usefixtures("_fake_get_configs_from_path")
@@ -382,8 +432,9 @@ def test_check_pullrequest_comments_when_no_trigger_needed(
     mock_comment_on_pr = mocker.patch.object(trigger, "comment_on_pr")
 
     mock_pr = MagicMock(number=123)
+    mock_pr.project = mock_trigger_config.project
     mock_pr.branch = mock_trigger_config.branch
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
 
     mock_comment_on_pr.assert_called_once()
 
@@ -404,11 +455,35 @@ def test_comment_on_pr_build_injection(
     mock_iso.arch = "arch"
     mock_iso.build = "PR-BUILD"
     data = Data.from_trigger_config_and_matched_iso(mock_trigger_config, mock_iso, mock_pr.number)
-    trigger.comment_on_pr(mock_pr, data)
+    trigger.comment_on_pr(mock_pr, [data])
 
-    assert mock_jobs[0]["build"] == "PR-BUILD"
-    cast("MagicMock", trigger.commenter.generate_comment).assert_called_once_with(mock_pr, mock_jobs)
+    passed_jobs = cast("MagicMock", trigger.commenter.generate_comment).call_args[0][1]
+    assert passed_jobs[0]["build"] == "PR-BUILD"
     mock_approve_pr.assert_called_once_with(trigger.gitea_token, "fake_repo", 123, "sha123", mocker.ANY)
+
+
+def test_comment_on_pr_one_flavor_fails_blocks_approval(
+    trigger: GiteaTrigger, mocker: MockerFixture, mock_args: Namespace
+) -> None:
+    """A failing flavor must block approval even when another flavor passes."""
+    mocker.patch("openqabot.config.settings.enable_detailed_comments", new=False)
+    mock_approve_pr = mocker.patch("openqabot.giteatrigger.approve_pr")
+    commenter = Commenter(mock_args, submissions=[])
+    commenter.client.openqa.baseurl = "https://openqa"
+    mock_gitea_comment = mocker.patch.object(commenter, "gitea_comment")
+    trigger.commenter = commenter
+
+    jobs_by_flavor = {
+        "A": [{"id": 1, "state": "done", "result": "passed", "build": "b"}],
+        "B": [{"id": 2, "state": "done", "result": "failed", "build": "b"}],
+    }
+    cast("MagicMock", trigger.openqa.get_jobs).side_effect = lambda data: jobs_by_flavor[data.flavor]
+
+    data_list = [Data(1, "git", 0, flavor, "x86_64", "sle", "15", "b", "product") for flavor in jobs_by_flavor]
+    trigger.comment_on_pr(MagicMock(number=1, url="http://host/o/r/pulls/1"), data_list)
+
+    assert mock_gitea_comment.call_args[0][2] == "failed"
+    mock_approve_pr.assert_not_called()
 
 
 def test_comment_on_pr_dry_run_approves(
@@ -432,7 +507,7 @@ def test_comment_on_pr_dry_run_approves(
     mock_iso.arch = "arch"
     mock_iso.build = "PR-BUILD"
     data = Data.from_trigger_config_and_matched_iso(mock_trigger_config, mock_iso, mock_pr.number)
-    trigger.comment_on_pr(mock_pr, data)
+    trigger.comment_on_pr(mock_pr, [data])
 
     mock_approve_pr.assert_not_called()
     assert "Dry run: Would approve PR 123" in caplog.text
@@ -446,7 +521,7 @@ def test_comment_on_pr_no_jobs(trigger: GiteaTrigger, mock_trigger_config: Trigg
     mock_pr = MagicMock(number=123)
     mock_iso = MagicMock()
     data = Data.from_trigger_config_and_matched_iso(mock_trigger_config, mock_iso, mock_pr.number)
-    trigger.comment_on_pr(mock_pr, data)
+    trigger.comment_on_pr(mock_pr, [data])
 
     cast("MagicMock", trigger.commenter.gitea_comment).assert_not_called()
 
@@ -459,8 +534,9 @@ def test_check_pullrequest_no_matched_iso(
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
 
     mock_pr = MagicMock(number=123)
+    mock_pr.project = mock_trigger_config.project
     mock_pr.branch = mock_trigger_config.branch
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
     # Should log warning but not crash
 
 
@@ -476,7 +552,7 @@ def test_comment_on_pr_data_creation(trigger: GiteaTrigger, mock_trigger_config:
     mock_iso.arch = "arch"
     mock_iso.build = "build"
     data = Data.from_trigger_config_and_matched_iso(mock_trigger_config, mock_iso, mock_pr.number)
-    trigger.comment_on_pr(mock_pr, data)
+    trigger.comment_on_pr(mock_pr, [data])
 
     mock_get_jobs.assert_called_once()
     data = mock_get_jobs.call_args[0][0]
@@ -525,7 +601,7 @@ def test_check_pullrequest_opensuse_success(
     """Tests the full opensuse PR check, trigger and approval path."""
     trigger.is_maintenance = True
     mock_trigger_config.branch = "openSUSE-Leap-15.5"
-    mock_trigger_config.project = "openSUSE/Leap/15.5"
+    mock_trigger_config.project = "openSUSE_Leap_15.5"
     mock_trigger_config.repo_template = "{repo_prefix}/"
     mock_trigger_config.settings = {"OS_TEST_TEMPLATE": "test-template"}
 
@@ -542,7 +618,7 @@ def test_check_pullrequest_opensuse_success(
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=True)
     mock_approve = mocker.patch("openqabot.giteatrigger.gitea.approve_pr")
 
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
 
     # Verify openQA post_job was called
     cast("MagicMock", trigger.openqa.post_job).assert_called_once()
@@ -568,6 +644,7 @@ def test_check_pullrequest_opensuse_no_staged_update(
     mock_trigger_config.repo_template = "{repo_prefix}/"
 
     mock_pr = MagicMock(spec=PullRequest)
+    mock_pr.project = mock_trigger_config.project
     mock_pr.branch = "openSUSE-Leap-15.5"
     mock_pr.number = 123
 
@@ -575,10 +652,10 @@ def test_check_pullrequest_opensuse_no_staged_update(
     mocker.patch.object(trigger.repodiff, "get_staged_update_name", side_effect=NoResultsError("error"))
     mock_log = mocker.patch("openqabot.giteatrigger.log.warning")
 
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
 
     # Verify warning log and early exit
-    mock_log.assert_called_once_with("No staged update name found for PR %s in %s", 123, "http://download.suse.de/ibs/")
+    mock_log.assert_called_once_with("No staged update name found for PR 123 in http://download.suse.de/ibs/")
     cast("MagicMock", trigger.openqa.post_job).assert_not_called()
 
 
@@ -597,10 +674,11 @@ def test_check_pullrequest_skipped(
 ) -> None:
     """Tests that check_pullrequest returns early if PR can be skipped."""
     mock_pr = MagicMock(spec=PullRequest)
+    mock_pr.project = mock_trigger_config.project
     mocker.patch.object(trigger, "_should_skip_pr", return_value=True)
     mock_log = mocker.patch("openqabot.giteatrigger.log.info")
 
-    trigger.check_pullrequest(mock_pr, mock_trigger_config)
+    trigger.check_pullrequest(mock_pr)
     mock_log.assert_not_called()
 
 
@@ -661,7 +739,7 @@ def test_comment_on_pr_exception(trigger: GiteaTrigger) -> None:
     mock_pr = MagicMock(number=123)
     # Should not raise exception
     data = Data(123, "git", 0, "flavor", "arch", "distri", "version", "build", "product")
-    trigger.comment_on_pr(mock_pr, data)
+    trigger.comment_on_pr(mock_pr, [data])
 
 
 def test_trigger_init_maintenance(

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -17,7 +17,7 @@ from pytest_mock import MockerFixture
 from openqabot import config
 from openqabot.commenter import Commenter
 from openqabot.errors import NoResultsError
-from openqabot.giteatrigger import GiteaTrigger
+from openqabot.giteatrigger import EvaluationResult, EvaluationSummary, GiteaTrigger
 from openqabot.loader.triggerconfig import TriggerConfig
 from openqabot.types.pullrequest import PullRequest
 from openqabot.types.types import Data
@@ -780,3 +780,31 @@ def test_is_build_finished_request_exception(
     )
     mock_pr = MagicMock(number=123)
     assert trigger.is_build_finished(mock_pr, mock_trigger_config) is False
+
+
+_data = Data(1, "git", 0, "f", "a", "d", "v", "b", "p")
+
+
+@pytest.mark.parametrize(
+    ("outcomes", "total_configs", "expected_any_triggered", "expected_covered_data_len", "expected_approve"),
+    [
+        ([], 0, False, 0, True),
+        ([EvaluationResult(triggered=True)], 1, True, 0, True),
+        ([EvaluationResult(triggered=False, data=_data)], 1, False, 1, True),
+        ([EvaluationResult(triggered=True), EvaluationResult(triggered=False, data=_data)], 2, True, 1, True),
+        ([EvaluationResult(triggered=True)], 2, True, 0, False),
+    ],
+)
+def test_evaluation_summary(
+    outcomes: list[EvaluationResult],
+    total_configs: int,
+    *,
+    expected_any_triggered: bool,
+    expected_covered_data_len: int,
+    expected_approve: bool,
+) -> None:
+    """Verifies all properties of EvaluationSummary with different inputs."""
+    summary = EvaluationSummary(outcomes, total_configs)
+    assert summary.any_triggered == expected_any_triggered
+    assert len(summary.covered_data) == expected_covered_data_len
+    assert summary.approve == expected_approve

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -5,7 +5,7 @@
 import logging
 from argparse import Namespace
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
 
@@ -54,6 +54,14 @@ def _fake_get_configs_from_path(mocker: MockerFixture, mock_trigger_config: Trig
     )
 
 
+def _make_pr(number: int | None, trigger_config: TriggerConfig, **kwargs: Any) -> MagicMock:
+    """Create a mocked PullRequest bound to a trigger config."""
+    pr = MagicMock(number=number, **kwargs)
+    pr.project = trigger_config.project
+    pr.branch = trigger_config.branch
+    return pr
+
+
 @pytest.fixture
 def trigger(
     mock_args: Namespace,
@@ -88,9 +96,7 @@ def test_check_pullrequest_triggers_job(
 
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=True)
-    mock_pr = MagicMock(number=123)
-    mock_pr.project = mock_trigger_config.project
-    mock_pr.branch = mock_trigger_config.branch
+    mock_pr = _make_pr(123, mock_trigger_config)
     trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_called_once()
@@ -139,9 +145,7 @@ def test_check_pullrequest_with_image_regex(trigger: GiteaTrigger, mocker: Mocke
     )
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=True)
     trigger.config_list = [trigger_config_with_image]
-    mock_pr = MagicMock(number=456)
-    mock_pr.project = trigger_config_with_image.project
-    mock_pr.branch = trigger_config_with_image.branch
+    mock_pr = _make_pr(456, trigger_config_with_image)
     trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_called_once()
@@ -193,9 +197,7 @@ def test_check_pullrequest_with_image_regex_not_found(
     )
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=True)
     trigger.config_list = [trigger_config_with_image]
-    mock_pr = MagicMock(number=789)
-    mock_pr.project = trigger_config_with_image.project
-    mock_pr.branch = trigger_config_with_image.branch
+    mock_pr = _make_pr(789, trigger_config_with_image)
     trigger.check_pullrequest(mock_pr)
 
     # Verify warning was logged
@@ -230,9 +232,7 @@ def test_is_openqatriggering_needed_false(
 
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=False)
-    mock_pr = MagicMock(number=123)
-    mock_pr.project = mock_trigger_config.project
-    mock_pr.branch = mock_trigger_config.branch
+    mock_pr = _make_pr(123, mock_trigger_config)
     trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_not_called()
@@ -293,9 +293,7 @@ def test_check_pullrequest_dry_run(
     mock_crawler = mocker.patch("openqabot.giteatrigger.Crawler")
     mock_crawler.return_value.get_regex_match_from_url.return_value = mock_match
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
-    mock_pr = MagicMock(number=456)
-    mock_pr.project = mock_trigger_config.project
-    mock_pr.branch = mock_trigger_config.branch
+    mock_pr = _make_pr(456, mock_trigger_config)
     trigger.check_pullrequest(mock_pr)
     cast("MagicMock", trigger.openqa.openqa.openqa_request).assert_not_called()
 
@@ -308,9 +306,7 @@ def test_check_pullrequest_no_iso_found(
     mock_crawler.return_value.get_regex_match_from_url.return_value = None
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
 
-    mock_pr = MagicMock(number=789)
-    mock_pr.project = mock_trigger_config.project
-    mock_pr.branch = mock_trigger_config.branch
+    mock_pr = _make_pr(789, mock_trigger_config)
     trigger.check_pullrequest(mock_pr)
 
     cast("MagicMock", trigger.openqa.post_job).assert_not_called()
@@ -375,8 +371,7 @@ def test_check_pullrequest_mixed_trigger_and_covered_skips_comment(
     mocker.patch.object(trigger, "_get_matched_iso", return_value=(mock_iso, "iso"))
     mocker.patch.object(trigger, "is_openqa_triggering_needed", side_effect=[True, False])
     mock_comment = mocker.patch.object(trigger, "comment_on_pr")
-    mock_pr = MagicMock(number=1)
-    mock_pr.project = "SLFO"
+    mock_pr = _make_pr(1, config_trigger)
     trigger.check_pullrequest(mock_pr)
     mock_comment.assert_not_called()
 
@@ -431,9 +426,7 @@ def test_check_pullrequest_comments_when_no_trigger_needed(
     mocker.patch.object(trigger, "is_openqa_triggering_needed", return_value=False)
     mock_comment_on_pr = mocker.patch.object(trigger, "comment_on_pr")
 
-    mock_pr = MagicMock(number=123)
-    mock_pr.project = mock_trigger_config.project
-    mock_pr.branch = mock_trigger_config.branch
+    mock_pr = _make_pr(123, mock_trigger_config)
     trigger.check_pullrequest(mock_pr)
 
     mock_comment_on_pr.assert_called_once()
@@ -533,9 +526,7 @@ def test_check_pullrequest_no_matched_iso(
     mocker.patch("openqabot.giteatrigger.Crawler").return_value.get_regex_match_from_url.return_value = None
     mocker.patch("openqabot.loader.triggerconfig.TriggerConfig.generate_obs_repo_url", return_value="http://fake.url/")
 
-    mock_pr = MagicMock(number=123)
-    mock_pr.project = mock_trigger_config.project
-    mock_pr.branch = mock_trigger_config.branch
+    mock_pr = _make_pr(123, mock_trigger_config)
     trigger.check_pullrequest(mock_pr)
     # Should log warning but not crash
 
@@ -605,12 +596,7 @@ def test_check_pullrequest_opensuse_success(
     mock_trigger_config.repo_template = "{repo_prefix}/"
     mock_trigger_config.settings = {"OS_TEST_TEMPLATE": "test-template"}
 
-    mock_pr = MagicMock(spec=PullRequest)
-    mock_pr.branch = "openSUSE-Leap-15.5"
-    mock_pr.number = 123
-    mock_pr.commit_sha = "sha123"
-    mock_pr.project = "openSUSE_Leap_15.5"
-    mock_pr.url = "http://fake-pr-url"
+    mock_pr = _make_pr(123, mock_trigger_config, spec=PullRequest, commit_sha="sha123", url="http://fake-pr-url")
     mock_pr.generate_webhook_id.return_value = "gitea:pr:123"
 
     mocker.patch.object(trigger, "is_build_finished", return_value=True)
@@ -643,10 +629,7 @@ def test_check_pullrequest_opensuse_no_staged_update(
     mock_trigger_config.branch = "openSUSE-Leap-15.5"
     mock_trigger_config.repo_template = "{repo_prefix}/"
 
-    mock_pr = MagicMock(spec=PullRequest)
-    mock_pr.project = mock_trigger_config.project
-    mock_pr.branch = "openSUSE-Leap-15.5"
-    mock_pr.number = 123
+    mock_pr = _make_pr(123, mock_trigger_config, spec=PullRequest)
 
     mocker.patch.object(trigger, "is_build_finished", return_value=True)
     mocker.patch.object(trigger.repodiff, "get_staged_update_name", side_effect=NoResultsError("error"))
@@ -673,8 +656,7 @@ def test_check_pullrequest_skipped(
     trigger: GiteaTrigger, mocker: MockerFixture, mock_trigger_config: TriggerConfig
 ) -> None:
     """Tests that check_pullrequest returns early if PR can be skipped."""
-    mock_pr = MagicMock(spec=PullRequest)
-    mock_pr.project = mock_trigger_config.project
+    mock_pr = _make_pr(None, mock_trigger_config, spec=PullRequest)
     mocker.patch.object(trigger, "_should_skip_pr", return_value=True)
     mock_log = mocker.patch("openqabot.giteatrigger.log.info")
 
@@ -774,12 +756,9 @@ def test_trigger_init_no_configs(mock_args: Namespace, mocker: MockerFixture) ->
 def test_build_openqa_settings_no_iso_name(trigger: GiteaTrigger, mock_trigger_config: TriggerConfig) -> None:
     """Test _build_openqa_settings when is_maintenance is False and iso_name is None."""
     trigger.is_maintenance = False
-    mock_pr = MagicMock(spec=PullRequest)
-    mock_pr.number = 123
-    mock_pr.commit_sha = "sha123"
-    mock_pr.project = "project"
-    mock_pr.branch = "main"
-    mock_pr.url = "http://fake-url"
+    mock_pr = MagicMock(
+        spec=PullRequest, number=123, commit_sha="sha123", project="project", branch="main", url="http://fake-url"
+    )
 
     matched_iso = MagicMock()
     matched_iso.product = "SLES"


### PR DESCRIPTION
Motivation:
Evaluating PRs across multiple test flavors was done individually per
flavor.  This resulted in PRs being approved as soon as tests for any
single flavor passed, even if other flavors failed.

Design Choices:
OpenQA jobs from all flavors are aggregated into a single check,
ensuring approval is only granted if every flavor passes openQA tests.

Related issue: https://progress.opensuse.org/issues/203874