### PR TITLE
fix: skip aggregate retrigger on unchanged repohash across days

### DIFF
--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -64,11 +64,10 @@ class Aggregate(BaseConf):
     @staticmethod
     def get_buildnr(repohash: str, old_repohash: str, build: str) -> str:
         """Determine the next build number based on current date and repohash."""
-        today = datetime.datetime.now(tz=UTC).date().strftime("%Y%m%d")
-
-        if build.startswith(today) and repohash == old_repohash:
+        if repohash == old_repohash:
             raise SameBuildExistsError
 
+        today = datetime.datetime.now(tz=UTC).date().strftime("%Y%m%d")
         counter = int(build.rsplit("-", maxsplit=1)[-1]) + 1 if build.startswith(today) else 1
         return f"{today}-{counter}"
 

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -193,10 +193,27 @@ def test_aggregate_call_pc_pint_fail(
     assert "No PINT image found for query" in caplog.text
 
 
-def test_get_buildnr_same_build() -> None:
-    today = datetime.datetime.now(tz=UTC).date().strftime("%Y%m%d")
+@pytest.mark.parametrize(
+    "old_build_days_ago",
+    [0, 2],
+    ids=["same-day", "prior-day-unchanged-repo"],
+)
+def test_get_buildnr_same_repohash_skips(old_build_days_ago: int) -> None:
+    old_date = datetime.datetime.now(tz=UTC).date() - datetime.timedelta(days=old_build_days_ago)
+    old_build = old_date.strftime("%Y%m%d") + "-1"
     with pytest.raises(SameBuildExistsError):
-        Aggregate.get_buildnr("hash", "hash", today + "-1")
+        Aggregate.get_buildnr("hash", "hash", old_build)
+
+
+def test_get_buildnr_new_repohash_increments_same_day() -> None:
+    today = datetime.datetime.now(tz=UTC).date().strftime("%Y%m%d")
+    assert Aggregate.get_buildnr("new", "old", today + "-1") == today + "-2"
+
+
+def test_get_buildnr_new_repohash_resets_on_new_day() -> None:
+    today = datetime.datetime.now(tz=UTC).date().strftime("%Y%m%d")
+    old_build = (datetime.datetime.now(tz=UTC).date() - datetime.timedelta(days=2)).strftime("%Y%m%d") + "-5"
+    assert Aggregate.get_buildnr("new", "old", old_build) == today + "-1"
 
 
 def test_filter_submissions_embargoed(


### PR DESCRIPTION
Motivation: qem-bot rescheduled aggregate openQA tests even when the
repohash was unchanged, wasting worker capacity, because the
same-repohash skip only fired when the previous build was from today.
This is not a regression: the date-gated skip has existed since the
initial commit.

Design Choices: Decouple the skip decision from the daily counter. Raise
SameBuildExistsError whenever repohash equals the previous repohash,
regardless of the previous build date; keep counter reset/increment for
the differing-repohash case.

Benefits: Eliminates unnecessary retriggers when repo content is
unchanged across days and simplifies get_buildnr.

Related issue: https://gitlab.suse.de/qa-maintenance/bot-ng/-/jobs/7155840