### PR TITLE
fix: abort gitea-trigger crawl on 404 instead of retrying

### DIFF
--- a/openqabot/loader/crawler.py
+++ b/openqabot/loader/crawler.py
@@ -31,12 +31,16 @@ class Crawler:
 
         """
         self.verify: bool = verify
-        retry_strategy = Retry(
+        # A 404 for an IBS repo folder means the content is absent and will
+        # not appear within the retry window, so abort immediately instead of
+        # retrying (poo#204114). Keep only transient codes that can succeed on
+        # retry.
+        self.retry_strategy = Retry(
             total=5,
-            status_forcelist=frozenset([401, 403, 404, 413, 429, 503]),
+            status_forcelist=frozenset([403, 413, 429, 503]),
             backoff_factor=1,
         )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
+        adapter = HTTPAdapter(max_retries=self.retry_strategy)
         self.retry_session = requests.Session()
         self.retry_session.mount("https://", adapter)
         self.retry_session.mount("http://", adapter)

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -97,3 +97,10 @@ def test_crawler_init_settings(crawler: Crawler) -> None:
     assert crawler.verify is not settings.insecure
     assert "https://" in crawler.retry_session.adapters
     assert "http://" in crawler.retry_session.adapters
+
+
+def test_crawler_does_not_retry_on_404(crawler: Crawler) -> None:
+    """404 (absent IBS folder) must abort immediately, not retry (poo#204114)."""
+    forcelist = crawler.retry_strategy.status_forcelist
+    assert 404 not in forcelist
+    assert forcelist == frozenset([403, 413, 429, 503])


### PR DESCRIPTION
Motivation: A 404 for an IBS repo folder means the content is absent and
will not appear within the retry window, yet the crawler retried five times
with backoff (~30s per call), stacking minutes of pointless delay onto every
gitea-trigger PR evaluation.

Design Choices: Drop 404 from the Retry status_forcelist so raise_for_status
raises immediately and the existing handler returns an empty listing. Keep
transient codes (403, 413, 429, 503) that can succeed on retry. Expose the
strategy as an attribute to assert the forcelist in tests.

Benefits: gitea-trigger evaluates PRs without absent folders slowing job
execution, freeing CI runtime.

Related issue: https://progress.opensuse.org/issues/204114