### PR TITLE
feat: fetch Gitea PR priorities using SMELT API v2

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -25,6 +25,7 @@ from osc.connection import http_GET
 from osc.core import MultibuildFlavorResolver
 
 from openqabot import config
+from openqabot.loader.smelt import get_gitea_update_data
 from openqabot.types.pullrequest import PullRequest
 from openqabot.utils import retry10 as retried_requests
 
@@ -740,6 +741,8 @@ def _build_submission_record(
     if not submission["packages"]:
         log.info("PR git:%s skipped: No packages found", pr.number)
         return None
+
+    submission["priority"], submission["emu"] = get_gitea_update_data(pr.project, pr.number)
 
     return submission
 

--- a/openqabot/loader/smelt.py
+++ b/openqabot/loader/smelt.py
@@ -4,10 +4,12 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from concurrent import futures
 from logging import getLogger
 from typing import Any, cast
 
+import requests
 from jsonschema import ValidationError, validate
 
 from openqabot import config
@@ -129,6 +131,29 @@ def get_json(query: str, host: str | None = None) -> dict[str, Any]:
     """Fetch JSON data from SMELT using a GraphQL query."""
     host = host or config.settings.smelt_graphql
     return retried_requests.get(host, params={"query": query}, verify=not config.settings.insecure).json()
+
+
+def _gitea_update_id(gitea_host: str, project: str, pr_number: int) -> str:
+    return f"{gitea_host}:{project.replace('/', ':')}:{pr_number}"
+
+
+def get_gitea_update_data(project: str, pr_number: int) -> tuple[int, bool]:
+    """Get priority and emu flag for a Gitea-based submission from SMELT API v2."""
+    gitea_host = urllib.parse.urlparse(config.settings.gitea_url).netloc
+    update_id = _gitea_update_id(gitea_host, project, pr_number)
+    encoded_id = urllib.parse.quote(update_id)
+    url = f"{config.settings.smelt_url}/api/experimental/v2/updates/{encoded_id}"
+
+    try:
+        response = retried_requests.get(url, verify=not config.settings.insecure)
+        response.raise_for_status()
+        res = response.json()
+    except (requests.exceptions.RequestException, ValueError, TypeError) as e:
+        log.warning("Could not get SMELT v2 update data for %s: %s", update_id, e)
+        return 0, False
+
+    data = res.get("data", {})
+    return data.get("priority", 0), data.get("is_emergency", False)
 
 
 def get_active_submission_ids() -> set[int]:

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -53,6 +53,18 @@ def fake_gitea_api() -> None:
     responses.add(GET, issues_url + "/124/comments", json=read_json_file("comments-124"))
     responses.add(GET, re.compile(issues_url + r"/.*/comments"), json=[])
     responses.add(GET, urljoin(host, patchinfo_path), body=patchinfo_data)
+    responses.add(
+        GET,
+        re.compile(r"https://smelt\.suse\.de/api/experimental/v2/updates/.*"),
+        json={
+            "status": "success",
+            "data": {
+                "id": "src.suse.de:products:SLFO:124",
+                "priority": 1325,
+                "is_emergency": False,
+            },
+        },
+    )
 
 
 @pytest.fixture
@@ -174,7 +186,7 @@ def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCapture
     assert "Loaded 7 active PRs from products/SLFO" in caplog.messages
     assert "Fetching info for PR git:131 from Gitea" in caplog.messages
     assert "Syncing Gitea PRs to QEM Dashboard: Considering 1 submissions" in caplog.messages
-    assert len(responses.calls) == 24
+    assert any("/api/experimental/v2/updates/" in cast("Any", call.request).url for call in responses.calls)
     assert len(cast("Any", responses.calls[-1].response).json()) == 1
     submission = cast("Any", responses.calls[-1].response).json()[0]
     assert submission["number"] == 124
@@ -192,7 +204,7 @@ def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCapture
     assert submission["isActive"]
     assert not submission["approved"]
     assert not submission["embargoed"]
-    assert submission["priority"] == 0
+    assert submission["priority"] == 1325
 
     # expect the scminfo from the product repo of the configured product
     assert "18bfa2a23fb7985d5d0" in submission["scminfo"]

--- a/tests/test_loader_smelt.py
+++ b/tests/test_loader_smelt.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: MIT
 """Test loader SMELT."""
 
+import re
 from unittest.mock import patch
 
 import pytest
+import requests
+import responses
 from jsonschema import ValidationError, validate
 from pytest_mock import MockerFixture
 
@@ -12,6 +15,7 @@ from openqabot.loader.smelt import (
     ACTIVE_INC_SCHEMA,
     INCIDENT_SCHEMA,
     get_active_submission_ids,
+    get_gitea_update_data,
     get_submission_from_smelt,
 )
 
@@ -161,3 +165,24 @@ def test_incident_schema_validation() -> None:
     }
     # Should not raise
     validate(instance=valid_data, schema=INCIDENT_SCHEMA)
+
+
+@responses.activate
+def test_get_gitea_update_data_success() -> None:
+    """Test get_gitea_update_data with a successful API response."""
+    responses.add(
+        responses.GET,
+        re.compile(r".*/api/experimental/v2/updates/.*"),
+        json={"status": "success", "data": {"priority": 366, "is_emergency": True}},
+    )
+    assert get_gitea_update_data("project", 123) == (366, True)
+
+
+def test_get_gitea_update_data_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """Test get_gitea_update_data with a failing API response."""
+    with patch(
+        "openqabot.loader.smelt.retried_requests.get", side_effect=requests.exceptions.RequestException("API error")
+    ):
+        res = get_gitea_update_data("project", 123)
+    assert res == (0, False)
+    assert "Could not get SMELT v2 update data" in caplog.text


### PR DESCRIPTION
Motivation:
Gitea PR-based SLE maintenance updates did not show correct priorities on the
blocked dashboard.

Design Choices:
Query the SMELT API v2 experimental updates endpoint using the Gitea update ID
(host:project:pr_number) to retrieve priority and is_emergency values.

Benefits:
The blocked dashboard properly displays accurate priorities for Gitea PR
submissions, allowing proper default sorting and ordering.

Related issue: https://progress.opensuse.org/issues/197348