### PR TITLE
chore(deps): deduplicate dependabot config using YAML anchors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,39 +2,29 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 5
-    labels:
-      - "waiting"
-      - "dependencies"
-    commit-message:
-      prefix: "chore"
-      include: scope
+    <<: &common
+      directory: "/"
+      schedule:
+        interval: "weekly"
+        day: "monday"
+      cooldown:
+        default-days: 7
+      open-pull-requests-limit: 5
+      labels:
+        - "waiting"
+        - "dependencies"
+      commit-message:
+        prefix: "chore"
+        include: scope
     groups:
       all-dependencies:
         patterns:
           - "*"
         update-types:
           - "major"
+
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 5
-    labels:
-      - "waiting"
-      - "dependencies"
-    commit-message:
-      prefix: "chore"
-      include: scope
+    <<: *common
     groups:
       all-actions:
         patterns:


### PR DESCRIPTION
Motivation:
The `dependabot.yml` configuration had substantial repetition across
ecosystems for standard properties like `schedule`, `directory`, `labels`,
`cooldown`, and `commit-message`.

Design Choices:
Implemented a YAML anchor (`&common`) on the pip ecosystem update definition
and used the merge key (`<<: *common`) on subsequent ecosystem configurations.

Benefits:
Reduces line count and makes future shared Dependabot configuration changes
(e.g., altering schedule or adding labels) much easier and less error-prone.