### PR TITLE
fix: skip incident retrigger on transient dashboard API failure

### DIFF
--- a/openqabot/errors.py
+++ b/openqabot/errors.py
@@ -53,3 +53,7 @@ class AmbiguousApprovalStatusError(Error):
 
 class PostOpenQAError(Error):
     """Raised when posting a job to openQA fails."""
+
+
+class DashboardError(Error):
+    """Raised when a dashboard API request fails or returns unusable data."""

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import requests
 
 from openqabot.config import OBSOLETE_PARAMS, settings
+from openqabot.errors import DashboardError
 from openqabot.loader import gitea
 from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_image
 from openqabot.utils import retry3 as retried_requests
@@ -78,23 +79,31 @@ class Submissions(BaseConf):
 
     @staticmethod
     def _get_scheduled_jobs(sub_id: int, submission_type: str | None = None) -> list[dict[str, Any]]:
-        """Fetch scheduled jobs from the dashboard."""
+        """Fetch scheduled jobs from the dashboard, raising DashboardError on failure."""
         try:
             url = settings.dashboard_url("api", "incident_settings", sub_id)
             params = {"type": submission_type} if submission_type else {}
             res = retried_requests.get(url, headers=settings.dashboard_token_dict, params=params).json()
-            return res if isinstance(res, list) else []
-        except (requests.exceptions.RequestException, json.JSONDecodeError):
+        except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
             log.exception("Dashboard API error: Could not retrieve scheduled jobs for submission %s", sub_id)
-            return []
+            raise DashboardError from e
+        return res if isinstance(res, list) else []
 
     @staticmethod
     def is_scheduled_job(ctx: SubContext, ver: str, submission_type: str | None = None) -> bool:
-        """Check if a job is already scheduled in the dashboard."""
+        """Check if a job is already scheduled in the dashboard.
+
+        If the dashboard API fails, treat the job as already scheduled so a
+        transient error does not trigger an unnecessary reschedule.
+        """
         if not (revs := ctx.sub.revisions_with_fallback(ctx.arch, ver)):
             return False
 
-        jobs = Submissions._get_scheduled_jobs(ctx.sub.id, submission_type)
+        try:
+            jobs = Submissions._get_scheduled_jobs(ctx.sub.id, submission_type)
+        except DashboardError:
+            return True
+
         return any(
             job["flavor"] == ctx.flavor
             and job["arch"] == ctx.arch

--- a/tests/test_submissions_gitea.py
+++ b/tests/test_submissions_gitea.py
@@ -4,6 +4,7 @@
 
 import responses
 
+from openqabot.config import settings as global_settings
 from openqabot.types.baseconf import JobConfig
 from openqabot.types.submissions import Submissions
 from openqabot.types.types import ArchVer, Repos
@@ -60,6 +61,9 @@ def test_gitea_submissions() -> None:
     issues = {"BASE_TEST_ISSUES": "SLFO:1.1.99#15.99"}
     flavor = "AAA"
     test_config = {"FLAVOR": {flavor: {"archs": archs, "issues": issues, "versioned_by_submission": True}}}
+
+    # no jobs scheduled yet on the dashboard
+    responses.add(responses.GET, f"{global_settings.qem_dashboard_url}api/incident_settings/42", json=[])
 
     # create a Git-based submission
     sub = MockSubmission(type="git")

--- a/tests/test_submissions_handle.py
+++ b/tests/test_submissions_handle.py
@@ -4,10 +4,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
 import pytest
+import requests
 
 from openqabot.config import DEFAULT_SUBMISSION_TYPE
 from openqabot.errors import NoRepoFoundError
@@ -133,10 +135,36 @@ def test_handle_submission_with_ci_url(mocker: MockerFixture) -> None:
     assert result["openqa"]["__CI_JOB_URL"] == "http://my-ci.com/123"
 
 
-def test_is_scheduled_job_error(mocker: MockerFixture) -> None:
-    sub = MockSubmission()
+def test_is_scheduled_job_non_list_response(mocker: MockerFixture) -> None:
+    sub = MockSubmission(rev_fallback_value=42)
     sub.id = 1
     mocker.patch("openqabot.types.submissions.retried_requests.get").return_value.json.return_value = {"error": "foo"}
+    ctx = SubContext(sub, "arch", "flavor", {})
+    assert not Submissions.is_scheduled_job(ctx, "ver")
+
+
+@pytest.mark.parametrize("failure", ["json", "request"])
+def test_is_scheduled_job_treats_api_error_as_scheduled(mocker: MockerFixture, failure: str) -> None:
+    # On a dashboard API error is_scheduled_job returns True so the caller
+    # skips scheduling instead of retriggering on a transient failure.
+    sub = MockSubmission(rev_fallback_value=42)
+    sub.id = 1
+    get = mocker.patch("openqabot.types.submissions.retried_requests.get")
+    if failure == "json":
+        get.return_value.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
+    else:
+        get.side_effect = requests.exceptions.RequestException("boom")
+    ctx = SubContext(sub, "arch", "flavor", {})
+    assert Submissions.is_scheduled_job(ctx, "ver")
+
+
+def test_is_scheduled_job_recovers_after_error(mocker: MockerFixture) -> None:
+    # On an API error the job is treated as scheduled but nothing is persisted,
+    # so once the dashboard recovers and reports no jobs the bot schedules the
+    # missing job again.
+    sub = MockSubmission(rev_fallback_value=42)
+    sub.id = 1
+    mocker.patch("openqabot.types.submissions.retried_requests.get").return_value.json.return_value = []
     ctx = SubContext(sub, "arch", "flavor", {})
     assert not Submissions.is_scheduled_job(ctx, "ver")
 


### PR DESCRIPTION
Motivation: A dashboard API error while checking already-scheduled
incident jobs was swallowed and treated as "no jobs", so incidents were
rescheduled on transient failures (seen as JSONDecodeError in job
7155840), wasting openQA capacity.

Design Choices: Make the dedup guard fail closed to match the aggregate
path. _get_scheduled_jobs raises a dedicated DashboardError on API
failure and always returns a list otherwise; is_scheduled_job catches it
and treats the incident as already scheduled, skipping it instead of
rescheduling on incomplete data. Signalling failure via an exception
avoids a tri-state None return that callers could misread.

Benefits: Transient dashboard outages no longer cause unnecessary
incident retriggers; submissions and aggregate paths now share the same
fail-closed default with a self-documenting error path.

Related issue: https://gitlab.suse.de/qa-maintenance/bot-ng/-/jobs/7155840