### PR TITLE
fix: handle PRs lacking a formal review from the configured CI bot

### DIFF
--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -320,8 +320,12 @@ class GiteaTrigger:
             log.warning("No events found for %s", pr_name)
             return False
         bot_events = pr_events.get(cast("str", config.settings.git_review_bot_user))
-        if not bot_events:
-            log.warning("User %s has no events on %s", config.settings.git_review_bot_user, pr_name)
+        if not bot_events or "review" not in bot_events:
+            log.warning(
+                "%s has no review event on %s, assuming build is not finished",
+                config.settings.git_review_bot_user,
+                pr_name,
+            )
             return False
 
         review = cast(

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -710,6 +710,18 @@ def test_is_build_finished_no_bot_comment(
     assert trigger.is_build_finished(mock_pr, mock_trigger_config) is False
 
 
+def test_is_build_finished_bot_comment_no_review(
+    trigger: GiteaTrigger, mocker: MockerFixture, mock_trigger_config: TriggerConfig
+) -> None:
+    """Tests is_build_finished when bot user commented but has no review event."""
+    mocker.patch(
+        "openqabot.loader.gitea.get_events_by_timeline",
+        return_value={config.settings.git_review_bot_user: {"comment": {"id": 123}}},
+    )
+    mock_pr = MagicMock(number=123)
+    assert trigger.is_build_finished(mock_pr, mock_trigger_config) is False
+
+
 def test_is_build_finished_states(
     trigger: GiteaTrigger, mocker: MockerFixture, mock_trigger_config: TriggerConfig
 ) -> None:


### PR DESCRIPTION
Motivation:
There are valid cases when the configured CI/review bot user (\`git_review_bot_user\`) leaves a regular comment on a PR instead of a formal review event.

Benefits:
This makes the build status check more robust by correctly ignoring PRs where the CI bot has interacted but not yet completed a formal review.