### PR TITLE
fix: skip openQA scheduling when no templates found for product

### DIFF
--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -68,7 +68,11 @@ class OpenQAInterface:
         try:
             self.openqa.openqa_request("POST", "isos", data=settings, retries=self.retries)
         except RequestError as e:
-            log.exception("openQA API error: %s", e.args[-1])
+            (_, _, status_code, text, *_) = e.args
+            if status_code == HTTPStatus.NOT_FOUND and "no templates found" in str(text):
+                log.info("Skipping job POST, no openQA templates for product (test-owner scope): %s", text)
+                return
+            log.exception("openQA API error: %s", text)
             log.exception("Job POST failed for settings: %s", pformat(settings))
             raise PostOpenQAError from e
         except Exception as e:

--- a/tests/test_openqaclient.py
+++ b/tests/test_openqaclient.py
@@ -62,6 +62,18 @@ def test_post_job_failed(caplog: pytest.LogCaptureFixture, fake_openqa_url: str)
     assert any("Job POST failed for settings" in m for m in caplog.messages)
 
 
+def test_post_job_no_templates_is_skipped(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO, logger="bot.openqa")
+    client = oQAI()
+    client.retries = 0
+    text = '{"count":0,"error":"no templates found for product sle-16.0-x86_64"}'
+    error = RequestError("POST", "no.where", 404, text)
+    with patch("openqabot.openqa.OpenQA_Client.openqa_request", side_effect=error):
+        client.post_job({"foo": "bar"})  # must not raise PostOpenQAError
+    assert any("no openQA templates for product" in m for m in caplog.messages)
+    assert not any("Traceback" in m for m in caplog.messages)
+
+
 @responses.activate
 @pytest.mark.usefixtures("fake_osd_rsp")
 def test_post_job_passed(caplog: pytest.LogCaptureFixture, fake_openqa_url: str) -> None:


### PR DESCRIPTION
Motivation: The bot-ng "approve increments" CI job dumped lengthy tracebacks
and was retried up to 20 times when openQA returned a 404 "no templates found
for product", an expected test-owner configuration issue outside qem-bot's
control (poo#198998).

Design Choices: In post_job, detect the specific 404 with "no templates found"
in the response and treat it as a non-fatal skip: log one concise info message
without a traceback and return instead of raising PostOpenQAError. This keeps
the process exit code zero for such cases, so GitLab CI no longer marks the job
failed and retries it. All other errors keep the previous log-and-raise path.

Benefits: Clean, actionable CI logs and no wasteful full-job retries for
conditions qem-bot cannot fix, letting the run finish quicker.

Related issue: https://progress.opensuse.org/issues/198998