### PR TITLE
fix: pick representative package name for submissions

### DIFF
--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -17,7 +17,7 @@ import requests
 import openqabot.config as config_module
 from openqabot import config, dashboard
 from openqabot.errors import NoResultsError
-from openqabot.types.submission import Submission
+from openqabot.types.submission import Submission, sort_packages
 from openqabot.types.types import Data
 
 if TYPE_CHECKING:
@@ -271,6 +271,9 @@ def update_submissions(data: list[dict[str, Any]], **kwargs: Any) -> int:  # ruf
     """Synchronize submission records with the dashboard."""
     retry = kwargs.get("retry", 0)
     query_params = kwargs.get("params", {})
+    for record in data:
+        if packages := record.get("packages"):
+            record["packages"] = sort_packages(packages)
     while retry >= 0:
         retry -= 1
         try:

--- a/openqabot/types/submission.py
+++ b/openqabot/types/submission.py
@@ -22,6 +22,55 @@ version_pattern = re.compile(r"(\d+(?:[.-](?:SP)?\d+)?)")
 EXPECTED_PART_LENGTH_WITH_ARCH = 3
 EXPECTED_PART_LENGTH_NO_ARCH = 2
 
+# Structural, package-agnostic suffixes marking arch-specific builds or
+# subpackages/flavors. Packages matching these are demoted when picking a
+# representative name so meaningful sources (e.g. "kernel-default") win over
+# arch/flavor variants (e.g. "dtb-aarch64", "kernel-syms").
+_DEMOTED_SUFFIXES = (
+    "-aarch64",
+    "-armv7l",
+    "-armv6l",
+    "-x86_64",
+    "-i586",
+    "-i686",
+    "-ppc64le",
+    "-ppc64",
+    "-s390x",
+    "-riscv64",
+    "-64kb",
+    "-lpae",
+    "-devel",
+    "-debuginfo",
+    "-debugsource",
+    "-doc",
+    "-docs",
+    "-lang",
+    "-static",
+    "-32bit",
+    "-base",
+    "-source",
+    "-syms",
+    "-obs-build",
+    "-obs-qa",
+    "-kvmsmall",
+    "-zfcpdump",
+    "-debug",
+)
+_DEMOTED_SUBSTRINGS = ("-livepatch-",)
+
+
+def _package_sort_key(name: str) -> tuple[bool, int, str]:
+    demoted = name.endswith(_DEMOTED_SUFFIXES) or any(s in name for s in _DEMOTED_SUBSTRINGS)
+    return (demoted, len(name), name)
+
+
+def sort_packages(names: list[str]) -> list[str]:
+    """Order packages so the most representative one comes first.
+
+    Non arch/flavor packages rank first, then shorter, then alphabetical.
+    """
+    return sorted(names, key=_package_sort_key)
+
 
 class Submission:
     """Information about a submission."""
@@ -71,7 +120,7 @@ class Submission:
 
     def _initialize_packages(self, raw_packages: list[str]) -> None:
         """Initialize packages from raw package data."""
-        self.packages: list[str] = sorted(raw_packages, key=len)
+        self.packages: list[str] = sort_packages(raw_packages)
         if not self.packages:
             raise EmptyPackagesError(self.project)
 

--- a/tests/test_loader_qem.py
+++ b/tests/test_loader_qem.py
@@ -360,6 +360,13 @@ def test_update_submissions_success(mock_patch: MagicMock, caplog: pytest.LogCap
     assert "QEM Dashboard submissions updated successfully" in caplog.records[0].message
 
 
+def test_update_submissions_reorders_packages(mock_patch: MagicMock) -> None:
+    mock_patch.return_value.status_code = 200
+    data = [{"packages": ["dtb-aarch64", "kernel-default", "kernel-syms"]}]
+    update_submissions(data)
+    assert mock_patch.call_args.kwargs["json"][0]["packages"][0] == "kernel-default"
+
+
 def test_update_submissions_request_exception(mock_patch: MagicMock, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.ERROR)
     mock_patch.side_effect = requests.exceptions.RequestException

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from openqabot.errors import EmptyChannelsError, EmptyPackagesError, NoRepoFoundError
-from openqabot.types.submission import Submission
+from openqabot.types.submission import Submission, sort_packages
 from openqabot.types.types import ArchVer, Repos
 
 from .fixtures.submissions import MockSubmission
@@ -43,6 +43,40 @@ test_data = {
     "embargoed": True,
     "priority": 600,
 }
+
+
+@pytest.mark.parametrize(
+    ("packages", "expected_first"),
+    [
+        pytest.param(
+            [
+                "dtb-aarch64",
+                "dtb-armv7l",
+                "kernel-64kb",
+                "kernel-debug",
+                "kernel-default",
+                "kernel-default-base",
+                "kernel-docs",
+                "kernel-kvmsmall",
+                "kernel-livepatch-SLE15-SP6_Update_29",
+                "kernel-lpae",
+                "kernel-obs-build",
+                "kernel-obs-qa",
+                "kernel-source",
+                "kernel-syms",
+                "kernel-zfcpdump",
+            ],
+            "kernel-default",
+            id="kernel source wins over arch/flavor variants",
+        ),
+        pytest.param(["nginx"], "nginx", id="single package unchanged"),
+        pytest.param(["curl", "libcurl4", "libcurl-devel"], "curl", id="devel subpackage demoted"),
+        pytest.param(["foo-devel", "foo-debuginfo"], "foo-devel", id="all-demoted falls back to shortest"),
+        pytest.param(["bbb", "aaa"], "aaa", id="alphabetical tie-break for determinism"),
+    ],
+)
+def test_sort_packages_representative_first(packages: list[str], expected_first: str) -> None:
+    assert sort_packages(packages)[0] == expected_first
 
 
 @pytest.fixture


### PR DESCRIPTION
Motivation: Submissions on qem-dashboard were titled after the first or
shortest package name, yielding confusing entries like "45152:dtb-aarch64"
instead of the meaningful "kernel-default".

Design Choices: Add a shared sort_packages heuristic demoting packages with
arch or subpackage/flavor suffixes, applied both to the dashboard payload
(update_submissions, covering smelt and gitea) and the Submission package
order used for the openQA BUILD string.

Benefits: Both the dashboard title (packages[0]) and the openQA BUILD now
show the representative source package, with no dashboard change required.