### PR TITLE
test: ignore local .env for consistent tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,8 @@ def _auto_clear_cache() -> None:
 def _session_settings() -> dict[str, Any]:
     """Capture default settings once per session to speed up test reset."""
     with patch.dict(os.environ, {}, clear=True), patch("osc.conf.get_config", side_effect=RuntimeError):
-        defaults = Settings()
+        # _env_file=None ignores any developer-local .env so defaults stay deterministic
+        defaults = Settings(_env_file=None)
         return {key: getattr(defaults, key) for key in Settings.model_fields}
 
 

--- a/tests/test_openqabot.py
+++ b/tests/test_openqabot.py
@@ -17,7 +17,7 @@ from typer.testing import CliRunner
 
 from openqabot.args import app
 from openqabot.args import main as args_main
-from openqabot.config import QEM_DASHBOARD
+from openqabot.config import settings
 from openqabot.errors import PostOpenQAError
 from openqabot.main import main
 from openqabot.openqa import OpenQAInterface
@@ -193,7 +193,7 @@ def mock_runtime(mocker: MockerFixture) -> None:
 def test_passed(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     bot = OpenQABot(mocked_openqa_bot)
-    responses.add(responses.PUT, f"{QEM_DASHBOARD}bar", json={"id": 234})
+    responses.add(responses.PUT, f"{settings.qem_dashboard_url}bar", json={"id": 234})
     bot()
 
     assert len(caplog.messages) == 7
@@ -206,7 +206,7 @@ def test_passed(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) 
 def test_passed_non_osd(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     bot = OpenQABot(mocked_openqa_bot)
-    responses.add(responses.PUT, f"{QEM_DASHBOARD}bar")
+    responses.add(responses.PUT, f"{settings.qem_dashboard_url}bar")
     bot()
 
     assert len(caplog.messages) == 7
@@ -220,7 +220,7 @@ def test_passed_non_osd(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureF
 def test_passed_post_osd_failed(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     bot = OpenQABot(mocked_openqa_bot)
-    responses.add(responses.PUT, f"{QEM_DASHBOARD}bar")
+    responses.add(responses.PUT, f"{settings.qem_dashboard_url}bar")
     bot()
 
     assert len(caplog.messages) == 7
@@ -238,7 +238,7 @@ def test_post_qem_success(mocked_openqa_bot: Namespace, mocker: MockerFixture) -
     test_data = {"status": "passed", "job_id": 999}
     responses.add(
         responses.PUT,
-        f"{QEM_DASHBOARD}{test_api}",
+        f"{settings.qem_dashboard_url}{test_api}",
         json={"id": 12345},
         status=200,
     )
@@ -246,7 +246,7 @@ def test_post_qem_success(mocked_openqa_bot: Namespace, mocker: MockerFixture) -
     bot.post_qem(test_data, test_api)
 
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == f"{QEM_DASHBOARD}{test_api}"
+    assert responses.calls[0].request.url == f"{settings.qem_dashboard_url}{test_api}"
 
 
 @responses.activate

--- a/tests/test_openqaclient.py
+++ b/tests/test_openqaclient.py
@@ -13,7 +13,7 @@ import responses
 from openqa_client.exceptions import RequestError
 from responses import matchers
 
-from openqabot.config import QEM_DASHBOARD
+from openqabot.config import settings
 from openqabot.errors import PostOpenQAError
 from openqabot.openqa import OpenQAInterface as oQAI
 
@@ -32,14 +32,14 @@ def fake_osd_rsp(fake_openqa_url: str) -> None:
 def fake_responses_failing_job_update() -> None:
     responses.add(
         responses.PATCH,
-        f"{QEM_DASHBOARD}api/jobs/42",
+        f"{settings.qem_dashboard_url}api/jobs/42",
         body="updated job",
         status=200,
         match=[matchers.json_params_matcher({"obsolete": False})],  # should *not* match
     )
     responses.add(
         responses.PATCH,
-        f"{QEM_DASHBOARD}api/jobs/42",
+        f"{settings.qem_dashboard_url}api/jobs/42",
         body="job not found",  # we pretend the job update fails
         status=404,
         match=[matchers.json_params_matcher({"obsolete": True})],

--- a/tests/test_smeltsync.py
+++ b/tests/test_smeltsync.py
@@ -12,7 +12,7 @@ import responses
 from pytest_mock import MockerFixture
 from responses import matchers
 
-from openqabot.config import QEM_DASHBOARD, SMELT
+from openqabot.config import SMELT, settings
 from openqabot.smeltsync import SMELTSync
 
 
@@ -79,7 +79,7 @@ def fake_dashboard_replyback() -> None:
 
     responses.add_callback(
         responses.PATCH,
-        re.compile(f"{QEM_DASHBOARD}api/incidents"),
+        re.compile(f"{settings.qem_dashboard_url}api/incidents"),
         callback=reply_callback,
         match=[matchers.query_param_matcher({})],
     )

--- a/tests/test_subsyncres.py
+++ b/tests/test_subsyncres.py
@@ -10,7 +10,7 @@ import pytest
 import responses
 from pytest_mock import MockerFixture
 
-from openqabot.config import QEM_DASHBOARD
+from openqabot.config import settings
 from openqabot.subsyncres import SubResultsSync
 
 openqa_url = (
@@ -35,7 +35,7 @@ def mock_dashboard_settings() -> None:
             "version": "13.3",
         },
     ]
-    responses.add(method="GET", url=f"{QEM_DASHBOARD}api/incident_settings/100", json=data)
+    responses.add(method="GET", url=f"{settings.qem_dashboard_url}api/incident_settings/100", json=data)
 
 
 @pytest.fixture


### PR DESCRIPTION
* test: capture default settings ignoring local .env
* test: resolve dashboard URL at runtime not import time
