### PR TITLE
fix: re-review Gitea submission when stale approval is re-requested

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -316,6 +316,19 @@ def is_review_requested_by(
     return any(user in user_specifications for user in users)
 
 
+def _effective_state(review: dict[str, Any]) -> str:
+    """Return a review's state, demoting a stale APPROVED to a pending re-review.
+
+    After a push the previous QAM approval is marked stale (not dismissed);
+    it must not count as approved so the submission is re-reviewed instead of
+    staying blocked (poo#202953).
+    """
+    state = review.get("state", "")
+    if state == "APPROVED" and review.get("stale"):
+        return "REQUEST_REVIEW"
+    return state
+
+
 def add_reviews(submission: dict[str, Any], reviews: list[Any]) -> int:
     """Process PR reviews and update submission status.
 
@@ -323,7 +336,7 @@ def add_reviews(submission: dict[str, Any], reviews: list[Any]) -> int:
     """
     pending_states = {"PENDING", "REQUEST_REVIEW"}
     open_reviews = [r for r in reviews if not r.get("dismissed", True)]
-    qam_states = [r.get("state", "") for r in open_reviews if is_review_requested_by(r)]
+    qam_states = [_effective_state(r) for r in open_reviews if is_review_requested_by(r)]
     has_other_pending = any(r.get("state", "") in pending_states for r in open_reviews if not is_review_requested_by(r))
 
     counts = Counter(qam_states)

--- a/tests/test_loader_gitea_submissions.py
+++ b/tests/test_loader_gitea_submissions.py
@@ -145,6 +145,30 @@ def test_add_reviews_coverage(mocker: MockerFixture) -> None:
     assert submission["inReview"] is True
 
 
+@pytest.mark.parametrize(
+    ("state", "stale", "exp_approved", "exp_in_review_qam"),
+    [
+        pytest.param("APPROVED", False, True, False, id="fresh-approval-is-approved"),
+        pytest.param("APPROVED", True, False, True, id="stale-approval-needs-rereview"),
+        pytest.param("REQUEST_REVIEW", True, False, True, id="stale-request-still-pending"),
+    ],
+)
+def test_add_reviews_stale_reapproval(
+    mocker: MockerFixture,
+    state: str,
+    stale: bool,  # noqa: FBT001
+    exp_approved: bool,  # noqa: FBT001
+    exp_in_review_qam: bool,  # noqa: FBT001
+) -> None:
+    """A stale QAM approval (poo#202953) must trigger re-review, not stay approved."""
+    mocker.patch("openqabot.loader.gitea.is_review_requested_by", return_value=True)
+    submission: dict[str, Any] = {}
+    reviews = [{"dismissed": False, "stale": stale, "state": state}]
+    assert gitea.add_reviews(submission, reviews) == 1
+    assert submission["approved"] is exp_approved
+    assert submission["inReviewQAM"] is exp_in_review_qam
+
+
 def test_update_scminfo_coverage(caplog: pytest.LogCaptureFixture) -> None:
     submission = {"number": 123}
     res = etree.fromstring("<root><scminfo></scminfo><scminfo>new</scminfo><scminfo>other</scminfo></root>")


### PR DESCRIPTION
Motivation: A previously approved product-increment PR that gets updates
pushed, its approval dismissed and re-requested was never re-reviewed by
qem-bot/qem-dashboard and stayed blocked with no rejection reason.

Design Choices: Gitea marks the prior QAM approval stale (not dismissed)
after a push, yet add_reviews still counted it as APPROVED. A new
_effective_state helper demotes a stale QAM APPROVED to REQUEST_REVIEW so
the submission is treated as pending re-review; stale pending reviews are
left untouched to avoid dropping PRs whose only review is a stale request.

Benefits: Re-requested reviews are picked up again, unblocking submissions
without manual intervention.

Related issue: https://progress.opensuse.org/issues/202953