### PR TITLE
fix(approver): honor max_workers in approval executors

### DIFF
--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -156,7 +156,7 @@ class Approver:
         )
 
         overall_result = True
-        with ThreadPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
             approvable_flags = list(executor.map(self.approvable, subreqs))
 
         submissions_to_approve = [sub for sub, ok in zip(subreqs, approvable_flags, strict=True) if ok]
@@ -170,7 +170,7 @@ class Approver:
                 log.info("Dry run: Would approve %s", ms2str(sub))
         else:
             osc.conf.get_config(override_apiurl=config.settings.obs_url)
-            with ThreadPoolExecutor() as executor:
+            with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
                 for result in executor.map(self.approve, submissions_to_approve):
                     overall_result &= result
 


### PR DESCRIPTION
Motivation:
The two ThreadPoolExecutor instances in Approver.__call__ ran unbounded,
diverging from the repo-wide convention and risking OBS/Gitea rate
limits when many submissions are processed.

Design Choices:
Pass max_workers=config.settings.max_workers to both executors, matching
aggrsync, subsyncres, incrementapprover, openqabot and giteatrigger.

Benefits:
Operators can throttle concurrency via QEM_BOT_MAX_WORKERS, preventing
request floods against remote services.