### PR TITLE
feat: omit PR-suffix from VERSION and use SUBMISSION_ID for Gitea builds

### DIFF
--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -177,6 +177,7 @@ class GiteaTrigger:
             "ARCH": matched_iso.arch,
             "FLAVOR": trigger_config.flavor,
             "_GITEA_PR": str(pullrequest.number),
+            "SUBMISSION_ID": f"git:{pullrequest.number}",
             "GITEA_SHA": pullrequest.commit_sha,
             "GITEA_PR_URL": pullrequest.url,
             "GITEA_REPO": pullrequest.project,

--- a/openqabot/types/isomatch.py
+++ b/openqabot/types/isomatch.py
@@ -28,6 +28,5 @@ class IsoMatch:
         version = iso_match.group("version")
         arch = iso_match.group("arch")
         build_num = iso_match.group("build")
-        version_str = f"{version}:PR-{pr_number}"
         build_str = f"PR-{pr_number}-{build_num}:{product}-{version}"
-        return cls(product, version_str, build_str, arch)
+        return cls(product, version, build_str, arch)

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -103,7 +103,8 @@ def test_check_pullrequest_triggers_job(
     args, _ = cast("MagicMock", trigger.openqa.post_iso).call_args
     settings = args[0]
     assert settings["FLAVOR"] == "Online-Staging"
-    assert settings["VERSION"] == "15.5:PR-123"
+    assert settings["VERSION"] == "15.5"
+    assert settings["SUBMISSION_ID"] == "git:123"
     assert settings["BUILD"] == "PR-123-1.1:SLES-15.5"
     assert settings["ISO_1_URL"] == "http://fake.url//SLES-15.5-Online-x86_64-Build1.1.install.iso"
     assert settings["ISO_1"] == "SLES-15.5-Online-x86_64-Build1.1.install.iso"
@@ -162,7 +163,8 @@ def test_check_pullrequest_with_image_regex(trigger: GiteaTrigger, mocker: Mocke
 
     # Verify common parameters are still set
     assert settings["FLAVOR"] == "Minimal-VM-Cloud-Staging-dev"
-    assert settings["VERSION"] == "16.1:PR-456"
+    assert settings["VERSION"] == "16.1"
+    assert settings["SUBMISSION_ID"] == "git:456"
     assert settings["BUILD"] == "PR-456-2.1:SLES-16.1"
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -86,7 +86,7 @@ def test_isomatch_from_regex_match() -> None:
     assert match is not None
     isomatch = IsoMatch.from_regex_match(match, 123)
     assert isomatch.product == "SLES"
-    assert isomatch.version == "15.5:PR-123"
+    assert isomatch.version == "15.5"
     assert isomatch.arch == "x86_64"
     assert isomatch.build == "PR-123-1.1:SLES-15.5"
 


### PR DESCRIPTION
Motivation
Staging builds for Gitea pull requests had the pull request number appended
to the openQA VERSION string, which polluted the product version history.

Design Choices
Remove the :PR-suffix from Gitea-triggered ISO matches' version string.
Always set the SUBMISSION_ID openQA parameter to the Gitea pull request ID.

Benefits
This simplifies product version management in openQA and leverages the
SUBMISSION_ID mechanism to isolate the job history of different pull requests.

Related issue: https://progress.opensuse.org/issues/200952