### PR TITLE
fix: Reduce log volume on repodiff for huge package lists

### DIFF
--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -33,6 +33,7 @@ name_tag = ns + "name"
 version_tag = ns + "version"
 arch_tag = ns + "arch"
 primary_re = re.compile(r".*-primary.xml(?:.(gz|zst))?$")
+MAX_PKG_LIST_LENGTH = 200
 
 
 class Package(NamedTuple):
@@ -251,7 +252,11 @@ class RepoDiff:
             diff_by_arch[arch] = diff
             if diff:
                 pkg_list = ", ".join(f"{p.name}-{p.version}-{p.rel}" for p in sorted(diff, key=lambda x: x.name))
-                log.info("Repo diff for arch %s: %d new packages: %s", arch, len(diff), pkg_list)
+                if len(pkg_list) > MAX_PKG_LIST_LENGTH:
+                    pkg_list = pkg_list[: MAX_PKG_LIST_LENGTH - 1] + "…"
+                msg = f"Repo diff for arch {arch}: {len(diff)} new packages: {pkg_list} "
+                msg += f"(run `qem-bot repo-diff --repo-a {repo_a} --repo-b {repo_b}` for full diff)"
+                log.debug(msg)
         return (diff_by_arch, count)
 
     def compute_diff(self, repo_a: str, repo_b: str) -> tuple[defaultdict[str, set[Package]], int]:

--- a/tests/test_repodiff.py
+++ b/tests/test_repodiff.py
@@ -3,6 +3,7 @@
 """Test RepoDiff."""
 
 import json
+import logging
 from argparse import Namespace
 from collections import defaultdict
 
@@ -332,3 +333,20 @@ def test_load_packages_stream_exception(
     res = diff.load_packages("project")
     assert res == {}
     assert "Failed to parse repo data stream" in caplog.text
+
+
+def test_compute_diff_for_packages_long_list(caplog: pytest.LogCaptureFixture) -> None:
+    """Test compute_diff_for_packages with a long list to trigger truncation."""
+    packages_a = defaultdict(set)
+    packages_b = defaultdict(set)
+    for i in range(25):
+        # f"{p.name}-{p.version}-{p.rel}" -> pkg-X-1.0-1 which is 10+ chars.
+        # 25 packages will be > 200 chars.
+        packages_b["x86_64"].add(Package(f"pkg-{i:03d}", "0", "1.0", "1", "x86_64"))
+
+    caplog.set_level(logging.DEBUG, logger="bot.repo_diff")
+    _res, count = RepoDiff.compute_diff_for_packages("repo_a", packages_a, "repo_b", packages_b)
+
+    assert count == 25
+    assert "pkg-" in caplog.text
+    assert "…" in caplog.text


### PR DESCRIPTION
Motivation
The repo-diff log output in bot-ng gets huge and unreadable when there
are hundreds or thousands of packages differences in repos, as seen in recent
failures.

Design Choices
We now reduce the logging level from info to debug for this message
to avoid cluttering standard CI logs. Additionally, we enforce a maximum string
length of 200 characters for the package list. If exceeded, it gets truncated
and an ellipsis is appended. We also appended instructions for users on
how to manually run a complete diff comparison.

Benefits
Better readability and lower log clutter in CI pipelines without losing
the ability to examine exact repository differences locally.