### PR TITLE
feat: eliminate architecture ambiguity in IncrementConfig

### DIFF
--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -43,7 +43,6 @@ class IncrementConfig:
     distri: str
     version: str
     flavor: str
-    arch: str = "any"
     flavor_suffix: str = DEFAULT_FLAVOR_SUFFIX
     project_base: str = ""
     build_project_suffix: str = ""
@@ -125,9 +124,7 @@ class IncrementConfig:
 
     def accepts_build_info(self, build_info: BuildInfo) -> bool:
         """Return True if the build information matches this configuration."""
-        if not all(
-            getattr(self, k) in {"any", getattr(build_info, k)} for k in ("distri", "flavor", "version", "arch")
-        ):
+        if not all(getattr(self, k) in {"any", getattr(build_info, k)} for k in ("distri", "flavor", "version")):
             return False
         if self.archs and build_info.arch not in self.archs:
             return False
@@ -143,11 +140,14 @@ class IncrementConfig:
     @classmethod
     def from_config_entry(cls, entry: dict[str, Any]) -> IncrementConfig:
         """Create an IncrementConfig from a dictionary entry."""
+        archs = set(entry.get("archs", []))
+        # Fold the singular "arch" key into "archs" so architecture filtering has a single source of truth.
+        if (arch := entry.get("arch", "any")) != "any":
+            archs.add(arch)
         return cls(
             distri=entry["distri"],
             version=entry.get("version", "any"),
             flavor=entry.get("flavor", "any"),
-            arch=entry.get("arch", "any"),
             flavor_suffix=entry.get("flavor_suffix", DEFAULT_FLAVOR_SUFFIX),
             project_base=entry["project_base"],
             build_project_suffix=entry["build_project_suffix"],
@@ -157,7 +157,7 @@ class IncrementConfig:
             product_regex=entry["product_regex"],
             version_regex=entry.get("version_regex", DEFAULT_VERSION_REGEX),
             packages=entry.get("packages", []),
-            archs=set(entry.get("archs", [])),
+            archs=archs,
             settings=entry.get("settings", {}),
             additional_builds=entry.get("additional_builds", []),
             reference_repos=entry.get("reference_repos", {}),
@@ -187,12 +187,16 @@ class IncrementConfig:
         Only override when CLI args differ from expected defaults (not dataclass defaults).
         This allows configs to specify their own values while still supporting CLI overrides.
         """
-        cli_defaults = {"distri": "sle", "version": "any", "flavor": "any", "arch": "any"}
+        cli_defaults = {"distri": "sle", "version": "any", "flavor": "any"}
         overrides = {}
 
         for field_name, default_value in cli_defaults.items():
             if hasattr(args, field_name) and (arg_value := getattr(args, field_name)) != default_value:
                 overrides[field_name] = arg_value
+
+        # A CLI "--arch" replaces the config's "archs" set outright, so the CLI intent always wins.
+        if (arch := getattr(args, "arch", "any")) != "any":
+            overrides["archs"] = {arch}
 
         return [replace(config, **overrides) if overrides else config for config in configs]
 
@@ -201,4 +205,7 @@ class IncrementConfig:
         """Create a single IncrementConfig from CLI arguments."""
         all_fields = {f.name for f in fields(IncrementConfig)}
         config_args = {field_name: getattr(args, field_name) for field_name in all_fields if hasattr(args, field_name)}
+        # There is no "archs" CLI option, so fold the singular "--arch" into the "archs" set.
+        if (arch := getattr(args, "arch", "any")) != "any":
+            config_args["archs"] = {arch}
         return IncrementConfig(**config_args)

--- a/tests/test_loader_incrementconfig.py
+++ b/tests/test_loader_incrementconfig.py
@@ -134,7 +134,7 @@ def test_accepts_build_info_regex() -> None:
         distri="sle",
         version="any",
         flavor="Online-Increments",
-        arch="x86_64",
+        archs={"x86_64"},
         product_regex="^SLES",
         version_regex="^15.5",
     )
@@ -147,3 +147,52 @@ def test_accepts_build_info_regex() -> None:
 
     # Mismatch version
     assert not config.accepts_build_info(BuildInfo("sle", "SLES", "15.4", "Online-Increments", "x86_64", "1"))
+
+
+def test_config_parsing_with_arch() -> None:
+    entry = {
+        "distri": "sle",
+        "project_base": "BASE",
+        "build_project_suffix": "BUILD",
+        "diff_project_suffix": "DIFF",
+        "build_listing_sub_path": "path",
+        "build_regex": "regex",
+        "product_regex": "pregex",
+        "arch": "s390x",
+    }
+    config = IncrementConfig.from_config_entry(entry)
+    assert config.archs == {"s390x"}
+
+
+def test_config_parsing_with_arch_and_archs() -> None:
+    entry = {
+        "distri": "sle",
+        "project_base": "BASE",
+        "build_project_suffix": "BUILD",
+        "diff_project_suffix": "DIFF",
+        "build_listing_sub_path": "path",
+        "build_regex": "regex",
+        "product_regex": "pregex",
+        "archs": ["x86_64"],
+        "arch": "s390x",
+    }
+    config = IncrementConfig.from_config_entry(entry)
+    assert config.archs == {"x86_64", "s390x"}
+
+
+def test_config_parsing_from_args_with_arch_override() -> None:
+    path = Path("tests/fixtures/config-increment-approver")
+    configs = IncrementConfig.from_args(
+        Namespace(increment_config=path, distri="sle", version="16.0", flavor="Online-Increments", arch="s390x")
+    )
+    assert len(configs) == 2
+    assert configs[0].archs == {"s390x"}
+    assert configs[1].archs == {"s390x"}
+
+
+def test_config_parsing_from_args_direct_with_arch() -> None:
+    config = IncrementConfig.from_args(
+        Namespace(increment_config=None, distri="sle", version="16.0", flavor="Online-Increments", arch="s390x")
+    )
+    assert len(config) == 1
+    assert config[0].archs == {"s390x"}


### PR DESCRIPTION
Motivation:
Previously, `IncrementConfig` tracked target architectures using two separate fields: a singular `arch` string (from the CLI or config) and an `archs` set. This duplication led to contradictory behavior when a CLI override (e.g., `--arch aarch64`) and config definition (e.g., `archs=[x86_64]`) conflicted, as different parts of the codebase read from different fields.

Design Choices:
- Removed the singular `arch` field from `IncrementConfig` in favor of a single `archs` set representing all target architectures.
- Consolidated parsing in `from_config_entry` to automatically fold the singular `arch` config key into `archs`.
- Configured CLI overrides to directly replace `archs` with `{arch}` when a specific architecture is passed via `--arch`, ensuring CLI parameters take precedence.
- Updated unit tests to verify the unified architecture behavior and maintain 100% test coverage.

Benefits:
Unifies architecture filtering under a single source of truth (`archs`), resolving conflicts between CLI arguments and configuration files.