### PR TITLE
build(deps): drop dataclasses dependency from the project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "dataclasses",
     "osc",
     "openqa-client",
     "pika",


### PR DESCRIPTION
As of version 0.4 `dataclasses` no longer works with Python 3.7. Since the project require python 3.13.0 `dataclasses` are already present within the standard library in stdlib.

https://pypi.org/project/dataclasses/