### PR TITLE
fix: parse type:id submission arg in Approver init

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -129,9 +129,15 @@ class Approver:
         self.dry = args.dry
         self.gitea_token: dict[str, str] = make_token_header(args.gitea_token)
         if single_submission is None:
-            self.single_submission = getattr(args, "submission", None) or getattr(args, "incident", None)
+            raw = getattr(args, "submission", None) or getattr(args, "incident", None)
+            if isinstance(raw, str) and ":" in raw:
+                s_type, s_id = raw.split(":", 1)
+                self.single_submission = int(s_id)
+                self.submission_type = s_type
+            else:
+                self.single_submission = int(raw) if raw is not None else None
+                self.submission_type = None
             self.all_submissions = args.all_submissions
-            self.submission_type = None
         else:
             self.single_submission = single_submission
             self.all_submissions = False

--- a/tests/test_approve_scenarios.py
+++ b/tests/test_approve_scenarios.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import logging
 import re
+from argparse import Namespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
 import responses
 
+from openqabot.approver import Approver
 from openqabot.config import settings
 from openqabot.loader.qem import JobAggr, SubReq
 
@@ -24,6 +26,21 @@ from .helpers import (
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+
+@pytest.mark.parametrize(
+    ("raw", "exp_sub", "exp_type"),
+    [
+        pytest.param("git:6189", 6189, "git", id="type-colon-id-string"),
+        pytest.param(42, 42, None, id="plain-int"),
+        pytest.param(None, None, None, id="none"),
+    ],
+)
+def test_approver_single_submission_parsing(raw: str | int | None, exp_sub: int | None, exp_type: str | None) -> None:
+    args = Namespace(dry=True, token="123", all_submissions=False, incident=raw, gitea_token=None, comment=False)
+    inst = Approver(args)
+    assert inst.single_submission == exp_sub
+    assert inst.submission_type == exp_type
 
 
 @pytest.fixture


### PR DESCRIPTION
Motivation:
Passing --submission git:6189 caused a KeyError('number') crash because
the raw string "git:6189" was used verbatim as the URL path component,
producing api/incidents/git:6189 which returns an error dict instead
of the expected incident payload.

Design Choices:
Split the "type:id" string in Approver.__init__ where the raw CLI value
is first consumed, setting single_submission=int(id) and submission_type
from the prefix. Integer values (existing internal callers) pass through
unchanged. Adds a parametrized unit test covering the three input shapes.

Benefits:
sub-approve --submission git:N now correctly fetches api/incidents/N with
the type filter, matching the established pattern in get_submissions().

Related issue: https://progress.opensuse.org/issues/202953