### PR TITLE
refactor(lint): replace name-based ruff selectors with rule codes

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -233,7 +233,7 @@ class Approver:
                 e,
             )
 
-    @lru_cache(maxsize=512)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=512)  # ruff: ignore[B019]
     def is_job_marked_acceptable_for_submission(self, job_id: int, sub: int) -> bool:
         """Check if a job is marked as acceptable for a submission."""
         regex = re.compile(ACCEPTABLE_FOR_TEMPLATE.format(sub=sub), re.DOTALL)
@@ -261,7 +261,7 @@ class Approver:
             return False
         return True
 
-    @lru_cache(maxsize=16384)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=16384)  # ruff: ignore[B019]
     def job_contains_submission(self, job_id: int, sub: int) -> bool:
         """Check if a job settings contain the submission under test."""
         job_settings = self.client.get_single_job(job_id)
@@ -320,7 +320,7 @@ class Approver:
         log.info("Ignoring not-ok aggregate %s and using instead %s for aggregate %s", not_ok_job_id, job["id"], sub)
         return OlderJobResult.OK
 
-    @lru_cache(maxsize=512)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=512)  # ruff: ignore[B019]
     def was_ok_before(self, not_ok_job_id: int, sub: int) -> bool:
         """Check if a similar job was successful before."""
         # We need a considerable amount of older jobs, since there could be many failed manual restarts from same day
@@ -400,7 +400,7 @@ class Approver:
         log.info("Found not-ok, not-ignored job %s for submission %s:%s", url, s_type, sub)
         return False
 
-    @lru_cache(maxsize=128)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=128)  # ruff: ignore[B019]
     def get_jobs(self, job_aggr: JobAggr, api: str, sub: int, submission_type: str | None = None) -> JobResult:
         """Retrieve jobs for a specific aggregate or incident setting.
 

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -161,7 +161,7 @@ def _require_gitea_token(args: SimpleNamespace) -> None:
 
 
 @app.callback()
-def main(  # ruff: ignore[too-many-arguments]
+def main(  # ruff: ignore[PLR0913]
     ctx: typer.Context,
     *,
     configs: Annotated[
@@ -363,7 +363,7 @@ def updates_run(
         typer.Option("-i", "--ignore-onetime", help="Ignore onetime and schedule those test runs"),
     ] = False,
 ) -> None:
-    """Aggregates only schedule for Maintenance Submissions in openQA."""  # ruff: ignore[non-imperative-mood]
+    """Aggregates only schedule for Maintenance Submissions in openQA."""  # ruff: ignore[D401]
     args = ctx.obj
     _require_token(args)
     args.ignore_onetime = ignore_onetime
@@ -385,7 +385,7 @@ def smelt_sync(ctx: typer.Context) -> None:
 
 
 @app.command("gitea-sync")
-def gitea_sync(  # ruff: ignore[too-many-arguments]
+def gitea_sync(  # ruff: ignore[PLR0913]
     ctx: typer.Context,
     *,
     gitea_project: gitea_project_arg = "products/SLFO",
@@ -435,7 +435,7 @@ def gitea_sync(  # ruff: ignore[too-many-arguments]
 
 
 @app.command("gitea-trigger")
-def gitea_trigger(  # ruff: ignore[too-many-arguments]
+def gitea_trigger(  # ruff: ignore[PLR0913]
     ctx: typer.Context,
     *,
     pr_label: Annotated[
@@ -477,7 +477,7 @@ def gitea_trigger(  # ruff: ignore[too-many-arguments]
 
 
 @app.command("sub-approve")
-def sub_approve(  # ruff: ignore[too-many-arguments]
+def sub_approve(  # ruff: ignore[PLR0913]
     ctx: typer.Context,
     *,
     all_submissions: Annotated[
@@ -564,7 +564,7 @@ def aggr_sync_results(ctx: typer.Context) -> None:
 
 
 @app.command("increment-approve")
-def increment_approve(  # ruff: ignore[too-many-arguments]
+def increment_approve(  # ruff: ignore[PLR0913]
     ctx: typer.Context,
     *,
     project_base: Annotated[
@@ -574,7 +574,7 @@ def increment_approve(  # ruff: ignore[too-many-arguments]
         str,
         typer.Option(
             "--build-project-suffix",
-            help="The project on OBS to monitor. Schedule jobs for (if --schedule is specified) and approve (if all tests passed)",  # ruff: ignore[line-too-long]
+            help="The project on OBS to monitor. Schedule jobs for (if --schedule is specified) and approve (if all tests passed)",  # ruff: ignore[E501]
         ),
     ] = "TEST",
     diff_project_suffix: Annotated[
@@ -711,7 +711,7 @@ def repo_diff(
         str, typer.Option("--repo-b", help="The second repository")
     ] = "SUSE:SLFO:Products:SLES:16.0:PUBLISH/product",
 ) -> None:
-    """Computes the diff between two repositories."""  # ruff: ignore[non-imperative-mood]
+    """Computes the diff between two repositories."""  # ruff: ignore[D401]
     args = ctx.obj
     args.repo_a = repo_a
     args.repo_b = repo_b

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -27,7 +27,7 @@ def get_default_obs_url() -> str:
         osc.conf.get_config()
         if apiurl := osc.conf.config.get("apiurl"):
             return apiurl
-    except Exception:  # ruff: ignore[blind-except, try-except-pass]
+    except Exception:  # ruff: ignore[BLE001, S110]
         pass
     return "https://api.suse.de"
 
@@ -35,7 +35,7 @@ def get_default_obs_url() -> str:
 class Settings(BaseSettings):
     """Configuration settings managed by Pydantic."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # ruff: ignore[any-type]
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # ruff: ignore[ANN401]
         """Initialize settings with optional overrides.
 
         This explicit constructor helps type checkers like 'ty' recognize valid parameters.
@@ -173,7 +173,7 @@ class Settings(BaseSettings):
 settings = Settings()
 
 
-def __getattr__(name: str) -> Any:  # ruff: ignore[any-type]
+def __getattr__(name: str) -> Any:  # ruff: ignore[ANN401]
     """Map legacy module-level constants to settings object attributes."""
     mapping = {
         "QEM_DASHBOARD": "qem_dashboard_url",

--- a/openqabot/dashboard.py
+++ b/openqabot/dashboard.py
@@ -17,7 +17,7 @@ def clear_cache() -> None:
     _GET_CACHE.clear()
 
 
-def get_json(route: str, **kwargs: Any) -> Any:  # ruff: ignore[any-type]
+def get_json(route: str, **kwargs: Any) -> Any:  # ruff: ignore[ANN401]
     """Fetch JSON data from the dashboard with caching."""
     # Use simple key based on route and stringified kwargs
     cache_key = route + str(sorted(kwargs.items()))
@@ -29,11 +29,11 @@ def get_json(route: str, **kwargs: Any) -> Any:  # ruff: ignore[any-type]
     return data
 
 
-def patch(route: str, **kwargs: Any) -> requests.Response:  # ruff: ignore[any-type]
+def patch(route: str, **kwargs: Any) -> requests.Response:  # ruff: ignore[ANN401]
     """Perform a PATCH request to the dashboard."""
     return retried_requests.patch(settings.dashboard_url(route), **kwargs)
 
 
-def put(route: str, **kwargs: Any) -> requests.Response:  # ruff: ignore[any-type]
+def put(route: str, **kwargs: Any) -> requests.Response:  # ruff: ignore[ANN401]
     """Perform a PUT request to the dashboard."""
     return retried_requests.put(settings.dashboard_url(route), **kwargs)

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -127,14 +127,16 @@ class IncrementApprover:
         log.debug("Checking openQA job results for %s", info_str)
 
         def fetch_stats(p: dict[str, Any]) -> OpenQAResult:
-            return self.client.get_scheduled_product_stats({
-                "distri": p["DISTRI"],
-                "version": p["VERSION"],
-                "flavor": p["FLAVOR"],
-                "arch": p["ARCH"],
-                "build": p["BUILD"],
-                "product": p.get("PRODUCT"),
-            })
+            return self.client.get_scheduled_product_stats(
+                {
+                    "distri": p["DISTRI"],
+                    "version": p["VERSION"],
+                    "flavor": p["FLAVOR"],
+                    "arch": p["ARCH"],
+                    "build": p["BUILD"],
+                    "product": p.get("PRODUCT"),
+                }
+            )
 
         with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
             stats = list(executor.map(fetch_stats, params))

--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -246,7 +246,7 @@ def _get_single_pr(token: dict[str, str], project: str, number: int) -> list[Pul
         if pr := PullRequest.from_json(cast("dict[str, Any]", get_json(f"repos/{project}/pulls/{number}", token))):
             return [pr]
     except (requests.exceptions.RequestException, json.JSONDecodeError) as ex:
-        log.error("PR git:%s ignored: %s", number, ex, exc_info=True)  # ruff: ignore[logging-exc-info]
+        log.error("PR git:%s ignored: %s", number, ex, exc_info=True)  # ruff: ignore[G201]
     return []
 
 
@@ -264,7 +264,7 @@ def _is_bot_approval_comment(comment: dict[str, Any], bot_user: str, commit_id: 
     return is_author and review_cmd in body and commit_str in body
 
 
-def review_pr(  # ruff: ignore[too-many-arguments]
+def review_pr(  # ruff: ignore[PLR0913]
     token: dict[str, str],
     repo_name: str,
     pr_number: int,
@@ -589,10 +589,12 @@ def add_build_results(submission: dict[str, Any], obs_urls: list[str], *, dry: b
     if results.failed:
         log.info("PR git:%i: Some packages failed: %s", submission["number"], ", ".join(results.failed))
 
-    submission.update({
-        "failed_or_unpublished_packages": sorted(results.failed | results.unpublished | results.unavailable),
-        "successful_packages": sorted(results.successful),
-    })
+    submission.update(
+        {
+            "failed_or_unpublished_packages": sorted(results.failed | results.unpublished | results.unavailable),
+            "successful_packages": sorted(results.successful),
+        }
+    )
 
     channels = submission.setdefault("channels", [])
     channels.extend(result for result in sorted(results.projects) if result not in channels)
@@ -678,7 +680,7 @@ def _fetch_details(
     project: str, number: int, token: dict[str, str], *, dry: bool
 ) -> tuple[list[Any], list[Any], list[Any]]:
     if dry:
-        if number == 124:  # ruff: ignore[magic-value-comparison]
+        if number == 124:  # ruff: ignore[PLR2004]
             return (
                 read_json_file_list("reviews-124"),
                 read_json_file_list("comments-124"),

--- a/openqabot/loader/qem.py
+++ b/openqabot/loader/qem.py
@@ -261,7 +261,7 @@ def get_aggregate_results(sub: int, submission_type: str | None = None) -> list[
     return list(chain.from_iterable(all_data))
 
 
-def update_submissions(data: list[dict[str, Any]], **kwargs: Any) -> int:  # ruff: ignore[any-type]
+def update_submissions(data: list[dict[str, Any]], **kwargs: Any) -> int:  # ruff: ignore[ANN401]
     """Synchronize submission records with the dashboard."""
     retry = kwargs.get("retry", 0)
     query_params = kwargs.get("params", {})

--- a/openqabot/mock_interceptor.py
+++ b/openqabot/mock_interceptor.py
@@ -171,10 +171,12 @@ def gitea_staging_config_callback(_request: requests.PreparedRequest) -> tuple[i
     return (
         200,
         {},
-        json.dumps({
-            "StagingProject": "openQA:Staging:A",
-            "QA": [{"Name": "SLES", "Label": "label1"}, {"Name": "SLES", "Label": "label2"}],
-        }),
+        json.dumps(
+            {
+                "StagingProject": "openQA:Staging:A",
+                "QA": [{"Name": "SLES", "Label": "label1"}, {"Name": "SLES", "Label": "label2"}],
+            }
+        ),
     )
 
 
@@ -183,46 +185,48 @@ def smelt_graphql_callback(_request: requests.PreparedRequest) -> tuple[int, dic
     return (
         200,
         {},
-        json.dumps({
-            "data": {
-                "incidents": {
-                    "edges": [
-                        {
-                            "node": {
-                                "incidentId": 100,
-                                "emu": False,
-                                "project": "SUSE:Maintenance:100",
-                                "repositories": {"edges": [{"node": {"name": "SUSE:Updates:Mock:15-SP3"}}]},
-                                "requestSet": {
-                                    "edges": [
-                                        {
-                                            "node": {
-                                                "requestId": 1000,
-                                                "status": {"name": "review"},
-                                                "reviewSet": {
-                                                    "edges": [
-                                                        {
-                                                            "node": {
-                                                                "assignedByGroup": {"name": "qam-openqa"},
-                                                                "status": {"name": "new"},
+        json.dumps(
+            {
+                "data": {
+                    "incidents": {
+                        "edges": [
+                            {
+                                "node": {
+                                    "incidentId": 100,
+                                    "emu": False,
+                                    "project": "SUSE:Maintenance:100",
+                                    "repositories": {"edges": [{"node": {"name": "SUSE:Updates:Mock:15-SP3"}}]},
+                                    "requestSet": {
+                                        "edges": [
+                                            {
+                                                "node": {
+                                                    "requestId": 1000,
+                                                    "status": {"name": "review"},
+                                                    "reviewSet": {
+                                                        "edges": [
+                                                            {
+                                                                "node": {
+                                                                    "assignedByGroup": {"name": "qam-openqa"},
+                                                                    "status": {"name": "new"},
+                                                                },
                                                             },
-                                                        },
-                                                    ],
+                                                        ],
+                                                    },
                                                 },
                                             },
-                                        },
-                                    ],
+                                        ],
+                                    },
+                                    "packages": {"edges": [{"node": {"name": "mock-package"}}]},
+                                    "crd": None,
+                                    "priority": 50,
                                 },
-                                "packages": {"edges": [{"node": {"name": "mock-package"}}]},
-                                "crd": None,
-                                "priority": 50,
                             },
-                        },
-                    ],
-                    "pageInfo": {"hasNextPage": False, "endCursor": ""},
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": ""},
+                    }
                 }
             }
-        }),
+        ),
     )
 
 
@@ -231,25 +235,27 @@ def openqa_jobs_callback(_request: requests.PreparedRequest) -> tuple[int, dict[
     return (
         200,
         {},
-        json.dumps({
-            "jobs": [
-                {
-                    "id": 2,
-                    "status": "passed",
-                    "result": "passed",
-                    "name": "mock_job_git",
-                    "group": "Mock Group",
-                    "group_id": 1,
-                    "clone_id": None,
-                    "settings": {
-                        "BUILD": ":git:124:tree",
-                        "FLAVOR": "Mock-Flavor",
-                        "REPOHASH": "42",
-                        "VERSION": "15.99",
-                    },
-                }
-            ]
-        }),
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": 2,
+                        "status": "passed",
+                        "result": "passed",
+                        "name": "mock_job_git",
+                        "group": "Mock Group",
+                        "group_id": 1,
+                        "clone_id": None,
+                        "settings": {
+                            "BUILD": ":git:124:tree",
+                            "FLAVOR": "Mock-Flavor",
+                            "REPOHASH": "42",
+                            "VERSION": "15.99",
+                        },
+                    }
+                ]
+            }
+        ),
     )
 
 

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -99,7 +99,7 @@ class OpenQAInterface:
         }
         return self.openqa.openqa_request("GET", "jobs", param)["jobs"]
 
-    @lru_cache(maxsize=512)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=512)  # ruff: ignore[B019]
     def get_job_comments(self, job_id: int) -> list[dict[str, str]]:
         """Fetch comments for a specific job."""
         try:
@@ -114,7 +114,7 @@ class OpenQAInterface:
             log.exception("openQA API error when fetching comments for job %s", job_id)
         return []
 
-    @lru_cache(maxsize=256)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=256)  # ruff: ignore[B019]
     def is_devel_group(self, groupid: int) -> bool:
         """Check if a job group is a development group."""
         ret = self.openqa.openqa_request("GET", f"job_groups/{groupid}")
@@ -123,7 +123,7 @@ class OpenQAInterface:
             ret[0]["parent_id"] == config.settings.development_parent_group_id if ret else True
         )  # ID of Development Group
 
-    @lru_cache(maxsize=256)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=256)  # ruff: ignore[B019]
     def get_single_job(self, job_id: int) -> dict[str, Any] | None:
         """Fetch details for a single job."""
         try:
@@ -159,7 +159,7 @@ class OpenQAInterface:
 
         return self.is_devel_group(group_id) if group_id else False
 
-    @lru_cache(maxsize=256)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=256)  # ruff: ignore[B019]
     def get_older_jobs(self, job_id: int, limit: int) -> dict:
         """Fetch older jobs for a specific job."""
         try:
@@ -177,7 +177,7 @@ class OpenQAInterface:
         """Fetch scheduling statistics for a product."""
         return self.openqa.openqa_request("GET", "isos/job_stats", params, retries=self.retries)
 
-    @lru_cache(maxsize=256)  # ruff: ignore[cached-instance-method]
+    @lru_cache(maxsize=256)  # ruff: ignore[B019]
     def get_job_group_info(self, group_id: int) -> dict[str, Any] | None:
         """Fetch job group details including description."""
         try:

--- a/openqabot/types/pullrequest.py
+++ b/openqabot/types/pullrequest.py
@@ -45,11 +45,11 @@ class OBSCommentable:
         """Check if representing a Gitea pull request."""
         return False
 
-    def format_link(  # ruff: ignore[no-self-use] - Interface compatibility requires format_link to be a non-static method
+    def format_link(
         self,
         label: str,
         url: str,
-        image_url: str | None = None,  # ruff: ignore[unused-method-argument]  - Interface compatibility
+        image_url: str | None = None,  # ruff: ignore[ARG002]  - Interface compatibility
     ) -> str:
         """Format a link with an optional image badge."""
         return f"[{label}]({url})"
@@ -79,7 +79,7 @@ class PullRequest:
         """Check if representing a Gitea pull request."""
         return True
 
-    def format_link(self, label: str, url: str, image_url: str | None = None) -> str:  # ruff: ignore[no-self-use] - Interface compatibility requires format_link to be a non-static method
+    def format_link(self, label: str, url: str, image_url: str | None = None) -> str:
         """Format a link with an optional image badge."""
         if image_url:
             return f"[![{label}]({image_url})]({url})"

--- a/pc_helper_online.py
+++ b/pc_helper_online.py
@@ -15,7 +15,7 @@ from openqabot.pc_helper import apply_pc_tools_image, apply_publiccloud_pint_ima
 from openqabot.utils import create_logger
 
 
-def _process_config_file(p: Path, loader: YAML, log: Any) -> None:  # ruff: ignore[any-type]
+def _process_config_file(p: Path, loader: YAML, log: Any) -> None:  # ruff: ignore[ANN401]
     try:
         data = loader.load(p)
     except (YAMLError, FileNotFoundError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ find = {}
 [tool.ruff]
 line-length = 120
 exclude = ['metadata']
-preview = true
+preview = false
 
 [tool.ruff.lint]
 # E, F: Standard pycodestyle and Pyflakes (default flake8)
@@ -88,7 +88,7 @@ preview = true
 # PL: Pylint
 extend-select =[
     "E", "F", "D", "Q", "PL",
-    "debugger", # https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
+    "T10", # https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
     "T2", # https://docs.astral.sh/ruff/rules/#flake8-print-t20
     "TD", # https://docs.astral.sh/ruff/rules/#flake8-todos-td
     "W",
@@ -97,7 +97,6 @@ extend-select =[
     "B",
     "SIM",
     "C4",
-    "T10",
     "FIX",
     "ISC",
     "ICN",
@@ -149,20 +148,17 @@ extend-select =[
 ]
 
 ignore = [
-    "incorrect-blank-line-before-class",
-    "len-test",  # use-implicit-booleaness-not-len (name is non-obvious)
-    "multi-line-summary-second-line",
-    "too-many-public-methods",
-    "docstring-missing-returns",
-    "docstring-missing-exception",
-    "missing-trailing-comma",
+    "D203",      # incorrect-blank-line-before-class
+    "PLC1802",   # len-test / use-implicit-booleaness-not-len (name is non-obvious)
+    "D213",      # multi-line-summary-second-line
+    "COM812",    # missing-trailing-comma
 ]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 9
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["magic-value-comparison", "any-type", "too-many-arguments", "assert", "hardcoded-password-string", "hardcoded-password-func-arg", "too-many-positional-arguments", "undocumented-public-function", "invalid-rule-code"]
+"tests/*" = ["PLR2004", "ANN401", "PLR0913", "S101", "S105", "S106", "PLR0917", "D103", "RUF102", "ARG"]
 
 [tool.ruff.format]
 # Enable reformatting of code snippets in docstrings.

--- a/scripts/manage_dashboard.py
+++ b/scripts/manage_dashboard.py
@@ -4,7 +4,7 @@
 """Manage local qem-dashboard environment for integration testing."""
 
 import os
-import subprocess  # ruff: ignore[suspicious-subprocess-import]
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -21,10 +21,10 @@ except ImportError:
 app = typer.Typer(help="Manage local qem-dashboard environment for integration testing")
 
 
-def run_command(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:  # ruff: ignore[missing-type-kwargs]
+def run_command(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:  # ruff: ignore[ANN003]
     """Run a subprocess command and return the result."""
     check_result = kwargs.pop("check", True)
-    return subprocess.run(cmd, check=check_result, **kwargs)  # ruff: ignore[subprocess-without-shell-equals-true]
+    return subprocess.run(cmd, check=check_result, **kwargs)  # ruff: ignore[S603]
 
 
 @app.command()
@@ -58,24 +58,26 @@ def start(
     run_command([podman_bin, "network", "create", "qem-net"])
 
     # Start DB
-    run_command([
-        podman_bin,
-        "run",
-        "-d",
-        "--name",
-        "qem-db",
-        "--network",
-        "qem-net",
-        "-e",
-        "POSTGRES_USER=postgres",
-        "-e",
-        "POSTGRES_PASSWORD=postgres",
-        "-e",
-        "POSTGRES_DB=postgres",
-        "-p",
-        "5432:5432",
-        postgres_image,
-    ])
+    run_command(
+        [
+            podman_bin,
+            "run",
+            "-d",
+            "--name",
+            "qem-db",
+            "--network",
+            "qem-net",
+            "-e",
+            "POSTGRES_USER=postgres",
+            "-e",
+            "POSTGRES_PASSWORD=postgres",
+            "-e",
+            "POSTGRES_DB=postgres",
+            "-p",
+            "5432:5432",
+            postgres_image,
+        ]
+    )
 
     typer.echo("Waiting for postgres to be ready...")
     # Wait for DB to be responsive
@@ -132,24 +134,26 @@ def start(
 
     # Start Dashboard
     typer.echo("Starting qem-dashboard...")
-    run_command([
-        podman_bin,
-        "run",
-        "-d",
-        "--name",
-        "qem-dashboard",
-        "--network",
-        "qem-net",
-        "-e",
-        'DASHBOARD_CONF_OVERRIDE={"pg":"postgresql://postgres:postgres@qem-db:5432/postgres"}',
-        "-p",
-        "3000:3000",
-        "qem-dashboard:latest",
-        "script/dashboard",
-        "daemon",
-        "-l",
-        "http://*:3000",
-    ])
+    run_command(
+        [
+            podman_bin,
+            "run",
+            "-d",
+            "--name",
+            "qem-dashboard",
+            "--network",
+            "qem-net",
+            "-e",
+            'DASHBOARD_CONF_OVERRIDE={"pg":"postgresql://postgres:postgres@qem-db:5432/postgres"}',
+            "-p",
+            "3000:3000",
+            "qem-dashboard:latest",
+            "script/dashboard",
+            "daemon",
+            "-l",
+            "http://*:3000",
+        ]
+    )
 
     typer.secho("Dashboard started on http://localhost:3000", fg=typer.colors.GREEN)
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -6,7 +6,7 @@
 import logging
 import os
 import re
-import subprocess  # ruff: ignore[suspicious-subprocess-import]
+import subprocess
 import sys
 from pathlib import Path
 
@@ -56,7 +56,7 @@ def update_readme() -> None:
     if not match:
         log.error("Could not find Usage section in Readme.md")
         sys.exit(1)
-    assert match  # ruff: ignore[assert]
+    assert match  # ruff: ignore[S101]
     current_content = match.group(2)
     if current_content == new_section_content:
         log.info("Readme.md is already up to date.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,7 @@ def _mock_load_dotenv(mocker: MockerFixture) -> None:
 def fake_qem(request: pytest.FixtureRequest, mocker: MockerFixture) -> None:
     request_param = request.node.get_closest_marker("qem_behavior").args[0]
 
-    def f_sub_settins(sub: int, submission_type: str | None = None, **_kwargs: Any) -> list[JobAggr]:  # ruff: ignore[unused-function-argument]
+    def f_sub_settins(sub: int, submission_type: str | None = None, **_kwargs: Any) -> list[JobAggr]:
         if "inc" in request_param:
             msg = "No results for settings"
             raise NoResultsError(msg)
@@ -173,7 +173,7 @@ def fake_qem(request: pytest.FixtureRequest, mocker: MockerFixture) -> None:
         }
         return results.get(sub, [])
 
-    def f_aggr_settings(sub: int, submission_type: str | None = None) -> list[JobAggr]:  # ruff: ignore[unused-function-argument]
+    def f_aggr_settings(sub: int, submission_type: str | None = None) -> list[JobAggr]:
         if "aggr" in request_param:
             msg = "No results for settings"
             raise NoResultsError(msg)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -64,19 +64,21 @@ def _make_smelt_subreq(sub: int) -> SubReq:
     return SubReq(
         sub,
         rr,
-        submission=Submission.create({
-            "number": sub,
-            "rr_number": rr,
-            "project": f"PRJ{sub}",
-            "inReview": True,
-            "isActive": True,
-            "approved": False,
-            "inReviewQAM": True,
-            "embargoed": False,
-            "channels": ["SUSE:Updates:SLE-Module-Development-Tools:15-SP4:x86_64"],
-            "packages": [f"pkg{sub}"],
-            "emu": False,
-        }),
+        submission=Submission.create(
+            {
+                "number": sub,
+                "rr_number": rr,
+                "project": f"PRJ{sub}",
+                "inReview": True,
+                "isActive": True,
+                "approved": False,
+                "inReviewQAM": True,
+                "embargoed": False,
+                "channels": ["SUSE:Updates:SLE-Module-Development-Tools:15-SP4:x86_64"],
+                "packages": [f"pkg{sub}"],
+                "emu": False,
+            }
+        ),
     )
 
 
@@ -89,22 +91,24 @@ def f_sub_approver(*_args: Any) -> list[SubReq]:
             "git",
             "https://src.suse.de/products/SLFO/pulls/124",
             "18bfa2a23fb7985d5d0cc356474a96a19d91d2d8652442badf7f13bc07cd1f3d",
-            submission=Submission.create({
-                "number": 5,
-                "rr_number": 500,
-                "type": "git",
-                "url": "https://src.suse.de/products/SLFO/pulls/124",
-                "scm_info": "...",
-                "project": "products/SLFO",
-                "inReview": True,
-                "isActive": True,
-                "approved": False,
-                "inReviewQAM": True,
-                "embargoed": False,
-                "channels": ["SUSE:SLFO:Main:1.0:x86_64#products/SLFO"],
-                "packages": ["pkg5"],
-                "emu": False,
-            }),
+            submission=Submission.create(
+                {
+                    "number": 5,
+                    "rr_number": 500,
+                    "type": "git",
+                    "url": "https://src.suse.de/products/SLFO/pulls/124",
+                    "scm_info": "...",
+                    "project": "products/SLFO",
+                    "inReview": True,
+                    "isActive": True,
+                    "approved": False,
+                    "inReviewQAM": True,
+                    "embargoed": False,
+                    "channels": ["SUSE:SLFO:Main:1.0:x86_64#products/SLFO"],
+                    "packages": ["pkg5"],
+                    "emu": False,
+                }
+            ),
         ),
     ]
 
@@ -341,15 +345,17 @@ def fake_openqa_responses_with_param_matching(
     for flavor in ("Online-Increments", "Foo-Increments"):
         for arch, json in json_by_arch.items():
             list_of_params.append(({"arch": arch, "flavor": flavor}, json))
-    list_of_params.append((
-        {
-            "arch": "x86_64",
-            "flavor": "Additional-Foo-Increments",
-            "build": "PI-139.1-additional-build",
-            "product": "SLES",
-        },
-        additional_builds_json,
-    ))
+    list_of_params.append(
+        (
+            {
+                "arch": "x86_64",
+                "flavor": "Additional-Foo-Increments",
+                "build": "PI-139.1-additional-build",
+                "product": "SLES",
+            },
+            additional_builds_json,
+        )
+    )
     return [
         responses.add(
             responses.GET,

--- a/tests/test_amqp_listener.py
+++ b/tests/test_amqp_listener.py
@@ -38,7 +38,7 @@ def test_listener_full_workflow(mocker: MagicMock) -> None:
     mock_channel.queue_bind.assert_called_with(exchange="pubsub", queue="tmp-queue", routing_key="test.key")
     fake_body = json.dumps({"foo": "bar"}).encode("utf-8")
     fake_method = MagicMock(routing_key="test.key")
-    listener._on_message(None, fake_method, None, fake_body)  # ty: ignore[invalid-argument-type]  # ruff: ignore[private-member-access]
+    listener._on_message(None, fake_method, None, fake_body)  # ty: ignore[invalid-argument-type]  # ruff: ignore[SLF001]
 
     assert received_data[0] == ({"foo": "bar"}, "test.key")
 
@@ -54,12 +54,12 @@ def test_on_message_routing_key_types() -> None:
 
     # Test routing_key as bytes
     fake_method_bytes = MagicMock(routing_key=b"bytes.key")
-    listener._on_message(None, fake_method_bytes, None, fake_body)  # ty: ignore[invalid-argument-type]  # ruff: ignore[private-member-access]
+    listener._on_message(None, fake_method_bytes, None, fake_body)  # ty: ignore[invalid-argument-type]  # ruff: ignore[SLF001]
     assert received_data[0] == ({"foo": "bar"}, "bytes.key")
 
     # Test routing_key as None
     fake_method_none = MagicMock(routing_key=None)
-    listener._on_message(None, fake_method_none, None, fake_body)  # ty: ignore[invalid-argument-type]  # ruff: ignore[private-member-access]
+    listener._on_message(None, fake_method_none, None, fake_body)  # ty: ignore[invalid-argument-type]  # ruff: ignore[SLF001]
     assert received_data[1] == ({"foo": "bar"}, "")
 
 

--- a/tests/test_approve_helpers.py
+++ b/tests/test_approve_helpers.py
@@ -110,7 +110,7 @@ def test_reject_calls_update_incident_reason(mocker: MockerFixture) -> None:
     approver.dry = False
     mock_update = mocker.patch("openqabot.approver.update_incident_reason")
     sub = SubReq(1, 2)
-    assert approver._reject(sub, "Reason %s") is False  # ruff: ignore[private-member-access]
+    assert approver._reject(sub, "Reason %s") is False  # ruff: ignore[SLF001]
     mock_update.assert_called_once_with(1, "Reason SUSE:Maintenance:1:2")
 
 
@@ -119,7 +119,7 @@ def test_reject_dry_run_skips_update_incident_reason(mocker: MockerFixture) -> N
     approver.dry = True
     mock_update = mocker.patch("openqabot.approver.update_incident_reason")
     sub = SubReq(1, 2)
-    assert approver._reject(sub, "Reason %s") is False  # ruff: ignore[private-member-access]
+    assert approver._reject(sub, "Reason %s") is False  # ruff: ignore[SLF001]
     mock_update.assert_not_called()
 
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -95,7 +95,7 @@ def test_sub_approve(
     tmp_path: Path,
     extra_args: list[str],
     env: dict[str, str],
-    expected_comment: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
+    expected_comment: bool,  # ruff: ignore[FBT001]
 ) -> None:
     approve = mocker.patch("openqabot.args.Approver")
     approve.return_value.return_value = 0

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -829,7 +829,7 @@ def test_summarize_message_detailed_comments(
     mock_args: Namespace,
     detailed_comment_mocks: dict[str, MagicMock],
     mocker: MockerFixture,
-    enabled: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
+    enabled: bool,  # ruff: ignore[FBT001]
     allow_devel: str | None,
     jobs: list[dict],
     group_info: dict | None,

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin, urlparse
 
 import pytest
 import responses
-from lxml import etree  # ruff: ignore[typing-only-third-party-import]  # ty: ignore[unresolved-import]
+from lxml import etree  # ruff: ignore[TC002]  # ty: ignore[unresolved-import]
 from responses import GET, matchers
 
 from openqabot.config import settings
@@ -42,7 +42,7 @@ def fake_gitea_api() -> None:
     pulls_url = urljoin(host, "api/v1/repos/products/SLFO/pulls")
     issues_url = urljoin(host, "api/v1/repos/products/SLFO/issues")
 
-    patchinfo_path = "products/SLFO/raw/commit/2cf58b3a9c32d139470a5f32d5aa64efbd0fa90dda0144b09421709252fcb0ea/patchinfo.23193048203482931/_patchinfo"  # ruff: ignore[line-too-long]
+    patchinfo_path = "products/SLFO/raw/commit/2cf58b3a9c32d139470a5f32d5aa64efbd0fa90dda0144b09421709252fcb0ea/patchinfo.23193048203482931/_patchinfo"  # ruff: ignore[E501]
     patchinfo_data = Path("tests/fixtures/responses/patch-info.xml").read_bytes()
     responses.add(GET, pulls_url + "?state=open", json=read_json_file("pulls"))
     responses.add(GET, re.compile(pulls_url + r"\?state=open&page=.*"), json=[])
@@ -338,17 +338,17 @@ def test_gitea_sync_amqp(args: Namespace, mocker: MockerFixture, caplog: pytest.
         "pull_request": {"id": 42, "number": 123, "base": {"repo": {"full_name": "products/SLFO"}}},
     }
     # check successful code path
-    sync._on_amqp_message(message, "suse.src.*.pull_request.opened")  # ruff: ignore[private-member-access]
+    sync._on_amqp_message(message, "suse.src.*.pull_request.opened")  # ruff: ignore[SLF001]
     mock_update.assert_called_once_with([mock_subm], params={"type": "git"}, retry=args.retry)
     mock_update.reset_mock()
 
     # check dry run
     args.dry = True
     sync = GiteaSync(args)
-    sync._on_amqp_message(message, "suse.src.*.pull_request.opened")  # ruff: ignore[private-member-access]
+    sync._on_amqp_message(message, "suse.src.*.pull_request.opened")  # ruff: ignore[SLF001]
 
     # check wrong PR does nothing
-    sync._on_amqp_message(  # ruff: ignore[private-member-access]
+    sync._on_amqp_message(  # ruff: ignore[SLF001]
         {"action": "opened", "pull_request": {"id": 42, "number": 123, "base": {"repo": {"full_name": "wrong/repo"}}}},
         "suse.src.*.pull_request.opened",
     )

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -243,30 +243,36 @@ def test_load_prs_for_project(trigger: GiteaTrigger, mocker: MockerFixture, mock
     mocker.patch(
         "openqabot.giteatrigger.get_open_prs",
         return_value=[
-            PullRequest.from_json({
-                "number": 1,
-                "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
-                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
-                "html_url": "u",
-                "head": {"sha": "xyz"},
-                "state": "open",
-            }),
-            PullRequest.from_json({
-                "number": 2,
-                "labels": [{"name": "wrong-label"}, {"name": "qalabel1"}],
-                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
-                "html_url": "u",
-                "head": {"sha": "xyz"},
-                "state": "open",
-            }),
-            PullRequest.from_json({
-                "number": 3,
-                "labels": [{"name": "needs-testing"}],
-                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
-                "html_url": "u",
-                "head": {"sha": "xyz"},
-                "state": "open",
-            }),
+            PullRequest.from_json(
+                {
+                    "number": 1,
+                    "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
+                    "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
+                    "html_url": "u",
+                    "head": {"sha": "xyz"},
+                    "state": "open",
+                }
+            ),
+            PullRequest.from_json(
+                {
+                    "number": 2,
+                    "labels": [{"name": "wrong-label"}, {"name": "qalabel1"}],
+                    "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
+                    "html_url": "u",
+                    "head": {"sha": "xyz"},
+                    "state": "open",
+                }
+            ),
+            PullRequest.from_json(
+                {
+                    "number": 3,
+                    "labels": [{"name": "needs-testing"}],
+                    "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
+                    "html_url": "u",
+                    "head": {"sha": "xyz"},
+                    "state": "open",
+                }
+            ),
         ],
     )
 
@@ -389,13 +395,15 @@ def test_get_prs_by_label_specific_number(
     mock_get_pr = mocker.patch(
         "openqabot.giteatrigger.get_open_prs",
         return_value=[
-            PullRequest.from_json({
-                "number": 1337,
-                "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
-                "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
-                "html_url": "u",
-                "head": {"sha": "xyz"},
-            })
+            PullRequest.from_json(
+                {
+                    "number": 1337,
+                    "labels": [{"name": "needs-testing"}, {"name": "qalabel1"}],
+                    "base": {"repo": {"name": "r", "full_name": "owner/r"}, "label": "l"},
+                    "html_url": "u",
+                    "head": {"sha": "xyz"},
+                }
+            )
         ],
     )
 
@@ -560,7 +568,7 @@ def test_should_skip_pr(trigger: GiteaTrigger, mock_trigger_config: TriggerConfi
     pr_ok = MagicMock(spec=PullRequest)
     pr_ok.branch = "slfo-main"
     pr_ok.has_all_labels.return_value = True
-    assert trigger._should_skip_pr(pr_ok, mock_trigger_config) is False  # ruff: ignore[private-member-access]
+    assert trigger._should_skip_pr(pr_ok, mock_trigger_config) is False  # ruff: ignore[SLF001]
 
     # Scenario 2: PR is missing required labels
     pr_skip = MagicMock(spec=PullRequest)
@@ -568,7 +576,7 @@ def test_should_skip_pr(trigger: GiteaTrigger, mock_trigger_config: TriggerConfi
     pr_skip.has_all_labels.return_value = False
     pr_skip.number = 123
     pr_skip.labels = {"label1"}
-    assert trigger._should_skip_pr(pr_skip, mock_trigger_config) is True  # ruff: ignore[private-member-access]
+    assert trigger._should_skip_pr(pr_skip, mock_trigger_config) is True  # ruff: ignore[SLF001]
 
     # Scenario 3: opensuse (o3) mode
     trigger.is_maintenance = True
@@ -577,13 +585,13 @@ def test_should_skip_pr(trigger: GiteaTrigger, mock_trigger_config: TriggerConfi
     pr_o3.branch = "master"
     pr_o3.number = 123
     mocker.patch.object(trigger, "is_build_finished", return_value=True)
-    assert trigger._should_skip_pr(pr_o3, mock_trigger_config) is False  # ruff: ignore[private-member-access]
+    assert trigger._should_skip_pr(pr_o3, mock_trigger_config) is False  # ruff: ignore[SLF001]
 
     mocker.patch.object(trigger, "is_build_finished", return_value=False)
-    assert trigger._should_skip_pr(pr_o3, mock_trigger_config) is True  # ruff: ignore[private-member-access]
+    assert trigger._should_skip_pr(pr_o3, mock_trigger_config) is True  # ruff: ignore[SLF001]
 
     pr_o3.branch = "wrong-branch"
-    assert trigger._should_skip_pr(pr_o3, mock_trigger_config) is True  # ruff: ignore[private-member-access]
+    assert trigger._should_skip_pr(pr_o3, mock_trigger_config) is True  # ruff: ignore[SLF001]
 
 
 def test_check_pullrequest_opensuse_success(
@@ -766,7 +774,7 @@ def test_build_openqa_settings_no_iso_name(trigger: GiteaTrigger, mock_trigger_c
     matched_iso.arch = "x86_64"
     matched_iso.build = "PR-123"
 
-    settings = trigger._build_openqa_settings(mock_pr, mock_trigger_config, matched_iso, "http://repo", None)  # ruff: ignore[private-member-access]
+    settings = trigger._build_openqa_settings(mock_pr, mock_trigger_config, matched_iso, "http://repo", None)  # ruff: ignore[SLF001]
     assert "ISO_1_URL" not in settings
     assert "HDD_1_URL" not in settings
 

--- a/tests/test_incrementapprover_helpers.py
+++ b/tests/test_incrementapprover_helpers.py
@@ -123,7 +123,7 @@ def test_filter_results(caplog: pytest.LogCaptureFixture, mocker: MockerFixture)
         }
     ]
     expected = [{"passed": {"j1": {"job_ids": [1], "group_id": 1}}}]
-    assert approver._filter_results(results) == expected  # ruff: ignore[private-member-access]
+    assert approver._filter_results(results) == expected  # ruff: ignore[SLF001]
 
 
 @responses.activate

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -520,7 +520,7 @@ def test_approval_if_failing_jobs_are_in_development_group(
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
     fake_openqa_url_job_stat: str,
-    schedule: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
+    schedule: bool,  # ruff: ignore[FBT001]
 ) -> None:
     responses.add(responses.GET, fake_openqa_url_job_stat, json={"done": {"failed": {"job_ids": [123], "group_id": 9}}})
     increment_approver = prepare_approver(caplog, schedule=schedule)

--- a/tests/test_loader_gitea_submissions.py
+++ b/tests/test_loader_gitea_submissions.py
@@ -172,14 +172,14 @@ def test_add_reviews_stale_reapproval(
 def test_update_scminfo_coverage(caplog: pytest.LogCaptureFixture) -> None:
     submission = {"number": 123}
     res = etree.fromstring("<root><scminfo></scminfo><scminfo>new</scminfo><scminfo>other</scminfo></root>")
-    gitea._update_scminfo(submission, res, "project", "")  # ruff: ignore[private-member-access]
+    gitea._update_scminfo(submission, res, "project", "")  # ruff: ignore[SLF001]
     assert submission["scminfo"] == "new"
     assert "Inconsistent SCM info" in caplog.text
 
     caplog.clear()
     submission = {"number": 123, "scminfo_prod": "old"}
     res = etree.fromstring("<root><scminfo>new</scminfo></root>")
-    gitea._update_scminfo(submission, res, "project", "prod")  # ruff: ignore[private-member-access]
+    gitea._update_scminfo(submission, res, "project", "prod")  # ruff: ignore[SLF001]
     assert submission["scminfo_prod"] == "old"
     assert "Inconsistent SCM info" in caplog.text
 

--- a/tests/test_loader_incrementconfig.py
+++ b/tests/test_loader_incrementconfig.py
@@ -33,7 +33,7 @@ def test_config_parsing(caplog: pytest.LogCaptureFixture) -> None:
     assert configs[1].distri == "bar"
     assert configs[1].version == "42"
     assert configs[1].flavor == "Test-Increments"
-    assert configs[1].project_base == ""  # ruff: ignore[compare-to-empty-string]
+    assert configs[1].project_base == ""
     assert configs[1].build_project() == "ToTest"
     assert configs[1].diff_project_url() == "http://download.suse.de/ibs/none"
 
@@ -108,7 +108,7 @@ def test_concat_project() -> None:
     )
     assert config.build_project() == "BASE"
     config.project_base = ""
-    assert config.build_project() == ""  # ruff: ignore[compare-to-empty-string]
+    assert config.build_project() == ""
     config.project_base = "BASE"
     config.build_project_suffix = "SUFFIX"
     assert config.build_project() == "BASE:SUFFIX"

--- a/tests/test_openqabot.py
+++ b/tests/test_openqabot.py
@@ -157,7 +157,7 @@ def mock_openqa_exception(mocker: MockerFixture) -> Any:
         def __init__(self, *_args: Any, **_kwargs: Any) -> None:
             pass
 
-        def post_job(self, *_args: Any, **_kwargs: Any) -> NoReturn:  # ruff: ignore[no-self-use]
+        def post_job(self, *_args: Any, **_kwargs: Any) -> NoReturn:
             raise PostOpenQAError
 
     return mocker.patch("openqabot.openqabot.OpenQAInterface", FakeClient)

--- a/tests/test_submissions_call.py
+++ b/tests/test_submissions_call.py
@@ -319,8 +319,8 @@ class LimitArchsSubmission(MockSubmission):
 
     def compute_revisions_for_product_repo(
         self,
-        product_repo: list[str] | str | None,  # ruff: ignore[unused-method-argument]
-        product_version: str | None,  # ruff: ignore[unused-method-argument]
+        product_repo: list[str] | str | None,
+        product_version: str | None,
         limit_archs: set[str] | None = None,
     ) -> bool:
         """Mock compute_revisions_for_product_repo."""


### PR DESCRIPTION
Migrate the Ruff configuration and inline suppressions from name-based selectors to standard rule codes.

Selecting rules by name now requires Ruff's experimental preview mode (`preview = true`), which is disabled to ensure linter stability in production.

Changes:
 - Disabled the experimental `preview`    mode in `pyproject.toml`.
 - Converted all name-based linter   selectors and ignores in `pyproject.toml`   to standard rule codes (e.g., `T10`,
   `D203`, `PLC1802`, `D213`, `COM812`).
 - Added `ARG` to `per-file-ignores`   for `tests/*` to handle mock/fixture   signature requirements.
 - Programmatically migrated all inline   `ruff: ignore` comments in Python   files to standard rule codes.
 - Removed preview-only and inactive   rules (such as `PLR0904`, `DOC201`,   `DOC501`, and `pydoclint` selectors)  and cleaned up redundant inline ignores.
 - Reformatted modified files with  `ruff format`.