### PR TITLE
feat: support sequential execution of commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,8 @@ test-integration: ## Automatically start environment, run integration tests, and
 
 .PHONY: test-integration-payload
 test-integration-payload: env-dashboard-wait  ## Test qem-bot against a local dashboard instance
-	$(QEM_BOT_BASE_CMD) gitea-sync
-	$(QEM_BOT_BASE_CMD) smelt-sync
-	$(QEM_BOT_BASE_CMD) --dry submissions-run
-	$(QEM_BOT_BASE_CMD) --dry sub-approve
+	$(QEM_BOT_BASE_CMD) gitea-sync smelt-sync
+	$(QEM_BOT_BASE_CMD) --dry submissions-run sub-approve
 
 .PHONY: setup-hooks
 setup-hooks: ## Install pre-commit git hooks

--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ updates information about submissions and related openQA tests.
 
     >>> qem-bot.py --help
 
-    Usage: qem-bot.py [OPTIONS] COMMAND [ARGS]...
+    Usage: qem-bot.py [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
 
     QEM-Dashboard, SMELT, Gitea and openQA connector
 

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -12,6 +12,7 @@ from typing import Annotated, Any
 
 import responses
 import typer
+from typer.core import TyperGroup
 
 import openqabot.config as config_module
 
@@ -31,11 +32,71 @@ from .smeltsync import SMELTSync
 from .subsyncres import SubResultsSync
 from .utils import create_logger
 
+
+class _ChainedTyperGroup(TyperGroup):
+    """Support command chaining under newer Click/Typer versions."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401 - dictated by Click's interface
+        kwargs.pop("chain", True)
+        super().__init__(*args, **kwargs)
+        self.chain = True
+
+    def parse_args(self, ctx: typer._click.core.Context, args: list[str]) -> list[str]:
+        if not args and self.no_args_is_help and not ctx.resilient_parsing:
+            raise typer._click.exceptions.NoArgsIsHelpError(ctx)  # noqa: SLF001 - private Click/Typer APIs
+
+        rest = typer._click.core.Command.parse_args(self, ctx, args)  # noqa: SLF001 - private Click/Typer APIs
+
+        ctx._protected_args = rest  # noqa: SLF001 - private Click/Typer APIs
+        ctx.args = []
+
+        return ctx.args
+
+    def collect_usage_pieces(self, ctx: typer._click.core.Context) -> list[str]:
+        rest = typer._click.core.Command.collect_usage_pieces(self, ctx)  # noqa: SLF001 - private Click/Typer APIs
+        rest.append("COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...")
+        return rest
+
+    def invoke(self, ctx: typer._click.core.Context) -> Any:  # noqa: ANN401 - dictated by Click's interface
+        if not ctx._protected_args:  # noqa: SLF001 - private Click/Typer APIs
+            ctx.fail("Missing command.")
+
+        args = [*ctx._protected_args, *ctx.args]  # noqa: SLF001 - private Click/Typer APIs
+        ctx.args = []
+        ctx._protected_args = []  # noqa: SLF001 - private Click/Typer APIs
+
+        with ctx:
+            ctx.invoked_subcommand = "*" if args else None
+            typer._click.core.Command.invoke(self, ctx)  # noqa: SLF001 - private Click/Typer APIs
+
+            contexts = []
+            while args:
+                cmd_name, cmd, args = self.resolve_command(ctx, args)
+                assert cmd is not None  # noqa: S101 - type narrowing
+                sub_ctx = cmd.make_context(
+                    cmd_name,
+                    args,
+                    parent=ctx,
+                    allow_extra_args=True,
+                    allow_interspersed_args=False,
+                )
+                contexts.append(sub_ctx)
+                args, sub_ctx.args = sub_ctx.args, []
+
+            rv = []
+            for sub_ctx in contexts:
+                with sub_ctx:
+                    rv.append(sub_ctx.command.invoke(sub_ctx))
+            return rv
+
+
 app = typer.Typer(
     name="qem-bot",
     help="QEM-Dashboard, SMELT, Gitea and openQA connector",
     no_args_is_help=True,
     add_completion=False,
+    cls=_ChainedTyperGroup,
+    chain=True,
 )
 log = logging.getLogger("bot")
 
@@ -332,7 +393,8 @@ def full_run(
     args.disable_aggregates = False
 
     bot = OpenQABot(args)
-    sys.exit(bot())
+    if (ret := bot()) != 0:
+        sys.exit(ret)
 
 
 @app.command("submissions-run")
@@ -361,7 +423,8 @@ def submissions_run(
     args.disable_aggregates = True
 
     bot = OpenQABot(args)
-    sys.exit(bot())
+    if (ret := bot()) != 0:
+        sys.exit(ret)
 
 
 @app.command("updates-run")
@@ -381,7 +444,8 @@ def updates_run(
     args.disable_submissions = True
 
     bot = OpenQABot(args)
-    sys.exit(bot())
+    if (ret := bot()) != 0:
+        sys.exit(ret)
 
 
 @app.command("smelt-sync")
@@ -391,7 +455,8 @@ def smelt_sync(ctx: typer.Context) -> None:
     _require_token(args)
 
     syncer = SMELTSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("gitea-sync")
@@ -441,7 +506,8 @@ def gitea_sync(  # ruff: ignore[too-many-arguments]
     args.skip_initial_sync = skip_initial_sync
 
     syncer = GiteaSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("gitea-trigger")
@@ -483,7 +549,8 @@ def gitea_trigger(  # ruff: ignore[too-many-arguments]
     )
 
     syncer = GiteaTrigger(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("sub-approve")
@@ -525,7 +592,8 @@ def sub_approve(  # ruff: ignore[too-many-arguments]
     )
 
     approve = Approver(args)
-    sys.exit(approve())
+    if (ret := approve()) != 0:
+        sys.exit(ret)
 
 
 @app.command("sub-comment")
@@ -550,7 +618,8 @@ def sub_comment(
 
     submissions = get_submissions()
     comment = Commenter(args, submissions)
-    sys.exit(comment())
+    if (ret := comment()) != 0:
+        sys.exit(ret)
 
 
 @app.command("sub-sync-results")
@@ -560,7 +629,8 @@ def sub_sync_results(ctx: typer.Context) -> None:
     _require_token(args)
 
     syncer = SubResultsSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("aggr-sync-results")
@@ -570,7 +640,8 @@ def aggr_sync_results(ctx: typer.Context) -> None:
     _require_token(args)
 
     syncer = AggregateResultsSync(args)
-    sys.exit(syncer())
+    if (ret := syncer()) != 0:
+        sys.exit(ret)
 
 
 @app.command("increment-approve")
@@ -707,7 +778,8 @@ def increment_approve(  # ruff: ignore[too-many-arguments]
     )
 
     approve = IncrementApprover(args)
-    sys.exit(approve())
+    if (ret := approve()) != 0:
+        sys.exit(ret)
 
 
 @app.command("repo-diff")
@@ -727,7 +799,8 @@ def repo_diff(
     args.repo_b = repo_b
 
     repo_diff_obj = RepoDiff(args)
-    sys.exit(repo_diff_obj())
+    if (ret := repo_diff_obj()) != 0:
+        sys.exit(ret)
 
 
 @app.command("amqp")
@@ -746,4 +819,5 @@ def amqp_cmd(
         args.url = config_module.settings.amqp_url
 
     amqp_obj = AMQP(args)
-    sys.exit(amqp_obj())
+    if (ret := amqp_obj()) != 0:
+        sys.exit(ret)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -22,63 +22,49 @@ if TYPE_CHECKING:
 runner = CliRunner()
 
 
-def test_full_run(mocker: MockerFixture, tmp_path: Path) -> None:
-    bot = mocker.patch("openqabot.args.OpenQABot")
-    bot.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "full-run"])
-    assert result.exit_code == 0
-    bot.assert_called_once()
-    args = bot.call_args[0][0]
-    assert not args.disable_aggregates
-    assert not args.disable_submissions
+@pytest.mark.parametrize(
+    ("cmd", "mock_path", "disable_aggregates", "disable_submissions"),
+    [
+        ("full-run", "openqabot.args.OpenQABot", False, False),
+        ("submissions-run", "openqabot.args.OpenQABot", True, False),
+        ("updates-run", "openqabot.args.OpenQABot", False, True),
+        ("smelt-sync", "openqabot.args.SMELTSync", None, None),
+        ("gitea-sync", "openqabot.args.GiteaSync", None, None),
+        ("gitea-trigger", "openqabot.args.GiteaTrigger", None, None),
+        ("sub-comment", "openqabot.args.Commenter", None, None),
+        ("sub-sync-results", "openqabot.args.SubResultsSync", None, None),
+        ("aggr-sync-results", "openqabot.args.AggregateResultsSync", None, None),
+        ("increment-approve", "openqabot.args.IncrementApprover", None, None),
+        ("repo-diff", "openqabot.args.RepoDiff", None, None),
+    ],
+)
+def test_command_success_exits(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    cmd: str,
+    mock_path: str,
+    *,
+    disable_aggregates: bool | None,
+    disable_submissions: bool | None,
+) -> None:
+    """Test that each command correctly exits with 0 and invokes the proper class on success."""
+    if cmd == "sub-comment":
+        mocker.patch("openqabot.args.get_submissions", return_value=[])
 
-
-def test_submission_schedule(mocker: MockerFixture, tmp_path: Path) -> None:
-    bot = mocker.patch("openqabot.args.OpenQABot")
-    bot.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "submissions-run"])
-    assert result.exit_code == 0
-    bot.assert_called_once()
-    args = bot.call_args[0][0]
-    assert args.disable_aggregates
-    assert not args.disable_submissions
-
-
-def test_updates_run(mocker: MockerFixture, tmp_path: Path) -> None:
-    bot = mocker.patch("openqabot.args.OpenQABot")
-    bot.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "updates-run"])
-    assert result.exit_code == 0
-    bot.assert_called_once()
-    args = bot.call_args[0][0]
-    assert not args.disable_aggregates
-    assert args.disable_submissions
-
-
-def test_sync_smelt(mocker: MockerFixture, tmp_path: Path) -> None:
-    syncer = mocker.patch("openqabot.args.SMELTSync")
-    syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "smelt-sync"])
-    assert result.exit_code == 0
-    syncer.assert_called_once()
-
-
-def test_sync_gitea(mocker: MockerFixture, tmp_path: Path) -> None:
-    syncer = mocker.patch("openqabot.args.GiteaSync")
-    syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), "gitea-sync"])
-    assert result.exit_code == 0
-    syncer.assert_called_once()
-
-
-def test_gitea_trigger(mocker: MockerFixture, tmp_path: Path) -> None:
-    syncer = mocker.patch("openqabot.args.GiteaTrigger")
-    syncer.return_value.return_value = 0
     config_file = tmp_path / "trigger.yml"
     config_file.write_text("trigger_config: []")
-    result = runner.invoke(app, ["--gitea-token", "bar", "--configs", str(tmp_path), "gitea-trigger"])
+
+    mock_obj = mocker.patch(mock_path)
+    mock_obj.return_value.return_value = 0
+
+    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), cmd])
     assert result.exit_code == 0
-    syncer.assert_called_once()
+    mock_obj.assert_called_once()
+
+    if disable_aggregates is not None:
+        args = mock_obj.call_args[0][0]
+        assert args.disable_aggregates is disable_aggregates
+        assert args.disable_submissions is disable_submissions
 
 
 @pytest.mark.parametrize(
@@ -105,15 +91,6 @@ def test_sub_approve(
     assert approve.call_args[0][0].comment is expected_comment
 
 
-def test_sub_comment(mocker: MockerFixture, tmp_path: Path) -> None:
-    mocker.patch("openqabot.args.get_submissions", return_value=[])
-    comment = mocker.patch("openqabot.args.Commenter")
-    comment.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "sub-comment"])
-    assert result.exit_code == 0
-    comment.assert_called_once()
-
-
 def test_sub_comment_with_detailed_args(mocker: MockerFixture, tmp_path: Path) -> None:
     mocker.patch("openqabot.args.get_submissions", return_value=[])
     comment = mocker.patch("openqabot.args.Commenter")
@@ -137,31 +114,6 @@ def test_sub_comment_with_detailed_args(mocker: MockerFixture, tmp_path: Path) -
     )
     assert result.exit_code == 0
     comment.assert_called_once()
-
-
-def test_sub_sync_results(mocker: MockerFixture, tmp_path: Path) -> None:
-    syncer = mocker.patch("openqabot.args.SubResultsSync")
-    syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "sub-sync-results"])
-    assert result.exit_code == 0
-    syncer.assert_called_once()
-
-
-def test_aggr_sync_results(mocker: MockerFixture, tmp_path: Path) -> None:
-    syncer = mocker.patch("openqabot.args.AggregateResultsSync")
-    syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "aggr-sync-results"])
-    assert result.exit_code == 0
-    syncer.assert_called_once()
-
-
-def test_increment_approve(mocker: MockerFixture, tmp_path: Path) -> None:
-    approve = mocker.patch("openqabot.args.IncrementApprover")
-    approve.return_value.return_value = 0
-    # Provide a valid configs directory to avoid Configuration error in main callback
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "increment-approve"])
-    assert result.exit_code == 0
-    approve.assert_called_once()
 
 
 def test_increment_approve_with_detailed_args(mocker: MockerFixture, tmp_path: Path) -> None:
@@ -191,15 +143,6 @@ def test_increment_approve_with_detailed_args(mocker: MockerFixture, tmp_path: P
     assert args.fallback_contact == "Test Contact"
     assert args.generic_tool_issues_contact == "@test"
     assert args.max_detailed_comment_entries == 5
-
-
-def test_repo_diff(mocker: MockerFixture, tmp_path: Path) -> None:
-    repo_diff = mocker.patch("openqabot.args.RepoDiff")
-    repo_diff.return_value.return_value = 0
-    # Provide a valid configs directory to avoid Configuration error in main callback
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "repo-diff"])
-    assert result.exit_code == 0
-    repo_diff.assert_called_once()
 
 
 def test_amqp(mocker: MockerFixture, tmp_path: Path) -> None:
@@ -401,3 +344,70 @@ def test_cli_options_override_config_yml(mocker: MockerFixture, tmp_path: Path) 
     assert settings.insecure is True
     assert settings.dry is True
     assert settings.openqa_instance == "https://override.openqa"
+
+
+@pytest.mark.parametrize(
+    ("cmd", "mock_path"),
+    [
+        ("full-run", "openqabot.args.OpenQABot"),
+        ("submissions-run", "openqabot.args.OpenQABot"),
+        ("updates-run", "openqabot.args.OpenQABot"),
+        ("smelt-sync", "openqabot.args.SMELTSync"),
+        ("gitea-sync", "openqabot.args.GiteaSync"),
+        ("gitea-trigger", "openqabot.args.GiteaTrigger"),
+        ("sub-approve", "openqabot.args.Approver"),
+        ("sub-comment", "openqabot.args.Commenter"),
+        ("sub-sync-results", "openqabot.args.SubResultsSync"),
+        ("aggr-sync-results", "openqabot.args.AggregateResultsSync"),
+        ("increment-approve", "openqabot.args.IncrementApprover"),
+        ("repo-diff", "openqabot.args.RepoDiff"),
+        ("amqp", "openqabot.args.AMQP"),
+    ],
+)
+def test_command_failure_exits(mocker: MockerFixture, tmp_path: Path, cmd: str, mock_path: str) -> None:
+    """Test that each command correctly exits with 1 when it fails."""
+    if cmd == "sub-comment":
+        mocker.patch("openqabot.args.get_submissions", return_value=[])
+
+    config_file = tmp_path / "trigger.yml"
+    config_file.write_text("trigger_config: []")
+
+    mock_obj = mocker.patch(mock_path)
+    mock_obj.return_value.return_value = 1
+
+    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), cmd])
+    assert result.exit_code == 1
+    mock_obj.assert_called_once()
+
+
+def test_command_chaining_success(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test executing multiple commands sequentially when they all succeed."""
+    bot = mocker.patch("openqabot.args.OpenQABot")
+    bot.return_value.return_value = 0
+    syncer = mocker.patch("openqabot.args.SMELTSync")
+    syncer.return_value.return_value = 0
+
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "full-run", "smelt-sync"])
+    assert result.exit_code == 0
+    bot.assert_called_once()
+    syncer.assert_called_once()
+
+
+def test_command_chaining_fail_fast(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test executing multiple commands sequentially halts on first failure."""
+    bot = mocker.patch("openqabot.args.OpenQABot")
+    bot.return_value.return_value = 1
+    syncer = mocker.patch("openqabot.args.SMELTSync")
+    syncer.return_value.return_value = 0
+
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "full-run", "smelt-sync"])
+    assert result.exit_code == 1
+    bot.assert_called_once()
+    syncer.assert_not_called()
+
+
+def test_command_chaining_missing_command(tmp_path: Path) -> None:
+    """Test that calling the app with options but no command fails with "Missing command."."""
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path)])
+    assert result.exit_code == 2
+    assert "Missing command." in result.output


### PR DESCRIPTION
Motivation:
Running each CLI subcommand in separate CI pipelines incurs significant
environment and container image download overhead. Supporting multiple
commands sequentially in a single run drastically reduces setup runtime.

Design Choices:
Configure Typer with chain=True on the main app. Since Typer 0.26+ ignores
chain=True, subclass TyperGroup to custom _ChainedTyperGroup to implement
Click-compatible command chaining and restore backward-compatible help output.

Benefits:
Saves substantial GitLab CI pipeline runtime and container registry bandwidth.
Guarantees robust sequential command chaining compatibility across Typer/Click
versions with 100% statement and branch test coverage.