### PR TITLE
feat(config): support strict metadata validation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,12 @@ updates information about submissions and related openQA tests.
     │                                                  for all API calls           │
     │                                                  [env var: QEM_BOT_INSECURE] │
     │                                                  [default: no-insecure]      │
+    │ --strict-metadata                                Raise an error on           │
+    │                                                  unrecognized metadata keys  │
+    │                                                  instead of ignoring them    │
+    │                                                  with a warning              │
+    │                                                  [env var:                   │
+    │                                                  QEM_BOT_STRICT_METADATA]    │
     │ --token            -t                   TEXT     Token for qem dashboard api │
     │                                                  [env var: QEM_BOT_TOKEN]    │
     │ --gitea-token      -g                   TEXT     Token for Gitea api         │

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -202,6 +202,14 @@ def main(  # ruff: ignore[too-many-arguments]
             help="Disable TLS verification for all API calls",
         ),
     ] = False,
+    strict_metadata: Annotated[
+        bool,
+        typer.Option(
+            "--strict-metadata",
+            envvar="QEM_BOT_STRICT_METADATA",
+            help="Raise an error on unrecognized metadata keys instead of ignoring them with a warning",
+        ),
+    ] = False,
     token: Annotated[
         str | None,
         typer.Option("-t", "--token", envvar="QEM_BOT_TOKEN", help="Token for qem dashboard api"),
@@ -269,6 +277,7 @@ def main(  # ruff: ignore[too-many-arguments]
             "gitea_token": gitea_token,
             "singlearch": singlearch,
             "retry": retry,
+            "strict_metadata": strict_metadata,
         },
     )
 
@@ -293,6 +302,7 @@ def main(  # ruff: ignore[too-many-arguments]
         gitea_token=settings.gitea_token,
         singlearch=settings.singlearch,
         retry=settings.retry,
+        strict_metadata=settings.strict_metadata,
     )
 
 

--- a/openqabot/config.py
+++ b/openqabot/config.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
     app_backoff_factor: int = Field(default=60, alias="APP_BACKOFF_FACTOR")
     app_same_error_limit: int = Field(default=2, alias="APP_SAME_ERROR_LIMIT")
     app_error_similarity: int = Field(default=90, alias="APP_ERROR_SIMILARITY")
+    strict_metadata: bool = Field(default=False, alias="QEM_BOT_STRICT_METADATA")
     # Global options
     configs: Path = Field(default=Path("/etc/openqabot"), alias="QEM_BOT_CONFIGS")
     dry: bool = Field(default=False, alias="QEM_BOT_DRY")

--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -54,9 +54,15 @@ class Aggregate(BaseConf):
         self.excluded_packages = config.config.get("excluded_packages")
         self.test_issues = self.normalize_repos(config.config)
 
-    def _warn_unknown_keys(self, config: dict[str, Any]) -> None:
+    def _warn_unknown_keys(self, config_dict: dict[str, Any]) -> None:
         """Warn about unrecognized aggregate keys to catch typos like a misspelled blocklist."""
-        for key in set(config) - VALID_AGGREGATE_KEYS:
+        unknown_keys = set(config_dict) - VALID_AGGREGATE_KEYS
+        if not unknown_keys:
+            return
+        if config.settings.strict_metadata:
+            msg = f"Aggregate (product {self.product}): Unrecognized metadata keys {', '.join(sorted(unknown_keys))}"
+            raise ValueError(msg)
+        for key in unknown_keys:
             log.warning("Aggregate (product %s): Ignoring unknown metadata key %r", self.product, key)
 
     @staticmethod

--- a/openqabot/types/submissions.py
+++ b/openqabot/types/submissions.py
@@ -70,10 +70,19 @@ class Submissions(BaseConf):
         """Return a string representation of the Submissions."""
         return f"<Submissions product: {self.product}>"
 
-    def _warn_unknown_flavor_keys(self, config: dict[str, Any]) -> None:
+    def _warn_unknown_flavor_keys(self, config_dict: dict[str, Any]) -> None:
         """Warn about unrecognized per-flavor keys to catch typos like a misspelled blocklist."""
-        for flavor, data in config.items():
-            for key in set(data) - VALID_FLAVOR_KEYS:
+        for flavor, data in config_dict.items():
+            unknown_keys = set(data) - VALID_FLAVOR_KEYS
+            if not unknown_keys:
+                continue
+            if settings.strict_metadata:
+                msg = (
+                    f"Flavor {flavor} (product {self.product}): "
+                    f"Unrecognized metadata keys {', '.join(sorted(unknown_keys))}"
+                )
+                raise ValueError(msg)
+            for key in unknown_keys:
                 log.warning("Flavor %s (product %s): Ignoring unknown metadata key %r", flavor, self.product, key)
 
     @staticmethod

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -255,6 +255,13 @@ def test_warn_unknown_aggregate_keys(
         assert any(repr(key) in msg for msg in warned)
 
 
+def test_strict_unknown_aggregate_keys(aggregate_factory: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown aggregate keys raise a ValueError when strict_metadata is enabled."""
+    monkeypatch.setattr("openqabot.config.settings.strict_metadata", True)
+    with pytest.raises(ValueError, match=r"Unrecognized metadata keys .*bogus.*"):
+        aggregate_factory("product", config={"FLAVOR": "None", "archs": [], "test_issues": {}, "bogus": 1})
+
+
 @pytest.mark.parametrize(
     ("extra_config", "contains", "expected_kept"),
     [

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -98,3 +98,10 @@ def test_warn_unknown_flavor_keys(
     assert len(warned) == len(expected_warnings)
     for key in expected_warnings:
         assert any(repr(key) in msg for msg in warned)
+
+
+def test_strict_unknown_flavor_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown flavor keys raise a ValueError when strict_metadata is enabled."""
+    monkeypatch.setattr("openqabot.config.settings.strict_metadata", True)
+    with pytest.raises(ValueError, match=r"Unrecognized metadata keys .*bogus.*"):
+        _make_submissions({"AAA": {"archs": ["x86_64"], "bogus": 1}})


### PR DESCRIPTION
Motivation: Metadata keys are validated with warnings to avoid breaking older
configs, but unrecognized keys are easy to ignore. A strict mode allows CI to
fail fatally and catch typos early.

Design Choices: Add a `--strict-metadata` CLI flag and a `strict_metadata`
setting. When enabled, raise a `ValueError` in Aggregate and Submissions
instead of logging warnings.

Benefits: Config authors and CI pipelines can opt-in to strict validation,
preventing misspelled metadata keys from silently ignoring blocklists.

Related issue: https://progress.opensuse.org/issues/201987