### PR TITLE
perf: optimize repodiff memory usage via streaming

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -136,7 +136,7 @@ class IncrementApprover:
                 "product": p.get("PRODUCT"),
             })
 
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
             stats = list(executor.map(fetch_stats, params))
 
         job_ids = [

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import gzip
+import io
 import json
 import re
 import sys
@@ -149,8 +150,8 @@ class RepoDiff:
             raise NoResultsError(error_msg)
         return min(packages, key=lambda p: p.name).name
 
-    def load_repodata(self, url: str) -> etree.Element | None:
-        """Load and parse repository primary metadata for a repository URL."""
+    def load_repodata(self, url: str) -> bytes | etree._Element | None:
+        """Load repository primary metadata for a repository URL."""
         repodata_url = self.make_repodata_url(url)
         repo_data_listing = self.request_and_dump(
             repodata_url,
@@ -169,30 +170,70 @@ class RepoDiff:
             return None
         repo_data_raw = self.request_and_dump(repodata_url + repo_data_file, repo_data_file)
         if not isinstance(repo_data_raw, bytes):
+            log.warning("Repository metadata could not be fetched from %s", repodata_url + repo_data_file)
             return None
-        repo_data = RepoDiff.decompress(repo_data_file, repo_data_raw)
-        log.debug("Parsing repository metadata file: %s", repo_data_file)
-        return etree.fromstring(repo_data)
+        log.debug("Decompressing repository metadata file: %s", repo_data_file)
+        return RepoDiff.decompress(repo_data_file, repo_data_raw)
+
+    @staticmethod
+    def _extract_package(elem: Any) -> Package | None:  # noqa: ANN401
+        """Extract a single rpm package from an XML element."""
+        if elem.get("type") != "rpm":
+            return None
+        name_el = elem.find(name_tag)
+        version_info = elem.find(version_tag)
+        arch_el = elem.find(arch_tag)
+        if name_el is not None and version_info is not None and arch_el is not None:
+            return Package(
+                name_el.text,
+                version_info.get("epoch", "0"),
+                version_info.get("ver", "0"),
+                version_info.get("rel", "0"),
+                arch_el.text,
+            )
+        return None
+
+    @staticmethod
+    def _parse_packages_from_stream(repo_data: bytes) -> defaultdict[str, set[Package]]:
+        packages_by_arch = defaultdict(set)
+        try:
+            context = etree.iterparse(io.BytesIO(repo_data), events=("end",), tag=package_tag)
+        except Exception:
+            log.exception("Failed to parse repo data stream")
+            return packages_by_arch
+
+        for _, elem in context:
+            pkg = RepoDiff._extract_package(elem)
+            if pkg:
+                packages_by_arch[pkg.arch].add(pkg)
+            elem.clear()
+            parent = elem.getparent()
+            if parent is not None:
+                while elem.getprevious() is not None:
+                    del parent[0]
+        return packages_by_arch
+
+    @staticmethod
+    def _parse_packages_from_element(
+        repo_data: Any,  # noqa: ANN401 - lxml _Element is dynamic and has no public standard type
+    ) -> defaultdict[str, set[Package]]:
+        packages_by_arch = defaultdict(set)
+        for package in repo_data.iterfind(package_tag):
+            pkg = RepoDiff._extract_package(package)
+            if pkg:
+                packages_by_arch[pkg.arch].add(pkg)
+        return packages_by_arch
 
     def load_packages(self, url: str) -> defaultdict[str, set[Package]]:
         """Load the list of packages from a repository URL."""
         repo_data = self.load_repodata(url)
-        packages_by_arch = defaultdict(set)
-        if repo_data is None or not hasattr(repo_data, "iterfind"):
-            log.error("Could not load repo data for URL %s", url)
-            return packages_by_arch
-        log.debug("Loading package list for repository %s", url)
-        for package in repo_data.iterfind(package_tag):
-            if package.get("type") != "rpm":
-                continue
-            name = package.find(name_tag).text
-            version_info = package.find(version_tag)
-            epoch = version_info.get("epoch", "0")
-            version = version_info.get("ver", "0")
-            rel = version_info.get("rel", "0")
-            arch = package.find(arch_tag).text
-            packages_by_arch[arch].add(Package(name, epoch, version, rel, arch))
-        return packages_by_arch
+        if repo_data is None:
+            return defaultdict(set)
+        if isinstance(repo_data, bytes):
+            log.debug("Loading package list for repository %s via stream-parser", url)
+            return self._parse_packages_from_stream(repo_data)
+        log.debug("Loading package list for repository %s via element fallback", url)
+        return self._parse_packages_from_element(repo_data)
 
     @staticmethod
     def compute_diff_for_packages(

--- a/tests/test_repodiff.py
+++ b/tests/test_repodiff.py
@@ -12,7 +12,7 @@ from pytest_mock import MockerFixture
 
 from openqabot.config import settings
 from openqabot.errors import NoResultsError
-from openqabot.repodiff import RepoDiff
+from openqabot.repodiff import Package, RepoDiff
 
 
 @pytest.fixture
@@ -109,14 +109,6 @@ def test_load_packages_empty(diff: RepoDiff, mocker: MockerFixture) -> None:
     assert res == {}
 
 
-def test_load_packages_invalid_data(diff: RepoDiff, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
-    # Return a dict instead of etree.Element
-    mocker.patch.object(diff, "load_repodata", return_value={"invalid": "data"})
-    res = diff.load_packages("project")
-    assert res == {}
-    assert "Could not load repo data for URL project" in caplog.text
-
-
 def test_request_and_dump_exception(diff: RepoDiff, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     mocker.patch("openqabot.repodiff.retried_requests.get", side_effect=Exception("foo"))
     res = diff.request_and_dump("http://url", "name")
@@ -205,11 +197,12 @@ def test_find_primary_repodata_none(diff: RepoDiff, mocker: MockerFixture, caplo
     assert "Repository metadata not found" in caplog.text
 
 
-def test_load_repodata_request_failed(diff: RepoDiff, mocker: MockerFixture) -> None:
+def test_load_repodata_request_failed(diff: RepoDiff, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     # repo_data_listing found, but subsequent request fails
     mocker.patch.object(diff, "request_and_dump", side_effect=[{"data": [{"name": "foo-primary.xml"}]}, None])
     res = diff.load_repodata("project")
     assert res is None
+    assert "Repository metadata could not be fetched" in caplog.text
 
 
 def test_load_packages_not_rpm(diff: RepoDiff, mocker: MockerFixture) -> None:
@@ -238,3 +231,104 @@ def test_get_staged_update_name_empty(diff: RepoDiff, mocker: MockerFixture) -> 
     mocker.patch.object(diff, "load_packages", return_value={"x86_64": set()})
     with pytest.raises(NoResultsError, match="No packages detected"):
         diff.get_staged_update_name("http://repo")
+
+
+@pytest.mark.parametrize(
+    ("repo_data", "expected_pkgs"),
+    [
+        (
+            (
+                b'<metadata xmlns="http://linux.duke.edu/metadata/common">'
+                b'<package type="rpm">'
+                b"<name>test-package</name>"
+                b'<version epoch="0" ver="1.0" rel="1"/>'
+                b"<arch>x86_64</arch>"
+                b"</package></metadata>"
+            ),
+            {"x86_64": {Package("test-package", "0", "1.0", "1", "x86_64")}},
+        ),
+        (
+            (
+                b'<metadata xmlns="http://linux.duke.edu/metadata/common">'
+                b'<package type="other1"><name>other1</name></package>'
+                b'<package type="other2"><name>other2</name></package>'
+                b'<package type="rpm">'
+                b"<name>rpm-package</name>"
+                b'<version epoch="0" ver="2.0" rel="1"/>'
+                b"<arch>aarch64</arch>"
+                b"</package></metadata>"
+            ),
+            {"aarch64": {Package("rpm-package", "0", "2.0", "1", "aarch64")}},
+        ),
+        (
+            (
+                b'<metadata xmlns="http://linux.duke.edu/metadata/common">'
+                b'<package type="rpm"><name>incomplete</name></package></metadata>'
+            ),
+            {},
+        ),
+        (
+            b'<package xmlns="http://linux.duke.edu/metadata/common" type="other"><name>other-package</name></package>',
+            {},
+        ),
+        (
+            (
+                b'<package xmlns="http://linux.duke.edu/metadata/common" type="rpm">'
+                b"<name>rpm-package</name>"
+                b'<version epoch="0" ver="2.0" rel="1"/>'
+                b"<arch>aarch64</arch></package>"
+            ),
+            {"aarch64": {Package("rpm-package", "0", "2.0", "1", "aarch64")}},
+        ),
+        (
+            etree.fromstring(
+                '<metadata xmlns="http://linux.duke.edu/metadata/common">'
+                '<package type="rpm">'
+                "<name>element-package</name>"
+                '<version epoch="0" ver="3.0" rel="1"/>'
+                "<arch>x86_64</arch>"
+                "</package></metadata>"
+            ),
+            {"x86_64": {Package("element-package", "0", "3.0", "1", "x86_64")}},
+        ),
+        (
+            etree.fromstring(
+                '<metadata xmlns="http://linux.duke.edu/metadata/common">'
+                '<package type="rpm">'
+                "<name>incomplete-package</name>"
+                "</package></metadata>"
+            ),
+            {},
+        ),
+    ],
+    ids=[
+        "stream_valid_rpm",
+        "stream_non_rpm_and_clear",
+        "stream_missing_fields",
+        "stream_root_non_rpm_parent_none",
+        "stream_root_rpm_parent_none",
+        "fallback_valid_element",
+        "fallback_missing_fields",
+    ],
+)
+def test_load_packages_parameterized(
+    diff: RepoDiff,
+    mocker: MockerFixture,
+    repo_data: bytes | etree._Element,
+    expected_pkgs: dict[str, set[Package]],
+) -> None:
+    """Test load_packages parsing logic across various data types and layouts."""
+    mocker.patch.object(diff, "load_repodata", return_value=repo_data)
+    res = diff.load_packages("project")
+    assert res == expected_pkgs
+
+
+def test_load_packages_stream_exception(
+    diff: RepoDiff, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test stream parser exceptions handling."""
+    mocker.patch("openqabot.repodiff.etree.iterparse", side_effect=ValueError("corrupted XML"))
+    mocker.patch.object(diff, "load_repodata", return_value=b"corrupted bytes")
+    res = diff.load_packages("project")
+    assert res == {}
+    assert "Failed to parse repo data stream" in caplog.text


### PR DESCRIPTION
Motivation
The `increment-approve` command consumed more than 7.6 GiB of memory during dry
runs on live metadata repositories, causing OOM kills on GitLab runners with
limited memory.

Design Choices
Refactored `repodiff.py` to streaming-parse repository primary XML data via
`etree.iterparse` instead of building the full XML DOM tree in memory. Created
a shared static helper `_extract_package` to avoid duplication between the
stream parser and the element fallback parser, and added unit/integration tests
to maintain 100% statement and branch coverage.

Benefits
Decreased peak Maximum resident set size from ~7.6 GiB down to ~1.4 GiB
(measured via `/usr/bin/time -v`) while ensuring memory is safely cleared
during stream processing and keeping code duplication at zero.

Related issue: https://progress.opensuse.org/issues/204753