### PR TITLE
docs: correct type checking command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ ruff.
 
 - `make tidy`: Format code with ruff.
 - `make checkstyle`: Run full linting (ruff + vulture).
-- `make typecheck-ty`: Type checking.
+- `make check-types`: Type checking.
 - `make test`: Run all tests with full coverage
 
 ## Coverage Verification


### PR DESCRIPTION
Motivation: AGENTS.md referenced `make typecheck-ty` which is not a valid
Makefile target (the correct target is `make check-types-ty` or its alias
`make check-types`), causing confusion for developer tooling.

Design Choices: Update AGENTS.md to refer to `make check-types`.

Benefits: Developer documentation accurately reflects the project Makefile and
available checking targets.