### PR TITLE
feat: add native support for retry bot execution

### DIFF
--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -62,6 +62,11 @@ class Settings(BaseSettings):
             if name := by_alias.get(key, key if key in self.__class__.model_fields else None):
                 setattr(self, name, value)
 
+    # Error tolerance settings
+    app_max_retries: int = Field(default=1, alias="APP_MAX_RETRIES")
+    app_backoff_factor: int = Field(default=60, alias="APP_BACKOFF_FACTOR")
+    app_same_error_limit: int = Field(default=2, alias="APP_SAME_ERROR_LIMIT")
+    app_error_similarity: int = Field(default=90, alias="APP_ERROR_SIMILARITY")
     # Global options
     configs: Path = Field(default=Path("/etc/openqabot"), alias="QEM_BOT_CONFIGS")
     dry: bool = Field(default=False, alias="QEM_BOT_DRY")

--- a/openqabot/main.py
+++ b/openqabot/main.py
@@ -2,20 +2,62 @@
 # SPDX-License-Identifier: MIT
 """Entry point for the application."""
 
+import hashlib
 import sys
+import time
+import traceback
+from collections import defaultdict
+from logging import Logger
 
 from dotenv import load_dotenv
 
+import openqabot.config as config_module
+
 from .args import app
 from .utils import create_logger
+
+errorcnt = defaultdict(int)
+error_limit = 10
+
+
+def _handle_exception(e: Exception, log: Logger) -> None:
+    tb = traceback.extract_tb(e.__traceback__)
+    frames = [(frame.filename, frame.name) for frame in tb]
+    signature = f"{type(e).__name__}:" + "->".join(f"{filename}:{func_name}" for filename, func_name in frames)
+    k = hashlib.sha256(signature.encode("utf-8")).hexdigest()
+    errorcnt[k] += 1
+    count = errorcnt[k]
+    log.debug("exception: %s, errorcount: %d", k, count)
+    if count > error_limit:
+        log.error("error limit hit for exception %s, reraising", k)
+        raise e
+    log.info("Exception %s encountered, error count increased", e)
+
+
+def _run_attempt(attempt: int, log: Logger) -> bool:
+    try:
+        app()
+    except KeyboardInterrupt:
+        log.info("Interrupted by user")
+        sys.exit(1)
+    except Exception as ex:  # noqa: BLE001
+        _handle_exception(ex, log)
+    else:
+        return True
+
+    retries = config_module.settings.app_max_retries
+    delay = config_module.settings.app_backoff_factor * attempt
+    log.warning("attempt %d/%d failed, retrying in %ds", attempt, retries, delay)
+    time.sleep(delay)
+    return False
 
 
 def main() -> None:
     """Run the main entry point of the bot."""
     load_dotenv()
     log = create_logger("bot")
-    try:
-        app()
-    except KeyboardInterrupt:
-        log.info("Interrupted by user")
-        sys.exit(1)
+    attempt = 0
+    while attempt < config_module.settings.app_max_retries:
+        if _run_attempt(attempt, log):
+            break
+        attempt += 1

--- a/tests/test_openqabot.py
+++ b/tests/test_openqabot.py
@@ -19,7 +19,7 @@ from openqabot.args import app
 from openqabot.args import main as args_main
 from openqabot.config import settings
 from openqabot.errors import PostOpenQAError
-from openqabot.main import main
+from openqabot.main import errorcnt, main
 from openqabot.openqa import OpenQAInterface
 from openqabot.openqabot import OpenQABot
 
@@ -261,3 +261,69 @@ def test_post_qem_dry(mocked_openqa_bot: Namespace, mocker: MockerFixture) -> No
     bot.post_qem(test_data, test_api)
 
     assert len(responses.calls) == 0
+
+
+class MainTestError(Exception):
+    """Custom exception class for main tests to satisfy ruff rules."""
+
+
+def test_main_success(mocker: MockerFixture) -> None:
+    mock_app = mocker.patch("openqabot.main.app")
+    mock_logger = mocker.Mock()
+    mocker.patch("openqabot.main.create_logger", return_value=mock_logger)
+    mocker.patch("openqabot.main.load_dotenv")
+
+    main()
+
+    mock_app.assert_called_once()
+
+
+def test_main_retry_success(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "app_max_retries", 3)
+    mocker.patch.object(settings, "app_backoff_factor", 1)
+    mock_sleep = mocker.patch("openqabot.main.time.sleep")
+
+    call_count = 0
+
+    def side_effect() -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            msg = "Test error"
+            raise MainTestError(msg)
+
+    mocker.patch("openqabot.main.app", side_effect=side_effect)
+    mock_logger = mocker.Mock()
+    mocker.patch("openqabot.main.create_logger", return_value=mock_logger)
+    mocker.patch("openqabot.main.load_dotenv")
+
+    errorcnt.clear()
+
+    main()
+
+    assert call_count == 2
+    mock_sleep.assert_called_once_with(0)
+
+
+def test_main_exception_limit_reraise(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "app_max_retries", 15)
+    mocker.patch.object(settings, "app_backoff_factor", 0)
+    mocker.patch("openqabot.main.time.sleep")
+
+    def side_effect() -> None:
+        msg = "Persistent error"
+        raise MainTestError(msg)
+
+    mocker.patch("openqabot.main.app", side_effect=side_effect)
+    mock_logger = mocker.Mock()
+    mocker.patch("openqabot.main.create_logger", return_value=mock_logger)
+    mocker.patch("openqabot.main.load_dotenv")
+
+    errorcnt.clear()
+
+    with pytest.raises(MainTestError, match="Persistent error"):
+        main()
+
+    assert len(errorcnt) == 1
+    key = next(iter(errorcnt))
+    assert errorcnt[key] == 11


### PR DESCRIPTION
ticket: https://progress.opensuse.org/issues/204009

currently we using external tooling to achieve the same.
Native retry also track if similar exceptions are happening
and quit early when we just re-trying on same error. Inspired by https://github.com/okurz/leaky_bucket_error_count
