### PR TITLE
Revert "chore(deps): deduplicate dependabot config using YAML anchors"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,29 +2,39 @@
 version: 2
 updates:
   - package-ecosystem: "uv"
-    <<: &common
-      directory: "/"
-      schedule:
-        interval: "weekly"
-        day: "monday"
-      cooldown:
-        default-days: 7
-      open-pull-requests-limit: 5
-      labels:
-        - "waiting"
-        - "dependencies"
-      commit-message:
-        prefix: "chore"
-        include: scope
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - "waiting"
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: scope
     groups:
       all-dependencies:
         patterns:
           - "*"
         update-types:
           - "major"
-
   - package-ecosystem: "github-actions"
-    <<: *common
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    labels:
+      - "waiting"
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: scope
     groups:
       all-actions:
         patterns:


### PR DESCRIPTION
This reverts commit 88db4e73a4a10c90f797a6d4682812092e572f16 because of https://github.com/dependabot/dependabot-core/issues/1582