### PR TITLE
fix: log dry-run would-approve per submission in Approver.__call__

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -165,7 +165,10 @@ class Approver:
         for sub in submissions_to_approve:
             log.info("* %s", ms2str(sub))
 
-        if not self.dry:
+        if self.dry:
+            for sub in submissions_to_approve:
+                log.info("Dry run: Would approve %s", ms2str(sub))
+        else:
             osc.conf.get_config(override_apiurl=config.settings.obs_url)
             with ThreadPoolExecutor() as executor:
                 for result in executor.map(self.approve, submissions_to_approve):


### PR DESCRIPTION
Motivation:
With --dry, the approval loop was silently skipped after logging
"Submissions to approve: * git:N", giving no indication the action
was suppressed.

Design Choices:
Per-submission "Dry run: Would approve <sub>" log in the dry branch,
consistent with the "Dry run: Would <verb> <object>" convention used
across commenter.py, giteatrigger.py, and giteasync.py.

Benefits:
Dry-run output now unambiguously names each suppressed approval at
the point the decision is made, not as an aggregate count.