### PR TITLE
fix: validate live review state in _is_already_approved

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -275,11 +275,17 @@ def _is_already_approved(token: dict[str, str], repo_name: str, pr_number: int, 
         raise ValueError(error_msg)
 
     comments = iter_gitea_items(comments_url(repo_name, pr_number), token)
-    if any(_is_bot_approval_comment(c, bot_user, commit_id) for c in comments):
-        log.info("PR %s already approved via comment for commit %s", pr_number, commit_id)
-        return True
+    if not any(_is_bot_approval_comment(c, bot_user, commit_id) for c in comments):
+        return False
 
-    return False
+    bot_reviews = [r for r in iter_gitea_items(reviews_url(repo_name, pr_number), token) if is_review_requested_by(r)]
+    has_active_approval = any(
+        not r.get("dismissed", True) and _effective_state(r) == "APPROVED" and r.get("commit_id") == commit_id
+        for r in bot_reviews
+    )
+    approved = not bot_reviews or has_active_approval
+    log.info("PR %s live-review approval for commit %s: %s", pr_number, commit_id, approved)
+    return approved
 
 
 def approve_pr(token: dict[str, str], repo_name: str, pr_number: int, commit_id: str, msg: str) -> bool:

--- a/tests/test_loader_gitea_helpers.py
+++ b/tests/test_loader_gitea_helpers.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -232,31 +233,90 @@ def mock_settings(mocker: MockerFixture) -> MagicMock:
 
 
 @pytest.mark.parametrize(
-    ("bot_user", "api_response", "expected_log", "should_call_review"),
+    ("bot_user", "api_response_comments", "api_response_reviews", "should_call_review"),
     [
-        # Case 1: Already approved via bot comment
-        (
+        # Active APPROVED review for current commit -> no re-post
+        pytest.param(
             "bot",
             [{"body": "@bot: approved\nTested commit: sha123", "user": {"login": "bot"}}],
-            "PR 123 already approved via comment for commit sha123",
+            [{"dismissed": False, "state": "APPROVED", "user": {"login": "bot"}, "commit_id": "sha123"}],
             False,
+            id="active-approval-no-repost",
         ),
-        # Case 2: Comment matches but author is wrong (spoofing attempt)
-        (
+        # Comment author mismatch (spoofing) -> re-post
+        pytest.param(
             "bot",
             [{"body": "@bot: approved\nTested commit: sha123", "user": {"login": "imposter"}}],
-            None,
+            [],
             True,
+            id="spoofed-comment-repost",
         ),
-        # Case 3: Already approved via bot comment using obs_group name
-        (
+        # Active APPROVED review, team/obs_group authored comment -> no re-post
+        pytest.param(
             "bot-review",
             [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "openqa"}}],
-            "PR 123 already approved via comment for commit sha123",
+            [{"dismissed": False, "state": "APPROVED", "user": {"login": "bot-review"}, "commit_id": "sha123"}],
             False,
+            id="obs-group-comment-active-review-no-repost",
         ),
-        # Case 4: No bot comments found
-        ("bot", [], None, True),
+        # No bot comment at all -> re-post
+        pytest.param("bot", [], [], True, id="no-comment-repost"),
+        # Review dismissed -> re-post
+        pytest.param(
+            "bot-review",
+            [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "bot-review"}}],
+            [{"dismissed": True, "state": "APPROVED", "user": {"login": "bot-review"}, "commit_id": "sha123"}],
+            True,
+            id="dismissed-review-repost",
+        ),
+        # Review stale (post-push) -> re-post
+        pytest.param(
+            "bot-review",
+            [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "bot-review"}}],
+            [
+                {
+                    "dismissed": False,
+                    "stale": True,
+                    "state": "APPROVED",
+                    "user": {"login": "bot-review"},
+                    "commit_id": "sha123",
+                }
+            ],
+            True,
+            id="stale-review-repost",
+        ),
+        # Review in REQUEST_REVIEW state -> re-post
+        pytest.param(
+            "bot-review",
+            [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "bot-review"}}],
+            [{"dismissed": False, "state": "REQUEST_REVIEW", "user": {"login": "bot-review"}, "commit_id": "sha123"}],
+            True,
+            id="request-review-state-repost",
+        ),
+        # Comment exists, no reviews yet (qam-openqa-review hasn't acted) -> no re-post
+        pytest.param(
+            "bot-review",
+            [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "bot-review"}}],
+            [],
+            False,
+            id="comment-no-reviews-yet-no-repost",
+        ),
+        # APPROVED review for a different (older) commit -> re-post
+        pytest.param(
+            "bot-review",
+            [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "bot-review"}}],
+            [{"dismissed": False, "state": "APPROVED", "user": {"login": "bot-review"}, "commit_id": "old-sha"}],
+            True,
+            id="approval-for-older-commit-repost",
+        ),
+        # APPROVED review missing commit_id (fail closed) -> re-post
+        pytest.param(
+            "bot-review",
+            [{"body": "@bot-review: approved\nTested commit: sha123", "user": {"login": "bot-review"}}],
+            [{"dismissed": False, "state": "APPROVED", "user": {"login": "bot-review"}}],
+            True,
+            id="approval-missing-commit-id-repost",
+        ),
     ],
 )
 def test_approve_pr_scenarios(
@@ -264,23 +324,24 @@ def test_approve_pr_scenarios(
     mock_review_pr: MagicMock,
     mock_settings: MagicMock,
     mocker: MockerFixture,
-    caplog: pytest.LogCaptureFixture,
     bot_user: str | None,
-    api_response: list[dict],
-    expected_log: str | None,
+    api_response_comments: list[dict],
+    api_response_reviews: list[dict],
     should_call_review: bool,
 ) -> None:
-    caplog.set_level(logging.INFO, logger="bot.loader.gitea")
-    mocker.patch("openqabot.loader.gitea.iter_gitea_items", return_value=api_response)
+    def mock_iter_items(url: str, _token: Any) -> list[dict]:
+        if "issues" in url:
+            return api_response_comments
+        if "reviews" in url:
+            return api_response_reviews
+        msg = f"unexpected iter_gitea_items url: {url}"
+        raise AssertionError(msg)
 
+    mocker.patch("openqabot.loader.gitea.iter_gitea_items", side_effect=mock_iter_items)
     mock_settings.obs_group = "openqa"
     mock_settings.git_review_bot_user = bot_user
 
-    res = gitea.approve_pr({}, "repo", 123, "sha123", "msg")
-
-    assert res is True
-    if expected_log:
-        assert expected_log in caplog.text
+    assert gitea.approve_pr({}, "repo", 123, "sha123", "msg") is True
     if should_call_review:
         mock_review_pr.assert_called_once_with({}, "repo", 123, "msg", "sha123", approve=True)
     else:


### PR DESCRIPTION
Motivation:
The guard keyed solely on comment presence matched to commit_id, so an
APPROVED review for an older commit (or a dismissed/re-requested one for
the current commit) still suppressed re-approval. Introduced as a
data-driven rewrite that also consolidates selector logic.

Design Choices:
Use is_review_requested_by() (consistent with add_reviews) to select bot
reviews; cross-check r.get("commit_id") against commit_id so a stale
approval for an outdated SHA does not short-circuit; collapse the 4-branch
ladder to one expression with reason as data; drop list() wrap. Tests drop
brittle log-message assertions for behavioural assertions only and add the
commit_id-mismatch case now covered by the new guard.

Manual verification:
I called

```
./qem-bot.py -d --gitea-token $(cat .gitea_token) sub-approve --submission 6189
```

with a scoped token that prevents any actual commenting. The output
reveals that another approval comment would*actually be written.

Benefits:
Re-approval is triggered whenever the live review is dismissed, stale, or
for a different commit; idempotency retained when the review is genuinely
active and APPROVED for the current commit.

Related issue: https://progress.opensuse.org/issues/202953