### PR TITLE
feat: make _handle_exception debug log self-contained

### DIFF
--- a/openqabot/main.py
+++ b/openqabot/main.py
@@ -27,7 +27,7 @@ def _handle_exception(e: Exception, log: Logger) -> None:
     k = hashlib.sha256(signature.encode("utf-8")).hexdigest()
     errorcnt[k] += 1
     count = errorcnt[k]
-    log.debug("exception: %s, errorcount: %d", k, count)
+    log.debug("%s(%s) [hash=%s, count=%d]", type(e).__name__, e, k, count)
     if count > error_limit:
         log.error("error limit hit for exception %s, reraising", k)
         raise e

--- a/tests/test_openqabot.py
+++ b/tests/test_openqabot.py
@@ -15,6 +15,7 @@ import pytest
 import responses
 from typer.testing import CliRunner
 
+import openqabot.main as main_module
 from openqabot.args import app
 from openqabot.args import main as args_main
 from openqabot.config import settings
@@ -327,3 +328,20 @@ def test_main_exception_limit_reraise(mocker: MockerFixture) -> None:
     assert len(errorcnt) == 1
     key = next(iter(errorcnt))
     assert errorcnt[key] == 11
+
+
+def _raise_key_error() -> None:
+    key = "number"
+    raise KeyError(key)
+
+
+def test_handle_exception_debug_log_is_self_contained(mocker: MockerFixture) -> None:
+    mock_log = mocker.Mock()
+    errorcnt.clear()
+    try:
+        _raise_key_error()
+    except KeyError as e:
+        main_module._handle_exception(e, mock_log)  # ruff: ignore[private-member-access]
+
+    debug_calls = [str(c) for c in mock_log.debug.call_args_list]
+    assert any("KeyError" in c and "'number'" in c for c in debug_calls), debug_calls


### PR DESCRIPTION
Motivation:
The debug message "exception: <64-char-sha256>, errorcount: N" was
opaque at a glance — a developer had to cross-reference the hash with
a stack trace to know what type of error was occurring.

Design Choices:
Include the exception type name and message directly in the debug log
line: "ExcType(message) [hash=..., count=N]". The hash is retained for
correlation across multiple occurrences. Adds a unit test asserting that
the debug call contains both the type name and the message.

Benefits:
Developers scanning logs can immediately identify the error class and
message without needing to correlate a SHA256 to a separate traceback.