### PR TITLE
test(increment-approve): document retried-job coverage for poo#192355

### DIFF
--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -549,6 +549,9 @@ def test_approval_if_failing_jobs_are_in_development_group(
 def test_approval_with_mixed_jobs_development_ignored(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_openqa_url_job_stat: str
 ) -> None:
+    # poo#192355: openQA isos/job_stats resolves clones server-side and reports
+    # only the latest job's result, so a passing (retried) job drives approval
+    # here exactly like any other passing job; no clone-specific bot logic exists.
     responses.add(
         responses.GET,
         fake_openqa_url_job_stat,


### PR DESCRIPTION
Motivation: poo#192355 asked to verify product increments are approved
when originally triggered jobs fail but retried clones pass.

Design Choices: openQA isos/job_stats resolves clones server-side and
reports only the latest job's result, so no qem-bot code path distinguishes
a clone from any other passing job. The retry-approval and failing-block
behaviors are already covered by the mixed-jobs and not-ok-jobs scenario
tests; add a reference comment instead of a redundant test.

Related issue: https://progress.opensuse.org/issues/192355