### PR TITLE
fix: add check to make sure that we not processing several builds

### DIFF
--- a/openqabot/errors.py
+++ b/openqabot/errors.py
@@ -51,6 +51,10 @@ class AmbiguousApprovalStatusError(Error):
     """Raised when several request IDs pointing to the same openQA job."""
 
 
+class AmbiguousBuildsError(Error):
+    """Raised when several builds are available simultenously in IBS."""
+
+
 class PostOpenQAError(Error):
     """Raised when posting a job to openQA fails."""
 

--- a/openqabot/loader/buildinfo.py
+++ b/openqabot/loader/buildinfo.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
+from openqabot.errors import AmbiguousBuildsError
 from openqabot.types.increment import BuildInfo
 from openqabot.utils import get_obs_filter_params
 from openqabot.utils import retry10 as retried_requests
@@ -33,6 +34,7 @@ def load_build_info(
     params = get_obs_filter_params(build_regex)
     log.debug("Checking for '%s' files on %s with params %s", build_regex, url, params)
     rows = retried_requests.get(url, params=params).json().get("data", [])
+    loaded_build_info_set = {}
 
     def get_build_info_from_row(row: dict[str, Any]) -> BuildInfo | None:
         name = row.get("name", "")
@@ -54,4 +56,12 @@ def load_build_info(
 
         return BuildInfo(distri, product, version, flavor, arch, build)
 
-    return {build_info for row in rows if (build_info := get_build_info_from_row(row))}
+    loaded_build_info_set = {build_info for row in rows if (build_info := get_build_info_from_row(row))}
+
+    # we expecting that all BuildInfo objects corresponds to same build
+    # if it is not like that we can not proceed further
+    if len({build_info.build for build_info in loaded_build_info_set}) > 1:
+        error_text = f"{loaded_build_info_set} contains several builds in {url} collected with {config}"
+        raise AmbiguousBuildsError(error_text)
+
+    return loaded_build_info_set

--- a/tests/test_incrementapprover_build_info.py
+++ b/tests/test_incrementapprover_build_info.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 from responses import GET
 
 from openqabot.config import BUILD_REGEX
+from openqabot.errors import AmbiguousBuildsError
 from openqabot.loader.buildinfo import load_build_info
 from openqabot.loader.incrementconfig import IncrementConfig
 from openqabot.repodiff import Package
@@ -146,3 +147,24 @@ def test_extra_builds_package_version_regex_no_match(caplog: pytest.LogCaptureFi
     build_info = BuildInfo("sle", "SLES", "16.0", "flavor", "arch", "1.1")
     res = approver.extra_builds_for_package(package, config, build_info)
     assert res is None
+
+
+def test_load_build_info_ambiguous_builds(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
+    approver = prepare_approver(caplog)
+    config = IncrementConfig(
+        distri="sle",
+        version="16.0",
+        flavor="any",
+        project_base="BASE",
+        build_project_suffix="TEST",
+        build_regex=BUILD_REGEX,
+    )
+    mocker.patch("openqabot.loader.buildinfo.retried_requests.get").return_value.json.return_value = {
+        "data": [
+            {"name": "SLES-16.0-Online-x86_64-Build1.1.spdx.json"},
+            {"name": "SLES-16.0-Online-x86_64-Build2.2.spdx.json"},
+        ]
+    }
+    with pytest.raises(AmbiguousBuildsError) as excinfo:
+        load_build_info(config, config.build_regex, approver.get_regex_match)
+    assert "contains several builds in" in str(excinfo.value)


### PR DESCRIPTION


We were relying on set nature uniqueness before, but
seems like it is not enough because sometimes we may
have race condition when old build yet exists in OBS
and new one already uploaded. We should not proceed further
when such state detected. This patch solve this problem
