### PR TITLE
fix: separate OBS build links with double newlines

### DIFF
--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -213,6 +213,7 @@ class Commenter:
         """Generate markdown for openQA badges."""
         base_url = self.client.openqa.baseurl
         badge_msg = ""
+        separator = "\n" if sub.is_gitea else "\n\n"
         for b in sorted(builds):
             params = b.get_base_badge_params()
             label = f"Build {b.build}"
@@ -220,7 +221,7 @@ class Commenter:
             query = urlencode(params, safe="*")
             badge_url = f"{base_url}/tests/overview/badge?{query}"
             link_url = f"{base_url}/tests/overview?{query}"
-            badge_msg += sub.format_link(f"{label} Results", link_url, badge_url) + "\n"
+            badge_msg += sub.format_link(f"{label} Results", link_url, badge_url) + separator
         return badge_msg.strip()
 
     def _generate_detail_section(

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -368,6 +368,8 @@ def test_summarize_message(
         "https://openqa.opensuse.org/tests/overview/badge?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2"
         in result_gitea
     )
+    # Gitea links are separated by exactly one newline
+    assert "label=Build+1.1)\n[![Build 1.2 Results]" in result_gitea
 
     result_obs = c.summarize_message(OBSCommentable(124), set(builds), [])
     assert (
@@ -375,6 +377,12 @@ def test_summarize_message(
         in result_obs
     )
     assert (
+        "[Build 1.2 Results](https://openqa.opensuse.org/tests/overview?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2)"
+        in result_obs
+    )
+    # OBS links are separated by double newlines for line breaks
+    assert (
+        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*&label=Build+1.1)\n\n"
         "[Build 1.2 Results](https://openqa.opensuse.org/tests/overview?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2)"
         in result_obs
     )


### PR DESCRIPTION
Motivation:
Multiple build results posted to OBS are currently joined with single newlines,
which renders them inline on a single line and hurts readability.

Design Choices:
Use double newlines as a separator specifically for non-Gitea/OBS comments,
while preserving single newlines for Gitea to avoid altering badge spacing.

Benefits:
The build result links on OBS are now rendered as distinct block paragraphs,
drastically improving accessibility and readability.

Related issue: https://build.suse.de/requests/417379