### PR TITLE
fix: abort early on missing or invalid Gitea token

### DIFF
--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -148,6 +148,18 @@ def _require_token(args: SimpleNamespace) -> None:
         raise typer.Exit(1)
 
 
+def _require_gitea_token(args: SimpleNamespace) -> None:
+    """Enforce that a Gitea token is present before entering a command.
+
+    Call this guard at the start of every command that does need Gitea.
+    """
+    if args.gitea_token is None or not args.gitea_token.strip():
+        typer.echo(
+            "Error: Missing option '--gitea-token' / '-g' or environment variable QEM_BOT_GITEA_TOKEN.", err=True
+        )
+        raise typer.Exit(1)
+
+
 @app.callback()
 def main(  # ruff: ignore[too-many-arguments]
     ctx: typer.Context,
@@ -408,6 +420,7 @@ def gitea_sync(  # ruff: ignore[too-many-arguments]
     """Sync data from Gitea into QEM Dashboard."""
     args = ctx.obj
     _require_token(args)
+    _require_gitea_token(args)
     args.gitea_project = gitea_project
     args.allow_build_failures = allow_build_failures
     args.consider_unrequested_prs = consider_unrequested_prs
@@ -445,6 +458,7 @@ def gitea_trigger(  # ruff: ignore[too-many-arguments]
 ) -> None:
     """Trigger testing for PR(s) with certain label."""
     args = ctx.obj
+    _require_gitea_token(args)
     args.pr_number = pr_number
     args.pr_label = pr_label
     args.comment = comment

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 import urllib.error
 from collections import Counter
 from concurrent import futures
 from dataclasses import dataclass, field
 from functools import lru_cache
+from http import HTTPStatus
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
@@ -27,7 +29,7 @@ from osc.core import MultibuildFlavorResolver
 from openqabot import config
 from openqabot.loader.smelt import get_gitea_update_data
 from openqabot.types.pullrequest import PullRequest
-from openqabot.utils import retry10 as retried_requests
+from openqabot.utils import retry10_gitea as retried_requests
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -66,6 +68,16 @@ def make_token_header(token: str) -> dict[str, str]:
     return {} if token is None else {"Authorization": "token " + token}
 
 
+def check_response(response: requests.Response) -> None:
+    """Abort execution if response indicates Gitea authorization failure."""
+    if response.status_code == HTTPStatus.UNAUTHORIZED:
+        log.error("Gitea API error: Missing or invalid Gitea token (status code 401)")
+        sys.exit(1)
+    if response.status_code == HTTPStatus.FORBIDDEN:
+        log.error("Gitea API error: Insufficient permissions for Gitea token (status code 403)")
+        sys.exit(1)
+
+
 def get_json(
     query: str,
     token: dict[str, str],
@@ -76,6 +88,7 @@ def get_json(
     host = host or config.settings.gitea_url
     url = f"{host}/api/v1/{query}"
     response = retried_requests.get(url, verify=not config.settings.insecure, headers=token, params=params)
+    check_response(response)
     response.raise_for_status()
     return response.json()
 
@@ -92,6 +105,7 @@ def iter_gitea_items(query: str, token: dict[str, str], host: str | None = None)
 
     while url:
         response = retried_requests.get(url, verify=not config.settings.insecure, headers=token)
+        check_response(response)
         response.raise_for_status()
         res = response.json()
 
@@ -110,6 +124,7 @@ def _request_json(method: str, query: str, token: dict[str, str], post_data: Jso
     res = getattr(retried_requests, method.lower())(
         url, verify=not config.settings.insecure, headers=token, json=post_data
     )
+    check_response(res)
     if not res.ok:
         log.error("Gitea API error: %s to %s failed: %s", method.upper(), url, res.text)
 
@@ -627,6 +642,7 @@ def add_packages_from_patchinfo(
     else:
         try:
             response = retried_requests.get(patch_info_url, verify=not config.settings.insecure, headers=token)
+            check_response(response)
             response.raise_for_status()
             patch_info = etree.fromstring(response.content)
         except (etree.ParseError, requests.RequestException) as e:

--- a/openqabot/utils.py
+++ b/openqabot/utils.py
@@ -133,13 +133,17 @@ def number_of_retries(fallback: int = 3) -> int:
     return int(os.environ.get("QEM_BOT_RETRIES", 0 if "PYTEST_VERSION" in os.environ else fallback))
 
 
-def make_retry_session(retries: int, backoff_factor: float) -> Session:
+def make_retry_session(
+    retries: int,
+    backoff_factor: float,
+    status_forcelist: frozenset[int] = frozenset({403, 413, 429, 503}),
+) -> Session:
     """Create a requests session with retry capabilities."""
     adapter = HTTPAdapter(
         max_retries=Retry(
             number_of_retries(retries),
             backoff_factor=backoff_factor,
-            status_forcelist=frozenset({403, 413, 429, 503}),
+            status_forcelist=status_forcelist,
         ),
     )
     http = Session()
@@ -152,6 +156,7 @@ def make_retry_session(retries: int, backoff_factor: float) -> Session:
 retry3 = make_retry_session(3, 2)
 retry5 = make_retry_session(5, 1)
 retry10 = make_retry_session(10, 0.1)
+retry10_gitea = make_retry_session(10, 0.1, status_forcelist=frozenset({413, 429, 503}))
 
 
 CONTACT_PATTERN = re.compile(

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -66,7 +66,7 @@ def test_sync_smelt(mocker: MockerFixture, tmp_path: Path) -> None:
 def test_sync_gitea(mocker: MockerFixture, tmp_path: Path) -> None:
     syncer = mocker.patch("openqabot.args.GiteaSync")
     syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "gitea-sync"])
+    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), "gitea-sync"])
     assert result.exit_code == 0
     syncer.assert_called_once()
 
@@ -76,7 +76,7 @@ def test_gitea_trigger(mocker: MockerFixture, tmp_path: Path) -> None:
     syncer.return_value.return_value = 0
     config_file = tmp_path / "trigger.yml"
     config_file.write_text("trigger_config: []")
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "gitea-trigger"])
+    result = runner.invoke(app, ["--gitea-token", "bar", "--configs", str(tmp_path), "gitea-trigger"])
     assert result.exit_code == 0
     syncer.assert_called_once()
 
@@ -309,6 +309,24 @@ def test_main_no_token_exit(mocker: MockerFixture, tmp_path: Path) -> None:
     result = runner.invoke(app, ["--configs", str(tmp_path), "full-run"])
     assert result.exit_code == 1
     assert "Error: Missing option '--token' / '-t'." in result.output
+
+
+def test_main_no_gitea_token_exit_sync(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test that gitea-sync exits with 1 when gitea_token is missing."""
+    mocker.patch.dict("os.environ", {}, clear=True)
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "gitea-sync"])
+    assert result.exit_code == 1
+    assert "Error: Missing option '--gitea-token' / '-g' or environment variable QEM_BOT_GITEA_TOKEN." in result.output
+
+
+def test_main_no_gitea_token_exit_trigger(mocker: MockerFixture, tmp_path: Path) -> None:
+    """Test that gitea-trigger exits with 1 when gitea_token is missing."""
+    mocker.patch.dict("os.environ", {}, clear=True)
+    config_file = tmp_path / "trigger.yml"
+    config_file.write_text("trigger_config: []")
+    result = runner.invoke(app, ["--configs", str(tmp_path), "gitea-trigger"])
+    assert result.exit_code == 1
+    assert "Error: Missing option '--gitea-token' / '-g' or environment variable QEM_BOT_GITEA_TOKEN." in result.output
 
 
 def test_main_token_provided_no_help(mocker: MockerFixture, tmp_path: Path) -> None:

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -428,3 +428,18 @@ def test_review_pr_no_bot_user(
     mock_settings.git_review_bot_user = None
     with pytest.raises(ValueError, match="git_review_bot_user is required to post a review or comment"):
         gitea.review_pr({}, "repo", 123, "msg", "sha123")
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_check_response_unauthorized_forbidden(status_code: int) -> None:
+    mock_response = MagicMock(status_code=status_code)
+    with pytest.raises(SystemExit) as exc_info:
+        gitea.check_response(mock_response)
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.parametrize("status_code", [200, 404, 500])
+def test_check_response_other_statuses(status_code: int) -> None:
+    mock_response = MagicMock(status_code=status_code)
+    # Should not raise SystemExit
+    gitea.check_response(mock_response)


### PR DESCRIPTION
Motivation:
Using Gitea commands without a valid token causes requests to hang or retry
repeatedly.

Design Choices:
Added a CLI token validation guard for Gitea-specific commands, created a Gitea
retry session that bypasses 403 status code retries, and added immediate abort
on 401/403 responses.

Benefits:
Ensures early feedback for missing or invalid credentials instead of hanging.