### PR TITLE
fix(gitea): honor max_workers in submissions loader

### DIFF
--- a/openqabot/loader/gitea.py
+++ b/openqabot/loader/gitea.py
@@ -827,7 +827,7 @@ def get_submissions_from_open_prs(
     # configure osc to be able to request build info from OBS
     osc.conf.get_config(override_apiurl=config.settings.obs_url)
 
-    with futures.ThreadPoolExecutor() as executor:
+    with futures.ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:
         future_sub = [
             executor.submit(
                 make_submission_from_gitea_pr,


### PR DESCRIPTION
Motivation:
The ThreadPoolExecutor in get_submissions_from_open_prs was running
unbounded, which did not honor the global QEM_BOT_MAX_WORKERS setting.

Design Choices:
Pass max_workers=config.settings.max_workers to ThreadPoolExecutor in
loader/gitea.py, aligning with other executors in the codebase.

Benefits:
Ensures consistent concurrency limits across all thread pools, preventing
unintended request floods against remote services.