### PR TITLE
fix: populate scm_info in get_single_submission

### DIFF
--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -36,6 +36,18 @@ class SubReq(NamedTuple):
     scm_info: str | None = None
     submission: Submission | None = None
 
+    @classmethod
+    def from_dashboard(cls, d: dict) -> SubReq:
+        """Build a SubReq from a dashboard submission dict."""
+        return cls(
+            d["number"],
+            d["rr_number"],
+            d.get("type", ""),
+            d.get("url", ""),
+            d.get("scm_info", ""),
+            Submission.create(d),
+        )
+
 
 class JobAggr(NamedTuple):
     """Job and aggregate information."""
@@ -111,31 +123,13 @@ def get_active_submissions(submission_type: str | None = None) -> Sequence[int]:
 def get_submissions_approver() -> list[SubReq]:
     """Fetch submissions that are ready for QAM review."""
     submissions = dashboard.get_json("api/incidents", headers=config_module.settings.dashboard_token_dict)
-    return [
-        SubReq(
-            i["number"],
-            i["rr_number"],
-            i.get("type", ""),
-            i.get("url", ""),
-            i.get("scm_info", ""),
-            Submission.create(i),
-        )
-        for i in submissions
-        if i["inReviewQAM"]
-    ]
+    return [SubReq.from_dashboard(i) for i in submissions if i["inReviewQAM"]]
 
 
 def get_single_submission(submission_id: int, submission_type: str | None = None) -> list[SubReq]:
     """Fetch a single submission and wrap it in a list of SubReq objects."""
     submission = _get_submission(submission_id, submission_type)
-    return [
-        SubReq(
-            submission["number"],
-            submission["rr_number"],
-            submission.get("type"),
-            submission=Submission.create(submission),
-        )
-    ]
+    return [SubReq.from_dashboard(submission)]
 
 
 def get_submission_settings(

--- a/tests/test_loader_qem.py
+++ b/tests/test_loader_qem.py
@@ -170,7 +170,12 @@ def test_get_submissions_approver(mock_get_json: MagicMock) -> None:
 
 
 def test_get_single_submission(mock_get_json: MagicMock) -> None:
-    mock_get_json.return_value = {**_FULL_INCIDENT, "type": DEFAULT_SUBMISSION_TYPE}
+    mock_get_json.return_value = {
+        **_FULL_INCIDENT,
+        "type": DEFAULT_SUBMISSION_TYPE,
+        "url": "http://foo.bar",
+        "scm_info": "foo_commit",
+    }
 
     res = get_single_submission(1, submission_type=DEFAULT_SUBMISSION_TYPE)
 
@@ -178,6 +183,8 @@ def test_get_single_submission(mock_get_json: MagicMock) -> None:
     assert res[0].sub == 1
     assert res[0].req == 123
     assert res[0].type == DEFAULT_SUBMISSION_TYPE
+    assert res[0].url == "http://foo.bar"
+    assert res[0].scm_info == "foo_commit"
     assert res[0].submission is not None
     mock_get_json.assert_called_once_with(
         "api/incidents/1", headers=settings.dashboard_token_dict, params={"type": DEFAULT_SUBMISSION_TYPE}
@@ -493,6 +500,8 @@ def test_get_single_submission_with_type(mock_get_json: MagicMock) -> None:
     res = get_single_submission(123, submission_type=DEFAULT_SUBMISSION_TYPE)
     assert len(res) == 1
     assert res[0].sub == 123
+    assert not res[0].url
+    assert not res[0].scm_info
     assert res[0].submission is not None
     mock_get_json.assert_called_once_with(
         "api/incidents/123", headers=settings.dashboard_token_dict, params={"type": DEFAULT_SUBMISSION_TYPE}
@@ -504,6 +513,8 @@ def test_get_single_submission_no_type(mock_get_json: MagicMock) -> None:
     res = get_single_submission(123)
     assert len(res) == 1
     assert res[0].sub == 123
+    assert not res[0].url
+    assert not res[0].scm_info
     assert res[0].submission is not None
     mock_get_json.assert_called_once_with("api/incidents/123", headers=settings.dashboard_token_dict, params={})
 


### PR DESCRIPTION
Motivation:
When reviewing single Gitea submissions, qem-bot approved the Gitea PR with an
empty "commit" ID in the "Tested commit: <commit>" field because scm_info and
url were not populated in get_single_submission.

Design Choices:
Introduce SubReq.from_dashboard as the single mapping from a dashboard
submission dict to a SubReq, and delegate both get_submissions_approver and
get_single_submission to it so the two call sites cannot drift again.

Benefits:
Fixes the empty tested-commit field for Gitea PR reviews and removes the
duplicated construction that let the two loaders diverge in the first place.

Related issue: https://progress.opensuse.org/issues/194083