### PR TITLE
exclude_packages improvements

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -77,6 +77,8 @@ Example:
 * `packages` - optional, list of package names (or first part of pkg name). A submission must contain a package from this list to be included in the aggregate. Same semantics as the incidents `packages` key.
 * `excluded_packages` - optional, list of package names, opposite of `packages`. A submission containing a package in this list is excluded from the aggregate. Same semantics as the incidents `excluded_packages` key.
 
+Unrecognized aggregate keys are logged as a warning and ignored, so a misspelled key (e.g. `excluded_package` instead of `excluded_packages`) does not silently disable its intended effect.
+
 ## Incidents part of the configuration
 
 Used to schedule jobs per incident. Scheduled jobs will have the BUILD **:INCIDENT_NR:shortest_package_name**. All needed links to the scheduled incident repositories are in the `INCIDENT_REPO` variable.

--- a/doc/config.md
+++ b/doc/config.md
@@ -132,7 +132,7 @@ incidents:
 * `excluded_packages` - optional, list of package names, opposite of `packages`. If the Incident contains a package in this list, it isn't scheduled.
 * `params_expand` - flavor specific settings. Merged with `settings` dictionary. `params_expand` values take precedence over `settings`. `DISTRI` and `VERSION` cannot be configured with `params_expand`.
 
-All optional keys can be omitted. By default qem-bot schedules Incidents for any matching `issue`, for any package in Incident, with computed job priority and with `aggregate_job: true`.
+All optional keys can be omitted. By default qem-bot schedules Incidents for any matching `issue`, for any package in Incident, with computed job priority and with `aggregate_job: true`. Unrecognized per-flavor keys are logged as a warning and ignored, so a misspelled key (e.g. `excluded_package` instead of `excluded_packages`) does not silently disable its intended effect.
 
 ## Advanced Configuration: Concatenating Lists with !concat
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -74,6 +74,8 @@ Example:
   * `OS_TEST_ISSUES` variable is implicit, always used by *os-autoinst-distri-opensuse*, contains identification of the base product.
   * All others contain modules, addons, and extensions used in this aggregate. First part of the key name must be the same (uppercase, os-autoinst-distri-opensuse will convert it to lowercase) as an addon, extension or module identification in `SCC_ADDONS` variable defined in the job template inside the openQA instance.
 * `onetime` - optional key, boolean. By default, qem-bot sets it to `False`. When set to `True`, it limits the bot from scheduling this aggregate to only once per day.
+* `packages` - optional, list of package names (or first part of pkg name). A submission must contain a package from this list to be included in the aggregate. Same semantics as the incidents `packages` key.
+* `excluded_packages` - optional, list of package names, opposite of `packages`. A submission containing a package in this list is excluded from the aggregate. Same semantics as the incidents `excluded_packages` key.
 
 ## Incidents part of the configuration
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -144,6 +144,10 @@ incidents:
 
 All optional keys can be omitted. By default qem-bot schedules Incidents for any matching `issue`, for any package in Incident, with computed job priority and with `aggregate_job: true`. Unrecognized per-flavor keys are logged as a warning and ignored, so a misspelled key (e.g. `excluded_package` instead of `excluded_packages`) does not silently disable its intended effect.
 
+### Package matching (`packages`, `excluded_packages`)
+
+Every package-matching list (per-flavor `packages`/`excluded_packages`, the aggregate equivalents, and the central `excluded_packages`) uses the same rule: by default an entry matches a package by **prefix** (e.g. `kernel-livepatch` matches `kernel-livepatch-SLE16-RT_Update`). Prefix an entry with `=` to require an **exact** match instead (e.g. `=kernel-default` matches `kernel-default` but not `kernel-default-devel`). The package `kernel-livepatch-tools` never matches, so a broad `kernel-livepatch` entry does not catch the generic tooling package.
+
 ## Advanced Configuration: Concatenating Lists with !concat
 
 For complex configurations where several products or flavors share similar package lists or architectures, `qem-bot` supports a custom YAML tag `!concat`. This tag allows you to merge multiple lists (usually defined as anchors) into a single one.

--- a/doc/config.md
+++ b/doc/config.md
@@ -24,6 +24,12 @@ Example of `singlearch.yml`:
 If an incident has a package from this list, a job is automatically marked as not requiring **aggregate**. That means the Incident can be approved without existing aggregate jobs.
 Other YAML files contain the definition of **product** and data for either or both **aggregate** and **submissions**
 
+## Central configuration: `config.yml`
+
+An optional `config.yml` in the same directory holds settings shared across all products.
+
+* `excluded_packages` - optional, list of package names (or first part of pkg name). A central blocklist applied to **every** product's incident and aggregate scheduling, in addition to any per-flavor or per-aggregate `excluded_packages`. Use this to keep a package (e.g. `kernel-livepatch-...`) out of scheduling everywhere without duplicating the key across files. A non-list value is logged as a warning and ignored.
+
 
 ## Structure of a product definition
 

--- a/openqabot/loader/config.py
+++ b/openqabot/loader/config.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -112,14 +113,17 @@ def _try_load(loader: YAML, path: Path) -> dict | None:
     return data
 
 
-def _load_one_metadata(
-    path: Path,
-    data: dict,
-    *,
-    disable_aggregate: bool,
-    disable_submissions: bool,
-    extrasettings: set[str],
-) -> Iterator[Aggregate | Submissions]:
+@dataclass
+class MetadataLoadOptions:
+    """Options controlling how metadata is turned into job configurations."""
+
+    disable_aggregate: bool
+    disable_submissions: bool
+    extrasettings: set[str]
+    global_excluded_packages: list[str] | None = None
+
+
+def _load_one_metadata(path: Path, data: dict, opts: MetadataLoadOptions) -> Iterator[Aggregate | Submissions]:
     """Parse a single metadata configuration dictionary.
 
     Yields:
@@ -139,14 +143,15 @@ def _load_one_metadata(
     product_repo = data.get("product_repo")
     product_version = data.get("product_version")
 
+    def _job_config(config: dict) -> JobConfig:
+        return JobConfig(product, product_repo, product_version, settings, config, opts.global_excluded_packages)
+
     for key in data:
-        if key == "incidents" and not disable_submissions:
-            yield Submissions(
-                JobConfig(product, product_repo, product_version, settings, data["incidents"]), extrasettings
-            )
-        elif key == "aggregate" and not disable_aggregate:
+        if key == "incidents" and not opts.disable_submissions:
+            yield Submissions(_job_config(data["incidents"]), opts.extrasettings)
+        elif key == "aggregate" and not opts.disable_aggregate:
             try:
-                yield Aggregate(JobConfig(product, product_repo, product_version, settings, data["aggregate"]))
+                yield Aggregate(_job_config(data["aggregate"]))
             except NoTestIssuesError:
                 log.info("Aggregate configuration skipped: Missing 'test_issues' for product %s", product)
 
@@ -202,6 +207,24 @@ def concat_constructor(constructor: SafeConstructor, node: SequenceNode) -> Iter
 ConcatSafeConstructor.add_constructor("!concat", concat_constructor)
 
 
+def _load_central_excluded_packages(loader: YAML, path: Path) -> list[str] | None:
+    """Read the central 'excluded_packages' blocklist from config.yml in the configs dir.
+
+    This cross-product blocklist keeps packages (e.g. kernel livepatch updates)
+    out of scheduling everywhere, avoiding per-flavor duplication across files.
+    """
+    config_yml = (path if path.is_dir() else path.parent) / "config.yml"
+    if not config_yml.is_file() or not (data := _try_load(loader, config_yml)):
+        return None
+    excluded = data.get("excluded_packages")
+    if excluded is None:
+        return None
+    if not isinstance(excluded, list):
+        log.warning("Central blocklist ignored: 'excluded_packages' in %s is not a list", config_yml)
+        return None
+    return excluded
+
+
 def load_metadata(
     path: Path,
     *,
@@ -214,13 +237,15 @@ def load_metadata(
     loader.Constructor = ConcatSafeConstructor
     log.debug("Loading metadata from %s: Submissions=%s, Aggregates=%s", path, not submissions, not aggregate)
 
+    opts = MetadataLoadOptions(
+        disable_aggregate=aggregate,
+        disable_submissions=submissions,
+        extrasettings=extrasettings,
+        global_excluded_packages=_load_central_excluded_packages(loader, path),
+    )
+
     return [
-        item
-        for p in get_yml_list(path)
-        if (data := _try_load(loader, p))
-        for item in _load_one_metadata(
-            p, data, disable_aggregate=aggregate, disable_submissions=submissions, extrasettings=extrasettings
-        )
+        item for p in get_yml_list(path) if (data := _try_load(loader, p)) for item in _load_one_metadata(p, data, opts)
     ]
 
 

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -47,6 +47,8 @@ class Aggregate(BaseConf):
         self.flavor = config.config["FLAVOR"]
         self.archs = config.config["archs"]
         self.onetime = config.config.get("onetime", False)
+        self.packages = config.config.get("packages")
+        self.excluded_packages = config.config.get("excluded_packages")
         self.test_issues = self.normalize_repos(config.config)
 
     @staticmethod
@@ -79,6 +81,12 @@ class Aggregate(BaseConf):
                 return False
             if self.filter_embargoed(self.flavor) and submission.embargoed:
                 log.debug("Submission %s skipped: Embargoed and embargo-filtering enabled", submission)
+                return False
+            if self.packages is not None and not submission.contains_package(self.packages):
+                log.debug("Submission %s skipped: No package in aggregate 'packages' allowlist", submission)
+                return False
+            if self.excluded_packages is not None and submission.contains_package(self.excluded_packages):
+                log.debug("Submission %s skipped: Package in aggregate 'excluded_packages' blocklist", submission)
                 return False
             return True
 

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -28,6 +28,8 @@ log = getLogger("bot.types.aggregate")
 
 ALL_ISSUES_KEY = "TEST_ISSUES[]"
 
+VALID_AGGREGATE_KEYS = frozenset({"FLAVOR", "archs", "onetime", "packages", "excluded_packages", "test_issues"})
+
 
 class PostData(NamedTuple):
     """Data to be posted to dashboard."""
@@ -44,12 +46,18 @@ class Aggregate(BaseConf):
     def __init__(self, config: JobConfig) -> None:
         """Initialize the Aggregate class."""
         super().__init__(config)
+        self._warn_unknown_keys(config.config)
         self.flavor = config.config["FLAVOR"]
         self.archs = config.config["archs"]
         self.onetime = config.config.get("onetime", False)
         self.packages = config.config.get("packages")
         self.excluded_packages = config.config.get("excluded_packages")
         self.test_issues = self.normalize_repos(config.config)
+
+    def _warn_unknown_keys(self, config: dict[str, Any]) -> None:
+        """Warn about unrecognized aggregate keys to catch typos like a misspelled blocklist."""
+        for key in set(config) - VALID_AGGREGATE_KEYS:
+            log.warning("Aggregate (product %s): Ignoring unknown metadata key %r", self.product, key)
 
     @staticmethod
     def normalize_repos(config: dict[str, Any]) -> dict[str, ProdVer]:

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -96,6 +96,9 @@ class Aggregate(BaseConf):
             if self.excluded_packages is not None and submission.contains_package(self.excluded_packages):
                 log.debug("Submission %s skipped: Package in aggregate 'excluded_packages' blocklist", submission)
                 return False
+            if self.is_globally_excluded(submission):
+                log.debug("Submission %s skipped: Package in central 'excluded_packages' blocklist", submission)
+                return False
             return True
 
         return [s for s in submissions if is_valid(s)]

--- a/openqabot/types/baseconf.py
+++ b/openqabot/types/baseconf.py
@@ -21,6 +21,7 @@ class JobConfig:
     product_version: str | None
     settings: dict[str, Any]
     config: dict[str, Any]
+    global_excluded_packages: list[str] | None = None
 
 
 class BaseConf(ABC):
@@ -32,6 +33,11 @@ class BaseConf(ABC):
         self.product_repo = config.product_repo
         self.product_version = config.product_version
         self.settings = config.settings
+        self.global_excluded_packages = config.global_excluded_packages
+
+    def is_globally_excluded(self, submission: Submission) -> bool:
+        """Check if a submission matches the central (cross-product) blocklist."""
+        return bool(self.global_excluded_packages) and submission.contains_package(self.global_excluded_packages)
 
     @abstractmethod
     def __call__(

--- a/openqabot/types/submission.py
+++ b/openqabot/types/submission.py
@@ -294,5 +294,16 @@ class Submission:
         return any(p.startswith(("kgraft-patch-", "kernel-livepatch")) for p in packages)
 
     def contains_package(self, requires: list[str]) -> bool:
-        """Check if the submission contains any of the required packages."""
-        return any(p != "kernel-livepatch-tools" and p.startswith(tuple(requires)) for p in self.packages)
+        """Check if the submission contains any of the required packages.
+
+        An entry prefixed with ``=`` matches a package name exactly; any other
+        entry matches by prefix (the default). This lets configs opt into
+        precise matching, e.g. ``=kernel-default`` to avoid catching
+        ``kernel-default-devel``.
+        """
+        exact = {r[1:] for r in requires if r.startswith("=")}
+        prefixes = tuple(r for r in requires if not r.startswith("="))
+        return any(
+            p != "kernel-livepatch-tools" and (p in exact or (bool(prefixes) and p.startswith(prefixes)))
+            for p in self.packages
+        )

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -169,12 +169,13 @@ class Submissions(BaseConf):
             return True
         return sub.staging
 
-    @staticmethod
-    def _is_invalid_package_or_channel(ctx: SubContext, matches: dict[str, list[Repos]]) -> bool:
+    def _is_invalid_package_or_channel(self, ctx: SubContext, matches: dict[str, list[Repos]]) -> bool:
         sub, arch, flavor, data = ctx.sub, ctx.arch, ctx.flavor, ctx.data
         if data.get("packages") is not None and not sub.contains_package(data["packages"]):
             return True
         if data.get("excluded_packages") is not None and sub.contains_package(data["excluded_packages"]):
+            return True
+        if self.is_globally_excluded(sub):
             return True
         if not matches:
             log.debug("Submission %s skipped for %s on %s: No matching channels found in metadata", sub, flavor, arch)

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -24,6 +24,20 @@ if TYPE_CHECKING:
 
 log = getLogger("bot.types.submissions")
 
+VALID_FLAVOR_KEYS = frozenset({
+    "archs",
+    "issues",
+    "required_issues",
+    "aggregate_job",
+    "aggregate_check_true",
+    "aggregate_check_false",
+    "override_priority",
+    "versioned_by_submission",
+    "packages",
+    "excluded_packages",
+    "params_expand",
+})
+
 
 class SubContext(NamedTuple):
     """Context for a submission."""
@@ -47,6 +61,7 @@ class Submissions(BaseConf):
     def __init__(self, config: JobConfig, extrasettings: set[str]) -> None:
         """Initialize the Submissions class."""
         super().__init__(config)
+        self._warn_unknown_flavor_keys(config.config["FLAVOR"])
         self.flavors = self.normalize_repos(config.config["FLAVOR"])
         self.singlearch = extrasettings
         self.valid_archs = {arch for data in self.flavors.values() for arch in data["archs"]}
@@ -54,6 +69,12 @@ class Submissions(BaseConf):
     def __repr__(self) -> str:
         """Return a string representation of the Submissions."""
         return f"<Submissions product: {self.product}>"
+
+    def _warn_unknown_flavor_keys(self, config: dict[str, Any]) -> None:
+        """Warn about unrecognized per-flavor keys to catch typos like a misspelled blocklist."""
+        for flavor, data in config.items():
+            for key in set(data) - VALID_FLAVOR_KEYS:
+                log.warning("Flavor %s (product %s): Ignoring unknown metadata key %r", flavor, self.product, key)
 
     @staticmethod
     def normalize_repos(config: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -235,6 +235,26 @@ def test_filter_submissions_staging(aggregate_factory: Any, submission_mock: Any
     assert res == []
 
 
+@pytest.mark.parametrize(
+    ("extra_config", "contains", "expected_kept"),
+    [
+        pytest.param({}, False, True, id="no-filter-keeps"),
+        pytest.param({"packages": ["foo"]}, True, True, id="allowlist-match-keeps"),
+        pytest.param({"packages": ["foo"]}, False, False, id="allowlist-miss-drops"),
+        pytest.param({"excluded_packages": ["foo"]}, True, False, id="blocklist-match-drops"),
+        pytest.param({"excluded_packages": ["foo"]}, False, True, id="blocklist-miss-keeps"),
+    ],
+)
+def test_filter_submissions_package_lists(
+    aggregate_factory: Any, submission_mock: Any, extra_config: dict, *, contains: bool, expected_kept: bool
+) -> None:
+    """Aggregate applies 'packages' allowlist and 'excluded_packages' blocklist like incidents."""
+    acc = aggregate_factory("product", config={"FLAVOR": "None", "archs": [], "test_issues": {}, **extra_config})
+    sub = submission_mock()
+    sub.contains_package.return_value = contains
+    assert acc.filter_submissions([sub]) == ([sub] if expected_kept else [])
+
+
 def test_get_test_submissions_repos_existing(aggregate_factory: Any, submission_mock: Any) -> None:
     acc = aggregate_factory("product", config={"FLAVOR": "None", "archs": ["A"], "test_issues": {"ISSUES_1": "P:V"}})
     sub = submission_mock(product="P", version="V", arch="A")

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -236,6 +236,26 @@ def test_filter_submissions_staging(aggregate_factory: Any, submission_mock: Any
 
 
 @pytest.mark.parametrize(
+    ("extra_config", "expected_warnings"),
+    [
+        pytest.param({"onetime": True, "packages": ["x"]}, [], id="all-known-keys"),
+        pytest.param({"excluded_package": ["x"]}, ["excluded_package"], id="typo-blocklist"),
+        pytest.param({"bogus": 1, "typo": 2}, ["bogus", "typo"], id="multiple-unknown"),
+    ],
+)
+def test_warn_unknown_aggregate_keys(
+    aggregate_factory: Any, caplog: pytest.LogCaptureFixture, extra_config: dict, expected_warnings: list[str]
+) -> None:
+    """Unknown aggregate keys are warned about so a misspelled blocklist is not silently ignored."""
+    with caplog.at_level("WARNING", logger="bot.types.aggregate"):
+        aggregate_factory("product", config={"FLAVOR": "None", "archs": [], "test_issues": {}, **extra_config})
+    warned = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warned) == len(expected_warnings)
+    for key in expected_warnings:
+        assert any(repr(key) in msg for msg in warned)
+
+
+@pytest.mark.parametrize(
     ("extra_config", "contains", "expected_kept"),
     [
         pytest.param({}, False, True, id="no-filter-keeps"),

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -275,6 +275,16 @@ def test_filter_submissions_package_lists(
     assert acc.filter_submissions([sub]) == ([sub] if expected_kept else [])
 
 
+@pytest.mark.parametrize("contains", [True, False])
+def test_filter_submissions_central_blocklist(aggregate_factory: Any, submission_mock: Any, *, contains: bool) -> None:
+    """A submission matching the central blocklist is excluded from aggregate."""
+    acc = aggregate_factory("product")
+    acc.global_excluded_packages = ["kernel-livepatch"]
+    sub = submission_mock()
+    sub.contains_package.return_value = contains
+    assert acc.filter_submissions([sub]) == ([] if contains else [sub])
+
+
 def test_get_test_submissions_repos_existing(aggregate_factory: Any, submission_mock: Any) -> None:
     acc = aggregate_factory("product", config={"FLAVOR": "None", "archs": ["A"], "test_issues": {"ISSUES_1": "P:V"}})
     sub = submission_mock(product="P", version="V", arch="A")

--- a/tests/test_loader_config.py
+++ b/tests/test_loader_config.py
@@ -85,6 +85,40 @@ def test_load_metadata_exclude_all() -> None:
     assert len(result) == 0
 
 
+def _write_product(tmp_path: Path) -> None:
+    (tmp_path / "prod.yml").write_text(
+        "product: P\nsettings:\n  DISTRI: sle\n  VERSION: '1'\n"
+        "incidents:\n  FLAVOR:\n    F:\n      archs:\n        - x86_64\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("config_yml", "expected", "warns"),
+    [
+        pytest.param("excluded_packages:\n  - foo\n  - bar\n", ["foo", "bar"], False, id="list"),
+        pytest.param("obs_url: https://api.example.com\n", None, False, id="key-absent"),
+        pytest.param("excluded_packages: not-a-list\n", None, True, id="not-a-list"),
+        pytest.param(None, None, False, id="missing-file"),
+    ],
+)
+def test_load_metadata_central_blocklist(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    config_yml: str | None,
+    expected: list[str] | None,
+    *,
+    warns: bool,
+) -> None:
+    """The central blocklist from config.yml is threaded into every worker; non-list values warn."""
+    if config_yml is not None:
+        (tmp_path / "config.yml").write_text(config_yml)
+    _write_product(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="bot.loader.config"):
+        workers = load_metadata(tmp_path, aggregate=True, submissions=False, extrasettings=set())
+    assert workers[0].global_excluded_packages == expected
+    assert ("Central blocklist ignored" in caplog.text) is warns
+
+
 def test_read_products(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.loader.config")
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -487,3 +487,22 @@ def test_mock_submission_contains_package_none() -> None:
     sub = MockSubmission(packages=["pkg1"])
     assert sub.contains_package(["pkg1"]) is True
     assert sub.contains_package(["other"]) is False
+
+
+@pytest.mark.parametrize(
+    ("packages", "requires", "expected"),
+    [
+        pytest.param(["kernel-default-devel"], ["kernel-default"], True, id="prefix-match-default"),
+        pytest.param(["kernel-default-devel"], ["=kernel-default"], False, id="exact-miss"),
+        pytest.param(["kernel-default"], ["=kernel-default"], True, id="exact-match"),
+        pytest.param(["kernel-default", "foo"], ["=foo", "=bar"], True, id="exact-any"),
+        pytest.param(["kernel-livepatch-tools"], ["kernel-livepatch"], False, id="prefix-tools-exception"),
+        pytest.param(["kernel-livepatch-tools"], ["=kernel-livepatch-tools"], False, id="exact-tools-exception"),
+        pytest.param(["pkg"], ["=exact", "pre"], False, id="mixed-no-match"),
+        pytest.param(["prefixed-pkg"], ["=exact", "pre"], True, id="mixed-prefix-match"),
+    ],
+)
+def test_contains_package_exact_and_prefix(packages: list[str], requires: list[str], *, expected: bool) -> None:
+    """'=' entries match exactly; others match by prefix; kernel-livepatch-tools stays excluded."""
+    sub = MockSubmission(packages=packages)
+    assert Submission.contains_package(sub, requires) is expected

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -2,11 +2,20 @@
 # SPDX-License-Identifier: MIT
 """Test Submissions."""
 
+import pytest
+
 from openqabot.types.baseconf import JobConfig
 from openqabot.types.submissions import Submissions
 from openqabot.types.types import Repos
 
 from .fixtures.submissions import MockSubmission
+
+
+def _make_submissions(flavor_config: dict, product: str = "SLE") -> Submissions:
+    return Submissions(
+        JobConfig(product, None, None, {}, {"FLAVOR": flavor_config}),
+        extrasettings=set(),
+    )
 
 
 def test_submissions_constructor() -> None:
@@ -66,3 +75,26 @@ def test_making_repo_url() -> None:
     repo = subs.make_repo_url(sub, slfo_chan)
     exp_repo = "http://%REPO_MIRROR_HOST%/ibs/SUSE:/SLFO:/SUSE:/SLFO:/1.1.99:/PullRequest:/166:/SLES/product/repo/SLES-15.99-x86_64/"
     assert repo == exp_repo
+
+
+@pytest.mark.parametrize(
+    ("flavor_config", "expected_warnings"),
+    [
+        pytest.param({"AAA": {"archs": ["x86_64"], "excluded_packages": ["foo"]}}, [], id="all-known-keys"),
+        pytest.param(
+            {"AAA": {"archs": ["x86_64"], "excluded_package": ["foo"]}}, ["excluded_package"], id="typo-blocklist"
+        ),
+        pytest.param({"AAA": {"archs": ["x86_64"], "bogus": 1, "typo": 2}}, ["bogus", "typo"], id="multiple-unknown"),
+        pytest.param({}, [], id="no-flavors"),
+    ],
+)
+def test_warn_unknown_flavor_keys(
+    caplog: pytest.LogCaptureFixture, flavor_config: dict, expected_warnings: list[str]
+) -> None:
+    """Unknown per-flavor keys are warned about so a misspelled blocklist is not silently ignored."""
+    with caplog.at_level("WARNING", logger="bot.types.submissions"):
+        _make_submissions(flavor_config)
+    warned = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warned) == len(expected_warnings)
+    for key in expected_warnings:
+        assert any(repr(key) in msg for msg in warned)

--- a/tests/test_submissions_handle.py
+++ b/tests/test_submissions_handle.py
@@ -252,6 +252,27 @@ def test_handle_submission_excluded_packages_skip() -> None:
     assert submissions_obj.handle_submission(ctx, cfg) is None
 
 
+@pytest.mark.parametrize("blocked", [True, False])
+def test_should_skip_central_blocklist(*, blocked: bool) -> None:
+    """should_skip honors the central blocklist after per-flavor package/channel checks pass."""
+    sub = MockSubmission(id=1, ongoing=True, staging=False, contains_package_value=blocked)
+    submissions_obj = Submissions(
+        JobConfig(
+            product="SLES",
+            product_repo=None,
+            product_version=None,
+            settings={"VERSION": "15-SP3", "DISTRI": "SLES"},
+            config={"FLAVOR": {"AAA": {"archs": ["x86_64"], "issues": {}}}},
+            global_excluded_packages=["kernel-livepatch"] if blocked else None,
+        ),
+        extrasettings=set(),
+    )
+    ctx = SubContext(sub=sub, arch="x86_64", flavor="AAA", data={})
+    cfg = SubConfig(ci_url=None, ignore_onetime=True)
+    matches = {"OS_TEST_ISSUES": [Repos("SLES", "15-SP3", "x86_64")]}
+    assert submissions_obj.should_skip(ctx, cfg, matches) is blocked
+
+
 def test_handle_submission_livepatch_kgraft(mocker: MockerFixture) -> None:
     sub = MockSubmission(
         id=1,


### PR DESCRIPTION
* feat(submission): opt-in exact package matching with '=' prefix
* feat(config): central excluded_packages blocklist in config.yml
* feat(aggregate): warn on unknown aggregate metadata keys
* feat(aggregate): support packages and excluded_packages filters
* feat(submissions): warn on unknown per-flavor metadata keys
* test(increment-approve): document retried-job coverage for poo#192355

Related issue: https://progress.opensuse.org/issues/201987