### PR TITLE
feat: Add SUBMISSION_ID to separate openQA job history

### DIFF
--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -231,6 +231,7 @@ class Submissions(BaseConf):
             else self.settings["VERSION"],
             "DISTRI": self.settings["DISTRI"],
             "INCIDENT_ID": sub.id,
+            "SUBMISSION_ID": f"{sub.type}:{sub.id}",
             "REPOHASH": revs,
             "BUILD": f":{sub.type}:{sub.id}:{sub.packages[0]}",
             **OBSOLETE_PARAMS,

--- a/tests/test_submissions_gitea.py
+++ b/tests/test_submissions_gitea.py
@@ -38,6 +38,7 @@ def _assert_gitea_settings(
         "DISTRI": distri,
         "FLAVOR": flavor,
         "INCIDENT_ID": sub_id,
+        "SUBMISSION_ID": f"{sub_type}:{sub_id}",
         "INCIDENT_REPO": f"{expected_repo}-{arch}/",
         "REPOHASH": repo_hash,
         "VERSION": f"{product_ver}:git-{sub_id}",


### PR DESCRIPTION
Motivation
Independent pull requests were treated as consecutive builds in openQA, leading
to incorrect "carry-over" candidate selections and wrong "last good" builds.

Design Choices
Include the `SUBMISSION_ID` key natively formatted as `<type>:<id>` (e.g.
`git:6645`) in the openQA post payload settings next to `INCIDENT_ID`. The
tests for Gitea submissions were updated to assert this newly added value.

Benefits
openQA now automatically separates the history of different PRs, ensuring that
features like the Investigate tab and the bugref carry-over pick the correct
base build.

Related issue: https://progress.opensuse.org/issues/200985