### PR TITLE
fix: include OBS revisions and PC images in aggregate repohash

### DIFF
--- a/openqabot/types/aggregate.py
+++ b/openqabot/types/aggregate.py
@@ -177,6 +177,7 @@ class Aggregate(BaseConf):
         arch: str,
         data: PostData,
         ci_url: str | None,
+        settings_data: dict[str, Any],
     ) -> dict[str, Any] | None:
         """Create the full post data for the dashboard."""
         openqa_data: dict[str, Any] = {"REPOHASH": data.repohash, "BUILD": data.build}
@@ -187,10 +188,6 @@ class Aggregate(BaseConf):
         }
         if ci_url:
             full_post["openqa"]["__CI_JOB_URL"] = ci_url
-
-        settings_data = apply_public_cloud_settings(self.settings.copy())
-        if settings_data is None:
-            return None
 
         full_post["openqa"].update(settings_data)
         full_post["openqa"]["FLAVOR"] = self.flavor
@@ -214,6 +211,26 @@ class Aggregate(BaseConf):
         self._finalize_post(full_post, arch)
         return full_post
 
+    @staticmethod
+    def _compute_repohash(
+        test_submissions: defaultdict[str, list[Submission]],
+        settings_data: dict[str, Any],
+        issues_arch: str,
+        test_issues: dict[str, ProdVer],
+    ) -> str:
+        hashes = {
+            f"{sub.id}:{sub.revisions_with_fallback(issues_arch, test_issues[issue].version)}"
+            for issue, subs in test_submissions.items()
+            if issue != ALL_ISSUES_KEY
+            for sub in subs
+        } | {
+            str(settings_data[key])
+            for key in ("PUBLIC_CLOUD_IMAGE_ID", "PUBLIC_CLOUD_TOOLS_IMAGE_BASE")
+            if settings_data.get(key)
+        }
+
+        return merge_repohash(sorted(hashes))
+
     def process_arch(
         self,
         arch: str,
@@ -228,9 +245,11 @@ class Aggregate(BaseConf):
 
         test_submissions, test_repos = self.get_test_submissions_and_repos(valid_submissions, issues_arch)
 
-        repohash = merge_repohash(
-            sorted({str(sub.id) for sub in chain.from_iterable(test_submissions.values())}),
-        )
+        settings_data = apply_public_cloud_settings(self.settings.copy())
+        if settings_data is None:
+            return None
+
+        repohash = self._compute_repohash(test_submissions, settings_data, issues_arch, self.test_issues)
 
         try:
             old_jobs = dashboard.get_json(
@@ -273,6 +292,7 @@ class Aggregate(BaseConf):
             arch,
             PostData(test_submissions, test_repos, repohash, build),
             ci_url,
+            settings_data,
         )
 
     def __call__(
@@ -284,6 +304,8 @@ class Aggregate(BaseConf):
     ) -> list[dict[str, Any]]:
         """Process all architectures and return a list of posts for the dashboard."""
         valid_submissions = self.filter_submissions(submissions)
+        for s in valid_submissions:
+            s.compute_revisions_for_product_repo(None, None)
 
         results = [
             self.process_arch(arch, valid_submissions, ci_url, ignore_onetime=ignore_onetime) for arch in self.archs

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -18,7 +18,7 @@ from openqabot.errors import SameBuildExistsError
 from openqabot.types.aggregate import Aggregate, PostData
 from openqabot.types.baseconf import JobConfig
 from openqabot.types.submission import Submission
-from openqabot.types.types import Repos
+from openqabot.types.types import ProdVer, Repos
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock
@@ -44,13 +44,13 @@ def aggregate_factory() -> Any:
 @pytest.fixture
 def submission_mock(mocker: MockerFixture) -> Any:
     def _func(
+        sub_id: int = 123,
         product: str = "P",
         version: str = "V",
         arch: str = "A",
         *,
         embargoed: bool = False,
         staging: bool = False,
-        sub_id: int = 123,
     ) -> MagicMock:
         sub = mocker.MagicMock(spec=Submission)
         sub.id = sub_id
@@ -60,6 +60,7 @@ def submission_mock(mocker: MockerFixture) -> Any:
         sub.embargoed = embargoed
         sub.type = DEFAULT_SUBMISSION_TYPE
         sub.priority = None
+        sub.revisions_with_fallback.return_value = "rev_fallback"
         sub.__str__.return_value = str(sub.id)
         return sub
 
@@ -434,11 +435,52 @@ def test_aggregate_duplicate_submissions(aggregate_factory: Any, submission_mock
     test_repos["REPOS"] = ["repo"]
 
     post_data = PostData(test_submissions, test_repos, "hash", "build")
-    res = agg.create_full_post("x86_64", post_data, None)
+    res = agg.create_full_post("x86_64", post_data, None, {})
 
     assert res is not None
     assert len(res["qem"]["incidents"]) == 1
     assert res["qem"]["incidents"][0] == 123
+
+
+@pytest.mark.parametrize(
+    ("pc_image_id", "rev2_value", "is_different_from_baseline"),
+    [
+        pytest.param("ami-123", "rev2", False, id="identical_inputs_yield_identical_hash"),
+        pytest.param("ami-456", "rev2", True, id="changed_public_cloud_image_id_yields_different_hash"),
+        pytest.param("ami-123", "rev3", True, id="changed_submission_revision_yields_different_hash"),
+    ],
+)
+def test_aggregate_compute_repohash_changes_on_input_modification(
+    submission_mock: Any,
+    pc_image_id: str,
+    rev2_value: str,
+    *,
+    is_different_from_baseline: bool,
+) -> None:
+    sub1 = submission_mock(1)
+    sub1.revisions_with_fallback.return_value = "rev1"
+    sub2_baseline = submission_mock(2)
+    sub2_baseline.revisions_with_fallback.return_value = "rev2"
+    baseline_issues = {"issue1": ProdVer("product", "12"), "issue2": ProdVer("product", "12")}
+
+    baseline_hash = Aggregate._compute_repohash(  # noqa: SLF001
+        defaultdict(list, {"issue1": [sub1], "issue2": [sub2_baseline]}),
+        {"PUBLIC_CLOUD_IMAGE_ID": "ami-123"},
+        "x86_64",
+        baseline_issues,
+    )
+
+    sub2_test = submission_mock(2)
+    sub2_test.revisions_with_fallback.return_value = rev2_value
+
+    test_hash = Aggregate._compute_repohash(  # noqa: SLF001
+        defaultdict(list, {"issue1": [sub1], "issue2": [sub2_test]}),
+        {"PUBLIC_CLOUD_IMAGE_ID": pc_image_id},
+        "x86_64",
+        baseline_issues,
+    )
+
+    assert (baseline_hash != test_hash) is is_different_from_baseline
 
 
 def test_aggregate_url_format(aggregate_factory: Any, mocker: MockerFixture) -> None:
@@ -470,7 +512,7 @@ def test_aggregate_url_format(aggregate_factory: Any, mocker: MockerFixture) -> 
     test_repos["REPOS"] = [repo_url]
     post_data = PostData(test_submissions, test_repos, "hash", "build")
 
-    res = agg.create_full_post("x86_64", post_data, None)
+    res = agg.create_full_post("x86_64", post_data, None, {})
 
     assert res is not None
     dashboard_url = res["openqa"]["__DASHBOARD_INCIDENTS_URL"]


### PR DESCRIPTION
Motivation:
PR 607 decoupled the skip logic from the daily counter to save worker
capacity for unchanged aggregates. However, Aggregate was calculating
repohash using only incident IDs (sub.id). Even if an incident
package was rebuilt (causing a new OBS revision) or a dynamic setting
like a new Public Cloud PINT image changed, the repohash remained
identical, incorrectly skipping the job permanently.

Design Choices:
- Call compute_revisions_for_product_repo on all submissions before
  processing so that OBS revisions are fetched.
- Compute repohash using a combination of incident IDs and their OBS
  revisions (sub.id:rev).
- Evaluate apply_public_cloud_settings earlier to include dynamic
  Public Cloud image IDs in the repohash calculation.

Manual verification:
```
QEM_DASHBOARD_URL=https://dashboard.qam.suse.de ./qem-bot.py --dry updates-run
```

Instead of printing "A build with the same RepoHash already exists" and
skipping these products, the bot correctly calculated new repohashes
(e.g., e49b6f81ba6619ee8c3f26bc27cc6424 for SLES15SP6 ppc64le) and
printed "Dry run: Would update QEM Dashboard for api/update_settings". 


Benefits:
Eliminates unnecessary retriggers when nothing actually changes while
correctly scheduling new tests when incident packages are updated or
new external public cloud images are released.

Related issue: https://progress.opensuse.org/issues/205461