### PR TITLE
PART 2: feat: introduce handle-submissions command - After #500

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,8 +127,7 @@ test-integration: ## Automatically start environment, run integration tests, and
 
 .PHONY: test-integration-payload
 test-integration-payload: env-dashboard-wait  ## Test qem-bot against a local dashboard instance
-	$(QEM_BOT_BASE_CMD) gitea-sync
-	$(QEM_BOT_BASE_CMD) smelt-sync
+	$(QEM_BOT_BASE_CMD) sync
 	$(QEM_BOT_BASE_CMD) --dry submissions-run
 	$(QEM_BOT_BASE_CMD) --dry sub-approve
 

--- a/Readme.md
+++ b/Readme.md
@@ -81,17 +81,15 @@ updates information about submissions and related openQA tests.
     │                    openQA.                                                   │
     │ updates-run        Aggregates only schedule for Maintenance Submissions in   │
     │                    openQA.                                                   │
-    │ smelt-sync         Sync data from SMELT into QEM Dashboard.                  │
-    │ gitea-sync         Sync data from Gitea into QEM Dashboard.                  │
+    │ sync               Sync data from both SMELT and Gitea into QEM Dashboard.   │
     │ gitea-trigger      Trigger testing for PR(s) with certain label.             │
     │ sub-approve        Approve submissions which passed tests.                   │
-    │ sub-comment        Comment submissions in BuildService.                      │
     │ sub-sync-results   Sync results of openQA submission jobs to Dashboard.      │
     │ aggr-sync-results  Sync results of openQA aggregate jobs to Dashboard.       │
     │ increment-approve  Approve the most recent product increment for an OBS      │
     │                    project if tests passed.                                  │
-    │ repo-diff          Computes the diff between two repositories.               │
     │ amqp               AMQP listener daemon.                                     │
+    │ advanced           Advanced commands, e.g. for debugging.                    │
     ╰──────────────────────────────────────────────────────────────────────────────╯
 
 
@@ -107,7 +105,7 @@ details.
 ## Expected workflow
 
 * For every incident in SMELT or PR in Gitea an entry should show up in
-  qem-dashboard (`smelt-sync`, `gitea-sync`)
+  qem-dashboard (`sync`)
 * For every submission in qem-dashboard, submission and aggregate tests are
   triggered (`submissions-run`, `updates-run`)
 * Results from submission + aggregate tests show up on the dashboard

--- a/Readme.md
+++ b/Readme.md
@@ -76,20 +76,22 @@ updates information about submissions and related openQA tests.
     │ --help                                          Show this message and exit.  │
     ╰──────────────────────────────────────────────────────────────────────────────╯
     ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-    │ full-run           Full schedule for Maintenance Submissions in openQA.      │
-    │ submissions-run    Submissions only schedule for Maintenance Submissions in  │
-    │                    openQA.                                                   │
-    │ updates-run        Aggregates only schedule for Maintenance Submissions in   │
-    │                    openQA.                                                   │
-    │ sync               Sync data from both SMELT and Gitea into QEM Dashboard.   │
-    │ gitea-trigger      Trigger testing for PR(s) with certain label.             │
-    │ sub-approve        Approve submissions which passed tests.                   │
-    │ sub-sync-results   Sync results of openQA submission jobs to Dashboard.      │
-    │ aggr-sync-results  Sync results of openQA aggregate jobs to Dashboard.       │
-    │ increment-approve  Approve the most recent product increment for an OBS      │
-    │                    project if tests passed.                                  │
-    │ amqp               AMQP listener daemon.                                     │
-    │ advanced           Advanced commands, e.g. for debugging.                    │
+    │ full-run            Full schedule for Maintenance Submissions in openQA.     │
+    │ submissions-run     Submissions only schedule for Maintenance Submissions in │
+    │                     openQA.                                                  │
+    │ handle-submissions  Schedule tests, sync results, and approve Maintenance    │
+    │                     Submissions.                                             │
+    │ updates-run         Aggregates only schedule for Maintenance Submissions in  │
+    │                     openQA.                                                  │
+    │ sync                Sync data from both SMELT and Gitea into QEM Dashboard.  │
+    │ gitea-trigger       Trigger testing for PR(s) with certain label.            │
+    │ sub-approve         Approve submissions which passed tests.                  │
+    │ sub-sync-results    Sync results of openQA submission jobs to Dashboard.     │
+    │ aggr-sync-results   Sync results of openQA aggregate jobs to Dashboard.      │
+    │ increment-approve   Approve the most recent product increment for an OBS     │
+    │                     project if tests passed.                                 │
+    │ amqp                AMQP listener daemon.                                    │
+    │ advanced            Advanced commands, e.g. for debugging.                   │
     ╰──────────────────────────────────────────────────────────────────────────────╯
 
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -135,7 +135,7 @@ following automated targets:
     ```bash
     make test-integration
     ```
-    This will verify `gitea-sync`, `smelt-sync`, and dry-runs of
+    This will verify `advanced gitea-sync`, `advanced smelt-sync`, and dry-runs of
     `submissions-run` and `sub-approve`.
 
 For manual setup, check out [qem-dashboard](https://github.com/openSUSE/qem-dashboard)
@@ -159,7 +159,7 @@ the following one to sync Gitea PRs into the dashboard:
 
 ```
 python3 ./qem-bot.py -g "$GITEA_TOKEN" -t s3cret --fake-data \
-    -c etc/openqabot gitea-sync --allow-build-failures \
+    -c etc/openqabot advanced gitea-sync --allow-build-failures \
     --consider-unrequested-prs
 ```
 

--- a/openqabot/aggrsync.py
+++ b/openqabot/aggrsync.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 """Sync aggregate results."""
 
-from argparse import Namespace
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from itertools import chain
 from logging import getLogger
+from types import SimpleNamespace
 
 from . import config
 from .loader.config import read_products
@@ -20,7 +20,7 @@ class AggregateResultsSync(SyncRes):
 
     operation = "aggregate"
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the AggregateResultsSync class."""
         super().__init__(args)
         self.product = read_products(args.configs)

--- a/openqabot/amqp.py
+++ b/openqabot/amqp.py
@@ -3,9 +3,9 @@
 """AMQP listener for openQA events."""
 
 import re
-from argparse import Namespace
 from logging import getLogger
 from pprint import pformat
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 from .approver import Approver
@@ -28,7 +28,7 @@ build_agg_regex = re.compile(r"\d{8}-\d+")
 class AMQP(SyncRes):
     """AMQP listener and message handler."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the AMQP class."""
         super().__init__(args)
         self.args = args

--- a/openqabot/approver.py
+++ b/openqabot/approver.py
@@ -38,7 +38,7 @@ from .loader.qem import (
 )
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from types import SimpleNamespace
 
 
 class JobResult(Enum):
@@ -121,7 +121,7 @@ class Approver:
 
     def __init__(
         self,
-        args: Namespace,
+        args: SimpleNamespace,
         single_submission: int | None = None,
         submission_type: str | None = None,
     ) -> None:

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -225,6 +225,45 @@ def _run_gitea_sync(args: SimpleNamespace, options: GiteaSyncOptions) -> int:
     return GiteaSync(args)()
 
 
+def _run_submissions_schedule(args: SimpleNamespace, *, ignore_onetime: bool, submission: str | None) -> int:
+    args.ignore_onetime = ignore_onetime
+    args.submission = submission
+    args.disable_submissions = False
+    args.disable_aggregates = True
+    return OpenQABot(args)()
+
+
+def _run_sub_sync_results(args: SimpleNamespace) -> int:
+    return SubResultsSync(args)()
+
+
+def _run_sub_approve(  # ruff: ignore[too-many-arguments]
+    args: SimpleNamespace,
+    *,
+    all_submissions: bool,
+    submission: str | None,
+    comment: bool,
+    enable_detailed_comments: bool | None,
+    fallback_contact: str | None,
+    generic_tool_issues_contact: str | None,
+    max_detailed_comment_entries: int | None,
+) -> int:
+    args.all_submissions = all_submissions
+    args.submission = submission
+    args.incident = submission
+    args.comment = comment
+
+    _apply_detailed_comment_options(
+        args,
+        enable_detailed_comments=enable_detailed_comments,
+        fallback_contact=fallback_contact,
+        generic_tool_issues_contact=generic_tool_issues_contact,
+        max_detailed_comment_entries=max_detailed_comment_entries,
+    )
+
+    return Approver(args)()
+
+
 @app.callback()
 def main(  # ruff: ignore[too-many-arguments]
     ctx: typer.Context,
@@ -420,13 +459,53 @@ def submissions_run(
     """Submissions only schedule for Maintenance Submissions in openQA."""
     args = ctx.obj
     _require_token(args)
-    args.ignore_onetime = ignore_onetime
-    args.submission = submission
-    args.disable_submissions = False
-    args.disable_aggregates = True
+    sys.exit(_run_submissions_schedule(args, ignore_onetime=ignore_onetime, submission=submission))
 
-    bot = OpenQABot(args)
-    sys.exit(bot())
+
+@app.command("handle-submissions")
+def handle_submissions(  # ruff: ignore[too-many-arguments]
+    ctx: typer.Context,
+    *,
+    ignore_onetime: Annotated[
+        bool,
+        typer.Option("-i", "--ignore-onetime", help="Ignore onetime and schedule those test runs"),
+    ] = False,
+    submission: Annotated[
+        str | None,
+        typer.Option(
+            "-I",
+            "--submission",
+            help="Submission ID (to process and approve only a single submission)",
+        ),
+    ] = None,
+    all_submissions: Annotated[
+        bool,
+        typer.Option("--all-submissions", help="use all submissions without care about rrid for approval"),
+    ] = False,
+    comment: comment_option = True,
+    enable_detailed_comments: enable_detailed_comments_option = None,
+    fallback_contact: fallback_contact_option = None,
+    generic_tool_issues_contact: generic_tool_issues_contact_option = None,
+    max_detailed_comment_entries: max_detailed_comment_entries_option = None,
+) -> None:
+    """Schedule tests, sync results, and approve Maintenance Submissions."""
+    args = ctx.obj
+    _require_token(args)
+
+    bot_ret = _run_submissions_schedule(args, ignore_onetime=ignore_onetime, submission=submission)
+    sync_ret = _run_sub_sync_results(args)
+    approve_ret = _run_sub_approve(
+        args,
+        all_submissions=all_submissions,
+        submission=submission,
+        comment=comment,
+        enable_detailed_comments=enable_detailed_comments,
+        fallback_contact=fallback_contact,
+        generic_tool_issues_contact=generic_tool_issues_contact,
+        max_detailed_comment_entries=max_detailed_comment_entries,
+    )
+
+    sys.exit(bot_ret or sync_ret or approve_ret)
 
 
 @app.command("updates-run")
@@ -582,21 +661,18 @@ def sub_approve(  # ruff: ignore[too-many-arguments]
     """Approve submissions which passed tests."""
     args = ctx.obj
     _require_token(args)
-    args.all_submissions = all_submissions
-    args.submission = submission
-    args.incident = submission
-    args.comment = comment
-
-    _apply_detailed_comment_options(
-        args,
-        enable_detailed_comments=enable_detailed_comments,
-        fallback_contact=fallback_contact,
-        generic_tool_issues_contact=generic_tool_issues_contact,
-        max_detailed_comment_entries=max_detailed_comment_entries,
+    sys.exit(
+        _run_sub_approve(
+            args,
+            all_submissions=all_submissions,
+            submission=submission,
+            comment=comment,
+            enable_detailed_comments=enable_detailed_comments,
+            fallback_contact=fallback_contact,
+            generic_tool_issues_contact=generic_tool_issues_contact,
+            max_detailed_comment_entries=max_detailed_comment_entries,
+        )
     )
-
-    approve = Approver(args)
-    sys.exit(approve())
 
 
 @advanced_app.command("sub-comment")
@@ -631,8 +707,7 @@ def sub_sync_results(ctx: typer.Context) -> None:
     args = ctx.obj
     _require_token(args)
 
-    syncer = SubResultsSync(args)
-    sys.exit(syncer())
+    sys.exit(_run_sub_sync_results(args))
 
 
 @app.command("aggr-sync-results")

--- a/openqabot/args.py
+++ b/openqabot/args.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Annotated, Any
@@ -37,7 +38,16 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
 )
+advanced_app = typer.Typer(
+    name="advanced",
+    help="Advanced commands, e.g. for debugging.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+app.add_typer(advanced_app)
 log = logging.getLogger("bot")
+
+DEFAULT_GITEA_PROJECT = "products/SLFO"
 
 pr_number_arg = Annotated[
     int | None,
@@ -52,6 +62,32 @@ gitea_project_arg = Annotated[
         "--gitea-project",
         envvar="GITEA_PROJECT",
         help="Project in Gitea to check for PRs. Project defined by {owner}/{repo}",
+    ),
+]
+allow_build_failures_option = Annotated[
+    bool,
+    typer.Option("--allow-build-failures", help="Sync data from PRs despite failing packages"),
+]
+consider_unrequested_prs_option = Annotated[
+    bool,
+    typer.Option(
+        "--consider-unrequested-prs",
+        help=f"Consider PRs where no review from team {config_module.settings.obs_group} was requested as well",
+    ),
+]
+amqp_option = Annotated[
+    bool,
+    typer.Option(
+        "--amqp",
+        help="After initial sync listen for new PRs via AMQP and submit them to QEM dashboard immediately",
+    ),
+]
+amqp_url_option = Annotated[str | None, typer.Option("--amqp-url", help="the URL of the AMQP server")]
+skip_initial_sync_option = Annotated[
+    bool,
+    typer.Option(
+        "--amqp-only",
+        help="Skip initial sync before handling AMQP events for new PRs",
     ),
 ]
 
@@ -158,6 +194,35 @@ def _require_gitea_token(args: SimpleNamespace) -> None:
             "Error: Missing option '--gitea-token' / '-g' or environment variable QEM_BOT_GITEA_TOKEN.", err=True
         )
         raise typer.Exit(1)
+
+
+def _require_sync_tokens(args: SimpleNamespace) -> None:
+    """Enforce both tokens needed by any command syncing Gitea into the dashboard."""
+    _require_token(args)
+    _require_gitea_token(args)
+
+
+@dataclass(frozen=True)
+class GiteaSyncOptions:
+    """Options of a Gitea sync run, shared by the "sync" and "advanced gitea-sync" commands."""
+
+    gitea_project: str = DEFAULT_GITEA_PROJECT
+    allow_build_failures: bool = False
+    consider_unrequested_prs: bool = False
+    pr_number: int | None = None
+    amqp: bool = False
+    amqp_url: str | None = None
+    skip_initial_sync: bool = False
+
+
+def _run_gitea_sync(args: SimpleNamespace, options: GiteaSyncOptions) -> int:
+    """Apply Gitea sync options onto the shared context and run the sync."""
+    for key, value in asdict(options).items():
+        setattr(args, key, value)
+    # Default from settings (which was already loaded in main callback)
+    if options.amqp_url is None:
+        args.amqp_url = config_module.settings.amqp_url
+    return GiteaSync(args)()
 
 
 @app.callback()
@@ -384,7 +449,7 @@ def updates_run(
     sys.exit(bot())
 
 
-@app.command("smelt-sync")
+@advanced_app.command("smelt-sync")
 def smelt_sync(ctx: typer.Context) -> None:
     """Sync data from SMELT into QEM Dashboard."""
     args = ctx.obj
@@ -394,54 +459,60 @@ def smelt_sync(ctx: typer.Context) -> None:
     sys.exit(syncer())
 
 
-@app.command("gitea-sync")
+@app.command("sync")
+def sync(
+    ctx: typer.Context,
+    *,
+    gitea_project: gitea_project_arg = DEFAULT_GITEA_PROJECT,
+    allow_build_failures: allow_build_failures_option = False,
+    consider_unrequested_prs: consider_unrequested_prs_option = False,
+) -> None:
+    """Sync data from both SMELT and Gitea into QEM Dashboard."""
+    args = ctx.obj
+    # Guard before the SMELT sync so a missing Gitea token fails fast
+    _require_sync_tokens(args)
+
+    smelt_ret = SMELTSync(args)()
+    gitea_ret = _run_gitea_sync(
+        args,
+        GiteaSyncOptions(
+            gitea_project=gitea_project,
+            allow_build_failures=allow_build_failures,
+            consider_unrequested_prs=consider_unrequested_prs,
+        ),
+    )
+    sys.exit(smelt_ret or gitea_ret)
+
+
+@advanced_app.command("gitea-sync")
 def gitea_sync(  # ruff: ignore[too-many-arguments]
     ctx: typer.Context,
     *,
-    gitea_project: gitea_project_arg = "products/SLFO",
-    allow_build_failures: Annotated[
-        bool,
-        typer.Option("--allow-build-failures", help="Sync data from PRs despite failing packages"),
-    ] = False,
-    consider_unrequested_prs: Annotated[
-        bool,
-        typer.Option(
-            "--consider-unrequested-prs",
-            help=f"Consider PRs where no review from team {config_module.settings.obs_group} was requested as well",
-        ),
-    ] = False,
+    gitea_project: gitea_project_arg = DEFAULT_GITEA_PROJECT,
+    allow_build_failures: allow_build_failures_option = False,
+    consider_unrequested_prs: consider_unrequested_prs_option = False,
     pr_number: pr_number_arg = None,
-    amqp: Annotated[
-        bool,
-        typer.Option(
-            "--amqp",
-            help="After initial sync listen for new PRs via AMQP and submit them to QEM dashboard immediately",
-        ),
-    ] = False,
-    amqp_url: Annotated[str | None, typer.Option("--amqp-url", help="the URL of the AMQP server")] = None,
-    skip_initial_sync: Annotated[
-        bool,
-        typer.Option(
-            "--amqp-only",
-            help="Skip initial sync before handling AMQP events for new PRs",
-        ),
-    ] = False,
+    amqp: amqp_option = False,
+    amqp_url: amqp_url_option = None,
+    skip_initial_sync: skip_initial_sync_option = False,
 ) -> None:
     """Sync data from Gitea into QEM Dashboard."""
     args = ctx.obj
-    _require_token(args)
-    _require_gitea_token(args)
-    args.gitea_project = gitea_project
-    args.allow_build_failures = allow_build_failures
-    args.consider_unrequested_prs = consider_unrequested_prs
-    args.pr_number = pr_number
-    args.amqp = amqp
-    # Default from settings (which was already loaded in main callback)
-    args.amqp_url = amqp_url if amqp_url is not None else config_module.settings.amqp_url
-    args.skip_initial_sync = skip_initial_sync
-
-    syncer = GiteaSync(args)
-    sys.exit(syncer())
+    _require_sync_tokens(args)
+    sys.exit(
+        _run_gitea_sync(
+            args,
+            GiteaSyncOptions(
+                gitea_project=gitea_project,
+                allow_build_failures=allow_build_failures,
+                consider_unrequested_prs=consider_unrequested_prs,
+                pr_number=pr_number,
+                amqp=amqp,
+                amqp_url=amqp_url,
+                skip_initial_sync=skip_initial_sync,
+            ),
+        )
+    )
 
 
 @app.command("gitea-trigger")
@@ -528,9 +599,10 @@ def sub_approve(  # ruff: ignore[too-many-arguments]
     sys.exit(approve())
 
 
-@app.command("sub-comment")
+@advanced_app.command("sub-comment")
 def sub_comment(
     ctx: typer.Context,
+    *,
     enable_detailed_comments: enable_detailed_comments_option = None,
     fallback_contact: fallback_contact_option = None,
     generic_tool_issues_contact: generic_tool_issues_contact_option = None,
@@ -710,7 +782,7 @@ def increment_approve(  # ruff: ignore[too-many-arguments]
     sys.exit(approve())
 
 
-@app.command("repo-diff")
+@advanced_app.command("repo-diff")
 def repo_diff(
     ctx: typer.Context,
     *,

--- a/openqabot/commenter.py
+++ b/openqabot/commenter.py
@@ -22,8 +22,8 @@ from .types.increment import BuildIdentifier
 from .utils import extract_contact_from_description, normalize_results
 
 if TYPE_CHECKING:
-    from argparse import Namespace
     from collections.abc import Callable, Sequence
+    from types import SimpleNamespace
 
     from .types.pullrequest import CommentableProtocol
     from .types.submission import Submission
@@ -34,7 +34,7 @@ log = getLogger("bot.commenter")
 class Commenter:
     """Logic for commenting on submissions in OBS."""
 
-    def __init__(self, args: Namespace, submissions: Sequence[Submission]) -> None:
+    def __init__(self, args: SimpleNamespace, submissions: Sequence[Submission]) -> None:
         """Initialize the Commenter class."""
         self.dry = args.dry
         self.gitea_token = gitea.make_token_header(args.gitea_token)

--- a/openqabot/giteasync.py
+++ b/openqabot/giteasync.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 """Sync Gitea pull requests to dashboard."""
 
-from argparse import Namespace
 from logging import getLogger
 from pprint import pformat
+from types import SimpleNamespace
 from typing import Any
 
 from openqabot.types.pullrequest import PullRequest
@@ -19,7 +19,7 @@ log = getLogger("bot.giteasync")
 class GiteaSync:
     """Synchronization of Gitea PRs to dashboard."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the GiteaSync class."""
         self.dry: bool = args.dry
         self.fake_data: bool = args.fake_data

--- a/openqabot/giteatrigger.py
+++ b/openqabot/giteatrigger.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 """Trigger testing for PR(s) with certain label."""
 
-from argparse import Namespace
 from dataclasses import dataclass
 from itertools import chain
 from logging import getLogger
+from types import SimpleNamespace
 from typing import Any, cast
 
 import requests
@@ -73,7 +73,7 @@ class EvaluationSummary:
 class GiteaTrigger:
     """Trigger testing for PR(s) with certain label."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize GiteaTrigger class.
 
         Args:

--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -35,7 +35,7 @@ from .types.pullrequest import OBSCommentable
 from .utils import merge_dicts, unique_dicts
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from types import SimpleNamespace
 
 
 class JobState(Enum):
@@ -64,7 +64,7 @@ class IncrementApprover:
     disapprove the request.
     """
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the IncrementApprover class."""
         self.args = args
         self.client = OpenQAInterface()

--- a/openqabot/loader/incrementconfig.py
+++ b/openqabot/loader/incrementconfig.py
@@ -15,7 +15,7 @@ from openqabot import config
 from .config import get_configs_from_path
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from types import SimpleNamespace
 
     from openqabot.types.increment import BuildInfo
 
@@ -167,7 +167,7 @@ class IncrementConfig:
         )
 
     @staticmethod
-    def from_args(args: Namespace) -> list[IncrementConfig]:
+    def from_args(args: SimpleNamespace) -> list[IncrementConfig]:
         """Create increment configurations from command line arguments."""
         source = args.increment_config or (
             args.configs if getattr(args, "configs", None) and args.configs.exists() else None
@@ -181,7 +181,7 @@ class IncrementConfig:
         return [IncrementConfig._create_from_args(args)]
 
     @staticmethod
-    def _apply_cli_overrides(configs: list[IncrementConfig], args: Namespace) -> list[IncrementConfig]:
+    def _apply_cli_overrides(configs: list[IncrementConfig], args: SimpleNamespace) -> list[IncrementConfig]:
         """Apply CLI argument overrides to loaded configs.
 
         Only override when CLI args differ from expected defaults (not dataclass defaults).
@@ -197,7 +197,7 @@ class IncrementConfig:
         return [replace(config, **overrides) if overrides else config for config in configs]
 
     @staticmethod
-    def _create_from_args(args: Namespace) -> IncrementConfig:
+    def _create_from_args(args: SimpleNamespace) -> IncrementConfig:
         """Create a single IncrementConfig from CLI arguments."""
         all_fields = {f.name for f in fields(IncrementConfig)}
         config_args = {field_name: getattr(args, field_name) for field_name in all_fields if hasattr(args, field_name)}

--- a/openqabot/openqabot.py
+++ b/openqabot/openqabot.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 """Main OpenQABot logic."""
 
-from argparse import Namespace
 from concurrent.futures import ThreadPoolExecutor, wait
 from logging import getLogger
 from os import environ
+from types import SimpleNamespace
 from typing import Any
 
 import openqabot.config as config_module
@@ -22,7 +22,7 @@ log = getLogger("bot.openqabot")
 class OpenQABot:
     """Main OpenQABot logic."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the OpenQABot class."""
         log.info("Starting bot schedule")
         self.dry = args.dry

--- a/openqabot/repodiff.py
+++ b/openqabot/repodiff.py
@@ -24,7 +24,7 @@ from .utils import get_obs_filter_params
 from .utils import retry10 as retried_requests
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from types import SimpleNamespace
 
 log = getLogger("bot.repo_diff")
 ns = "{http://linux.duke.edu/metadata/common}"
@@ -64,7 +64,7 @@ class Package(NamedTuple):
 class RepoDiff:
     """Repository diff computation."""
 
-    def __init__(self, args: Namespace | None) -> None:
+    def __init__(self, args: SimpleNamespace | None) -> None:
         """Initialize the RepoDiff class."""
         self.args = args
         self.fake_data = args is not None and getattr(self.args, "fake_data", False)

--- a/openqabot/requests.py
+++ b/openqabot/requests.py
@@ -13,7 +13,7 @@ import osc.core
 from openqabot import config
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from types import SimpleNamespace
 
 log = getLogger("bot.requests")
 
@@ -72,7 +72,9 @@ def _find_request_on_obs_cached(
     return relevant_request
 
 
-def find_request_on_obs(args: Namespace, build_project: str, obs_url: str | None = None) -> osc.core.Request | None:
+def find_request_on_obs(
+    args: SimpleNamespace, build_project: str, obs_url: str | None = None
+) -> osc.core.Request | None:
     """Find a relevant product increment request on OBS."""
     resolved_url = obs_url or config.settings.obs_url
     return _find_request_on_obs_cached(

--- a/openqabot/smeltsync.py
+++ b/openqabot/smeltsync.py
@@ -14,7 +14,7 @@ from .loader.qem import update_submissions
 from .loader.smelt import get_active_submission_ids, get_submissions
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from types import SimpleNamespace
 
 log = getLogger("bot.smeltsync")
 
@@ -22,7 +22,7 @@ log = getLogger("bot.smeltsync")
 class SMELTSync:
     """Synchronization of SMELT incidents to dashboard."""
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the SMELTSync class."""
         self.dry: bool = args.dry
         self.submissions = get_submissions(get_active_submission_ids())

--- a/openqabot/subsyncres.py
+++ b/openqabot/subsyncres.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 """Sync submission results."""
 
-from argparse import Namespace
 from concurrent import futures
 from itertools import chain
 from logging import getLogger
+from types import SimpleNamespace
 
 from . import config
 from .loader.qem import get_active_submissions, get_submission_settings_data
@@ -19,7 +19,7 @@ class SubResultsSync(SyncRes):
 
     operation = "submission"
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the SubResultsSync class."""
         super().__init__(args)
         self.active = get_active_submissions()

--- a/openqabot/syncres.py
+++ b/openqabot/syncres.py
@@ -14,7 +14,7 @@ from .openqa import OpenQAInterface
 from .utils import normalize_results
 
 if TYPE_CHECKING:
-    from argparse import Namespace
+    from types import SimpleNamespace
 
     from .types.types import Data
 
@@ -26,7 +26,7 @@ class SyncRes:
 
     operation = "null"
 
-    def __init__(self, args: Namespace) -> None:
+    def __init__(self, args: SimpleNamespace) -> None:
         """Initialize the SyncRes class."""
         self.dry: bool = args.dry
         self.client = OpenQAInterface()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import os
 import re
-from argparse import Namespace
 from collections import defaultdict
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
@@ -110,7 +110,7 @@ def fake_openqa_comment_api() -> None:
 def make_approver(submission: int = 0, *, mocker: MockerFixture | None = None, comment: bool = False) -> int:
     if mocker:
         mocker.patch("openqabot.approver.Commenter", autospec=True)
-    args = Namespace(
+    args = SimpleNamespace(
         dry=True,
         token="123",
         all_submissions=False,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import logging
 import os
 import re
-from argparse import Namespace
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, NamedTuple
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlencode
@@ -109,7 +109,7 @@ def f_sub_approver(*_args: Any) -> list[SubReq]:
     ]
 
 
-args = Namespace(
+args = SimpleNamespace(
     dry=False,
     token="123",
     all_submissions=False,
@@ -222,7 +222,7 @@ def prepare_approver(
     caplog.set_level(logging.DEBUG, logger="bot.requests")
     caplog.set_level(logging.DEBUG, logger="bot.loader.buildinfo")
 
-    args = Namespace(
+    args = SimpleNamespace(
         dry=False,
         token="not-secret",
         gitea_token=None,
@@ -361,7 +361,7 @@ def fake_openqa_responses_with_param_matching(
     ]
 
 
-def make_approver_args(**kwargs: Any) -> Namespace:
+def make_approver_args(**kwargs: Any) -> SimpleNamespace:
     defaults = {
         "gitea_token": None,
         "token": "dummy_token",
@@ -369,4 +369,4 @@ def make_approver_args(**kwargs: Any) -> Namespace:
         "all_submissions": False,
     }
     defaults.update(kwargs)
-    return Namespace(**defaults)
+    return SimpleNamespace(**defaults)

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from argparse import Namespace
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -26,8 +26,8 @@ fake_job_done = "suse.openqa.job.done"
 
 
 @pytest.fixture
-def args() -> Namespace:
-    return Namespace(
+def args() -> SimpleNamespace:
+    return SimpleNamespace(
         dry=True,
         token="ToKeN",
         url="amqp://localhost",
@@ -36,11 +36,11 @@ def args() -> Namespace:
 
 
 @pytest.fixture
-def amqp(args: Namespace) -> AMQP:
+def amqp(args: SimpleNamespace) -> AMQP:
     return AMQP(args)
 
 
-def test_handling_aggregate_full_coverage(args: Namespace, mocker: MagicMock) -> None:
+def test_handling_aggregate_full_coverage(args: SimpleNamespace, mocker: MagicMock) -> None:
     mock_listener_class = mocker.patch("openqabot.amqp.AMQPListener")
     amqp = AMQP(args)
     result = amqp()

--- a/tests/test_approve_scenarios.py
+++ b/tests/test_approve_scenarios.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 import re
-from argparse import Namespace
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     ],
 )
 def test_approver_single_submission_parsing(raw: str | int | None, exp_sub: int | None, exp_type: str | None) -> None:
-    args = Namespace(dry=True, token="123", all_submissions=False, incident=raw, gitea_token=None, comment=False)
+    args = SimpleNamespace(dry=True, token="123", all_submissions=False, incident=raw, gitea_token=None, comment=False)
     inst = Approver(args)
     assert inst.single_submission == exp_sub
     assert inst.submission_type == exp_type

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -58,17 +58,43 @@ def test_updates_run(mocker: MockerFixture, tmp_path: Path) -> None:
 def test_sync_smelt(mocker: MockerFixture, tmp_path: Path) -> None:
     syncer = mocker.patch("openqabot.args.SMELTSync")
     syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "smelt-sync"])
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "advanced", "smelt-sync"])
     assert result.exit_code == 0
     syncer.assert_called_once()
 
 
-def test_sync_gitea(mocker: MockerFixture, tmp_path: Path) -> None:
+def test_sync_gitea_passes_debug_options(mocker: MockerFixture, tmp_path: Path) -> None:
     syncer = mocker.patch("openqabot.args.GiteaSync")
     syncer.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), "gitea-sync"])
+    result = runner.invoke(
+        app,
+        [
+            *["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path)],
+            *["advanced", "gitea-sync", "--pr-number", "42", "--amqp-only"],
+            *["--amqp-url", "amqps://example.com"],
+        ],
+    )
     assert result.exit_code == 0
-    syncer.assert_called_once()
+    args = syncer.call_args[0][0]
+    assert args.pr_number == 42
+    assert args.skip_initial_sync
+    assert args.amqp_url == "amqps://example.com"
+
+
+def test_sync(mocker: MockerFixture, tmp_path: Path) -> None:
+    smelt = mocker.patch("openqabot.args.SMELTSync")
+    smelt.return_value.return_value = 0
+    gitea = mocker.patch("openqabot.args.GiteaSync")
+    gitea.return_value.return_value = 0
+    result = runner.invoke(app, ["--token", "foo", "--gitea-token", "bar", "--configs", str(tmp_path), "sync"])
+    assert result.exit_code == 0
+    smelt.assert_called_once()
+    gitea.assert_called_once()
+    args = gitea.call_args[0][0]
+    assert args.gitea_project == "products/SLFO"
+    assert args.pr_number is None
+    assert not args.amqp
+    assert not args.skip_initial_sync
 
 
 def test_gitea_trigger(mocker: MockerFixture, tmp_path: Path) -> None:
@@ -109,7 +135,7 @@ def test_sub_comment(mocker: MockerFixture, tmp_path: Path) -> None:
     mocker.patch("openqabot.args.get_submissions", return_value=[])
     comment = mocker.patch("openqabot.args.Commenter")
     comment.return_value.return_value = 0
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "sub-comment"])
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "advanced", "sub-comment"])
     assert result.exit_code == 0
     comment.assert_called_once()
 
@@ -125,6 +151,7 @@ def test_sub_comment_with_detailed_args(mocker: MockerFixture, tmp_path: Path) -
             "foo",
             "--configs",
             str(tmp_path),
+            "advanced",
             "sub-comment",
             "--enable-detailed-comments",
             "--fallback-contact",
@@ -197,7 +224,7 @@ def test_repo_diff(mocker: MockerFixture, tmp_path: Path) -> None:
     repo_diff = mocker.patch("openqabot.args.RepoDiff")
     repo_diff.return_value.return_value = 0
     # Provide a valid configs directory to avoid Configuration error in main callback
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "repo-diff"])
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "advanced", "repo-diff"])
     assert result.exit_code == 0
     repo_diff.assert_called_once()
 
@@ -311,12 +338,20 @@ def test_main_no_token_exit(mocker: MockerFixture, tmp_path: Path) -> None:
     assert "Error: Missing option '--token' / '-t'." in result.output
 
 
-def test_main_no_gitea_token_exit_sync(mocker: MockerFixture, tmp_path: Path) -> None:
-    """Test that gitea-sync exits with 1 when gitea_token is missing."""
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param(["advanced", "gitea-sync"], id="advanced gitea-sync rejects missing gitea token"),
+        pytest.param(["sync"], id="sync rejects missing gitea token before running the SMELT sync"),
+    ],
+)
+def test_main_no_gitea_token_exit_sync(mocker: MockerFixture, tmp_path: Path, command: list[str]) -> None:
     mocker.patch.dict("os.environ", {}, clear=True)
-    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), "gitea-sync"])
+    smelt = mocker.patch("openqabot.args.SMELTSync")
+    result = runner.invoke(app, ["--token", "foo", "--configs", str(tmp_path), *command])
     assert result.exit_code == 1
     assert "Error: Missing option '--gitea-token' / '-g' or environment variable QEM_BOT_GITEA_TOKEN." in result.output
+    smelt.assert_not_called()
 
 
 def test_main_no_gitea_token_exit_trigger(mocker: MockerFixture, tmp_path: Path) -> None:

--- a/tests/test_args_handle_submissions.py
+++ b/tests/test_args_handle_submissions.py
@@ -1,0 +1,36 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: MIT
+"""Tests for the handle-submissions command."""
+
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+from typer.testing import CliRunner
+
+from openqabot.args import app
+
+runner = CliRunner()
+
+
+def test_handle_submissions(mocker: MockerFixture, tmp_path: Path) -> None:
+    bot = mocker.patch("openqabot.args.OpenQABot")
+    bot.return_value.return_value = 0
+    sync = mocker.patch("openqabot.args.SubResultsSync")
+    sync.return_value.return_value = 0
+    approve = mocker.patch("openqabot.args.Approver")
+    approve.return_value.return_value = 0
+
+    result = runner.invoke(
+        app,
+        ["--token", "foo", "--configs", str(tmp_path), "handle-submissions", "--ignore-onetime"],
+    )
+
+    assert result.exit_code == 0
+    bot.assert_called_once()
+    sync.assert_called_once()
+    approve.assert_called_once()
+
+    bot_args = bot.call_args[0][0]
+    assert bot_args.ignore_onetime is True
+    assert bot_args.disable_submissions is False
+    assert bot_args.disable_aggregates is True

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from argparse import Namespace
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
@@ -61,8 +61,8 @@ def make_comment_api() -> Callable[..., MagicMock]:
 
 
 @pytest.fixture
-def mock_args() -> Namespace:
-    return Namespace(dry=True, gitea_token="gitea_token")
+def mock_args() -> SimpleNamespace:
+    return SimpleNamespace(dry=True, gitea_token="gitea_token")
 
 
 @pytest.fixture
@@ -110,7 +110,7 @@ def commenter_setup(mocker: MockerFixture) -> dict[str, MagicMock]:
     }
 
 
-def test_commenter_init(commenter_setup: dict[str, MagicMock], mock_args: Namespace) -> None:
+def test_commenter_init(commenter_setup: dict[str, MagicMock], mock_args: SimpleNamespace) -> None:
     subs = [MagicMock(spec=Submission)]
     c = Commenter(mock_args, submissions=subs)
     assert c.dry == mock_args.dry
@@ -119,7 +119,7 @@ def test_commenter_init(commenter_setup: dict[str, MagicMock], mock_args: Namesp
     assert c.submissions == subs
 
 
-def test_commenter_init_with_submissions(mock_args: Namespace) -> None:
+def test_commenter_init_with_submissions(mock_args: SimpleNamespace) -> None:
     subs = [MagicMock(spec="openqabot.types.submission.Submission")]
     c = Commenter(mock_args, submissions=subs)
     assert c.submissions == subs
@@ -128,7 +128,7 @@ def test_commenter_init_with_submissions(mock_args: Namespace) -> None:
 @pytest.mark.usefixtures("commenter_setup")
 def test_commenter_call_failed_jobs(
     mocker: MockerFixture,
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     make_job: Callable,
@@ -150,7 +150,7 @@ def test_commenter_call_failed_jobs(
 @pytest.mark.usefixtures("commenter_setup")
 def test_commenter_call_passed_jobs(
     mocker: MockerFixture,
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
 ) -> None:
     mocker.patch(
@@ -167,7 +167,7 @@ def test_commenter_call_passed_jobs(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_no_request(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -180,7 +180,7 @@ def test_osc_comment_no_request(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_comment_on_submission_empty_msg(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     mocker: MockerFixture,
 ) -> None:
@@ -193,7 +193,7 @@ def test_comment_on_submission_empty_msg(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_dry_run(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     make_comment_api: Callable,
@@ -211,7 +211,7 @@ def test_osc_comment_dry_run(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_on_request_uses_custom_obs_url(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     make_comment_api: Callable,
     commenter_setup: dict[str, MagicMock],
 ) -> None:
@@ -228,7 +228,7 @@ def test_osc_comment_on_request_uses_custom_obs_url(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_with_revision(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     make_comment_api: Callable,
@@ -247,7 +247,7 @@ def test_osc_comment_with_revision(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_no_comment(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     make_comment_api: Callable,
@@ -264,7 +264,7 @@ def test_osc_comment_no_comment(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_similar_exists(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     make_comment_api: Callable,
@@ -284,7 +284,7 @@ def test_osc_comment_similar_exists(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_delete_existing_not_similar_not_dry(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     make_comment_api: Callable,
     commenter_setup: dict[str, MagicMock],
@@ -302,7 +302,7 @@ def test_osc_comment_delete_existing_not_similar_not_dry(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_replace_not_dry(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     make_comment_api: Callable,
     commenter_setup: dict[str, MagicMock],
@@ -322,7 +322,7 @@ def test_osc_comment_replace_not_dry(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_osc_comment_replace_dry_run(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     make_comment_api: Callable,
@@ -347,7 +347,7 @@ def test_osc_comment_replace_dry_run(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_summarize_message(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     commenter_setup: dict[str, MagicMock],
     mocker: MockerFixture,
 ) -> None:
@@ -390,7 +390,7 @@ def test_summarize_message(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_summarize_message_allow_devel(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     commenter_setup: dict[str, MagicMock],
     mocker: MockerFixture,
 ) -> None:
@@ -419,7 +419,7 @@ def test_summarize_message_allow_devel(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_gitea_comment_dry_run(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     commenter_setup: dict[str, MagicMock],
@@ -440,7 +440,7 @@ def test_gitea_comment_dry_run(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_gitea_comment_post_new(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     commenter_setup: dict[str, MagicMock],
 ) -> None:
@@ -459,7 +459,7 @@ def test_gitea_comment_post_new(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_gitea_comment_patch_existing(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     commenter_setup: dict[str, MagicMock],
 ) -> None:
@@ -479,7 +479,7 @@ def test_gitea_comment_patch_existing(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_commenter_call_git(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     mocker: MockerFixture,
     make_job: Callable,
@@ -498,7 +498,7 @@ def test_commenter_call_git(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_gitea_comment_no_token(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     commenter_setup: dict[str, MagicMock],
@@ -514,7 +514,7 @@ def test_gitea_comment_no_token(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_comment_on_submission_empty_msg_git(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     mocker: MockerFixture,
 ) -> None:
@@ -527,7 +527,7 @@ def test_comment_on_submission_empty_msg_git(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_gitea_comment_no_url(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -540,7 +540,7 @@ def test_gitea_comment_no_url(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_gitea_comment_similar_exists(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_git_sub: MagicMock,
     caplog: pytest.LogCaptureFixture,
     commenter_setup: dict[str, MagicMock],
@@ -562,7 +562,7 @@ def test_gitea_comment_similar_exists(
 @pytest.mark.usefixtures("commenter_setup")
 def test_commenter_call_empty_msg(
     mocker: MockerFixture,
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mock_smelt_sub: MagicMock,
 ) -> None:
     mocker.patch("openqabot.commenter.get_submission_results", return_value=[{"status": "passed"}])
@@ -574,7 +574,7 @@ def test_commenter_call_empty_msg(
 
 
 @pytest.mark.usefixtures("commenter_setup")
-def test_comment_on_submission_unsupported_type(mock_args: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_comment_on_submission_unsupported_type(mock_args: SimpleNamespace, caplog: pytest.LogCaptureFixture) -> None:
     """Test skipping unsupported submission types."""
     caplog.set_level(logging.DEBUG, logger="bot.commenter")
     c = Commenter(mock_args, submissions=[])
@@ -599,7 +599,7 @@ def test_comment_on_submission_unsupported_type(mock_args: Namespace, caplog: py
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_comment_on_submission_no_results_error(
-    mock_args: Namespace, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+    mock_args: SimpleNamespace, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
 ) -> None:
     """Test handling of NoResultsError and ValueError during result fetching."""
     caplog.set_level(logging.DEBUG, logger="bot.commenter")
@@ -630,7 +630,7 @@ def test_comment_on_submission_no_results_error(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_comment_on_submission_running_jobs(
-    mock_args: Namespace, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+    mock_args: SimpleNamespace, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
 ) -> None:
     """Test postponing comments when jobs are still running."""
     caplog.set_level(logging.DEBUG, logger="bot.commenter")
@@ -659,7 +659,7 @@ def test_comment_on_submission_running_jobs(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_comment_on_submission_no_jobs(
-    mock_args: Namespace, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
+    mock_args: SimpleNamespace, caplog: pytest.LogCaptureFixture, mocker: MockerFixture
 ) -> None:
     """Test behavior when no jobs are found for a submission."""
     caplog.set_level(logging.DEBUG, logger="bot.commenter")
@@ -687,7 +687,7 @@ def test_comment_on_submission_no_jobs(
 
 
 @pytest.mark.usefixtures("commenter_setup")
-def test_generate_comment_raw_openqa_jobs(mock_args: Namespace) -> None:
+def test_generate_comment_raw_openqa_jobs(mock_args: SimpleNamespace) -> None:
     """Test generating comment from raw openQA jobs lacking status key."""
     c = Commenter(mock_args, submissions=[])
     raw_jobs = [
@@ -826,7 +826,7 @@ def detailed_comment_mocks(
 )
 @pytest.mark.usefixtures("commenter_setup")
 def test_summarize_message_detailed_comments(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     detailed_comment_mocks: dict[str, MagicMock],
     mocker: MockerFixture,
     enabled: bool,  # ruff: ignore[boolean-type-hint-positional-argument]
@@ -852,7 +852,7 @@ def test_summarize_message_detailed_comments(
 
 @pytest.mark.usefixtures("commenter_setup")
 def test_summarize_message_detailed_comments_duplicate_group(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     detailed_comment_mocks: dict[str, MagicMock],
 ) -> None:
     """Test summarize_message when multiple jobs have the same group_id."""

--- a/tests/test_giteasync.py
+++ b/tests/test_giteasync.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import logging
 import re
-from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from urllib.error import HTTPError
 from urllib.parse import urljoin, urlparse
@@ -125,8 +125,8 @@ def fake_get_multibuild_data(obs_project: str) -> str:
 
 
 @pytest.fixture
-def args() -> Namespace:
-    return Namespace(
+def args() -> SimpleNamespace:
+    return SimpleNamespace(
         dry=False,
         fake_data=False,
         token="123",
@@ -154,7 +154,7 @@ def gitea_sync_mocks(mocker: MockerFixture) -> None:
 def run_gitea_sync(
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
-    args: Namespace,
+    args: SimpleNamespace,
     *,
     no_build_results: bool = False,
 ) -> None:
@@ -169,7 +169,7 @@ def run_gitea_sync(
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_gitea_sync_on_dry_run_does_not_sync(args: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_gitea_sync_on_dry_run_does_not_sync(args: SimpleNamespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.giteasync")
     args.dry = True
     assert GiteaSync(args)() == 0
@@ -178,7 +178,7 @@ def test_gitea_sync_on_dry_run_does_not_sync(args: Namespace, caplog: pytest.Log
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     mocker.patch("openqabot.config.settings.obs_products", "SLES")
     run_gitea_sync(mocker, caplog, args)
     expected_repo = "SUSE:SLFO:1.1.99:PullRequest:124:SLES"
@@ -215,7 +215,7 @@ def test_sync_with_product_repo(mocker: MockerFixture, caplog: pytest.LogCapture
 @pytest.mark.usefixtures("fake_gitea_api", "fake_repo", "fake_dashboard_replyback", "gitea_sync_mocks")
 def test_sync_with_product_version_from_repo_listing(
     mocker: MockerFixture,
-    args: Namespace,
+    args: SimpleNamespace,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     mocker.patch("openqabot.config.settings.obs_repo_type", "standard")  # has no scmsync so repo listing is used
@@ -235,7 +235,9 @@ def test_sync_with_product_version_from_repo_listing(
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_sync_with_codestream_repo(mocker: MockerFixture, args: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_sync_with_codestream_repo(
+    mocker: MockerFixture, args: SimpleNamespace, caplog: pytest.LogCaptureFixture
+) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.giteasync")
     mocker.patch("openqabot.config.settings.obs_repo_type", "standard")
     mocker.patch("openqabot.config.settings.obs_products", "")
@@ -246,7 +248,7 @@ def test_sync_with_codestream_repo(mocker: MockerFixture, args: Namespace, caplo
 
 @responses.activate
 @pytest.mark.usefixtures("fake_gitea_api", "fake_dashboard_replyback", "gitea_sync_mocks")
-def test_sync_without_results(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_sync_without_results(mocker: MockerFixture, caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     args.allow_build_failures = False
     run_gitea_sync(mocker, caplog, args, no_build_results=True)
     m = "Skipping PR git:124: No packages have been built/published (there are 0 failed/unpublished packages)"
@@ -317,13 +319,13 @@ def test_adding_packages_from_files() -> None:
 
 
 def test_gitea_sync_skips_initial_on_request(
-    args: Namespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    args: SimpleNamespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ) -> None:
     args.skip_initial_sync = True
     run_gitea_sync(mocker, caplog, args)
 
 
-def test_gitea_sync_amqp(args: Namespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
+def test_gitea_sync_amqp(args: SimpleNamespace, mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     args.skip_initial_sync = True
     args.amqp = True
     mocker.patch("openqabot.giteasync.AMQPListener")

--- a/tests/test_giteatrigger.py
+++ b/tests/test_giteatrigger.py
@@ -3,8 +3,8 @@
 """Tests GiteaTrigger class."""
 
 import logging
-from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
@@ -30,9 +30,9 @@ def mock_trigger_config() -> TriggerConfig:
 
 
 @pytest.fixture
-def mock_args() -> Namespace:
+def mock_args() -> SimpleNamespace:
     """Provide a standard set of CLI arguments for initialization."""
-    return Namespace(
+    return SimpleNamespace(
         dry=False,
         gitea_token="fake_token",
         gitea_project="repo/name",
@@ -64,7 +64,7 @@ def _make_pr(number: int | None, trigger_config: TriggerConfig, **kwargs: Any) -
 
 @pytest.fixture
 def trigger(
-    mock_args: Namespace,
+    mock_args: SimpleNamespace,
     mocker: MockerFixture,
     _fake_get_configs_from_path: None,
 ) -> GiteaTrigger:
@@ -380,7 +380,7 @@ def test_check_pullrequest_mixed_trigger_and_covered_skips_comment(
 
 @pytest.mark.usefixtures("_fake_get_configs_from_path")
 def test_get_prs_by_label_specific_number(
-    mock_args: Namespace, mocker: MockerFixture, mock_trigger_config: TriggerConfig
+    mock_args: SimpleNamespace, mocker: MockerFixture, mock_trigger_config: TriggerConfig
 ) -> None:
     """Cover user provides a specific PR number via CLI."""
     mock_args.pr_number = 1337
@@ -458,7 +458,7 @@ def test_comment_on_pr_build_injection(
 
 
 def test_comment_on_pr_one_flavor_fails_blocks_approval(
-    trigger: GiteaTrigger, mocker: MockerFixture, mock_args: Namespace
+    trigger: GiteaTrigger, mocker: MockerFixture, mock_args: SimpleNamespace
 ) -> None:
     """A failing flavor must block approval even when another flavor passes."""
     mocker.patch("openqabot.config.settings.enable_detailed_comments", new=False)
@@ -727,7 +727,7 @@ def test_comment_on_pr_exception(trigger: GiteaTrigger) -> None:
 
 
 def test_trigger_init_maintenance(
-    mock_args: Namespace, mocker: MockerFixture, mock_trigger_config: TriggerConfig
+    mock_args: SimpleNamespace, mocker: MockerFixture, mock_trigger_config: TriggerConfig
 ) -> None:
     """Cover the maintenance initialization path."""
     mock_args.maintenance = True
@@ -746,7 +746,7 @@ def test_is_openqa_triggering_needed_with_results(trigger: GiteaTrigger, mock_tr
     assert trigger.is_openqa_triggering_needed(mock_iso, mock_trigger_config) is False
 
 
-def test_trigger_init_no_configs(mock_args: Namespace, mocker: MockerFixture) -> None:
+def test_trigger_init_no_configs(mock_args: SimpleNamespace, mocker: MockerFixture) -> None:
     """Verify that ValueError is raised if no configs are found."""
     mocker.patch("openqabot.giteatrigger.get_configs_from_path", return_value=[])
     mocker.patch("openqabot.loader.gitea.make_token_header")

--- a/tests/test_incrementapprover_obs.py
+++ b/tests/test_incrementapprover_obs.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from argparse import Namespace
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 from urllib.parse import urlparse
@@ -116,7 +116,7 @@ def testfind_request_on_obs_caching(mocker: MockerFixture, caplog: pytest.LogCap
 
 def testhandle_approval_dry(caplog: pytest.LogCaptureFixture, mocker: MockerFixture) -> None:
     caplog.set_level(logging.INFO)
-    args = Namespace(
+    args = SimpleNamespace(
         dry=True,
         token="token",
         gitea_token=None,

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import logging
 import re
-from argparse import Namespace
 from collections import defaultdict
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
@@ -337,7 +337,7 @@ def test_skipping_with_mismatching_package(mocker: MockerFixture, caplog: pytest
         mock_load.return_value = [BuildInfo("sle", "SLES", "16.0", "Online-Increments", "x86_64", "139.1")]
 
         approver = IncrementApprover(
-            Namespace(
+            SimpleNamespace(
                 dry=True,
                 token="token",
                 gitea_token=None,

--- a/tests/test_loader_incrementconfig.py
+++ b/tests/test_loader_incrementconfig.py
@@ -3,8 +3,8 @@
 """Test loader increment config."""
 
 import logging
-from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -52,7 +52,7 @@ def test_config_parsing(caplog: pytest.LogCaptureFixture) -> None:
 
 def test_config_parsing_from_args() -> None:
     config = IncrementConfig.from_args(
-        Namespace(increment_config=None, distri="sle", version="16.0", flavor="Online-Increments")
+        SimpleNamespace(increment_config=None, distri="sle", version="16.0", flavor="Online-Increments")
     )
     assert len(config) == 1
     assert config[0].distri == "sle"
@@ -67,7 +67,7 @@ def test_config_parsing_from_args() -> None:
 def test_config_parsing_from_args_with_path(config_index: int, expected_distri: str) -> None:
     path = Path("tests/fixtures/config-increment-approver")
     configs = IncrementConfig.from_args(
-        Namespace(increment_config=path, distri="sle", version="16.0", flavor="Online-Increments")
+        SimpleNamespace(increment_config=path, distri="sle", version="16.0", flavor="Online-Increments")
     )
     assert len(configs) == 2
     config = configs[config_index]
@@ -82,7 +82,7 @@ def test_config_parsing_from_args_with_path(config_index: int, expected_distri: 
 def test_config_parsing_from_args_with_auto_discovery() -> None:
     path = Path("tests/fixtures/config-increment-approver")
     configs = IncrementConfig.from_args(
-        Namespace(increment_config=None, configs=path, distri="sle", version="16.0", flavor="Online-Increments")
+        SimpleNamespace(increment_config=None, configs=path, distri="sle", version="16.0", flavor="Online-Increments")
     )
     assert len(configs) == 2
     assert configs[0].distri == "foo"
@@ -92,7 +92,7 @@ def test_config_parsing_from_args_with_auto_discovery() -> None:
 def test_config_parsing_from_args_fallback_to_cli() -> None:
     path = Path("tests/fixtures/config")
     configs = IncrementConfig.from_args(
-        Namespace(increment_config=None, configs=path, distri="sle", version="16.0", flavor="Online-Increments")
+        SimpleNamespace(increment_config=None, configs=path, distri="sle", version="16.0", flavor="Online-Increments")
     )
     assert len(configs) == 1
     assert configs[0].distri == "sle"

--- a/tests/test_openqabot.py
+++ b/tests/test_openqabot.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import logging
 import os
-from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, NoReturn
 from urllib.parse import ParseResult, urlparse
 
@@ -125,8 +125,8 @@ def test_main_missing_token_with_help_returns_early(mocker: MockerFixture) -> No
 
 
 @pytest.fixture
-def mocked_openqa_bot() -> Namespace:
-    return Namespace(
+def mocked_openqa_bot() -> SimpleNamespace:
+    return SimpleNamespace(
         dry=False,
         ignore_onetime=False,
         singlearch="single",
@@ -191,7 +191,7 @@ def mock_runtime(mocker: MockerFixture) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_passed(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_passed(mocked_openqa_bot: SimpleNamespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     bot = OpenQABot(mocked_openqa_bot)
     responses.add(responses.PUT, f"{settings.qem_dashboard_url}bar", json={"id": 234})
@@ -204,7 +204,7 @@ def test_passed(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) 
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_passed_non_osd(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_passed_non_osd(mocked_openqa_bot: SimpleNamespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     bot = OpenQABot(mocked_openqa_bot)
     responses.add(responses.PUT, f"{settings.qem_dashboard_url}bar")
@@ -218,7 +218,7 @@ def test_passed_non_osd(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureF
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_exception")
-def test_passed_post_osd_failed(mocked_openqa_bot: Namespace, caplog: pytest.LogCaptureFixture) -> None:
+def test_passed_post_osd_failed(mocked_openqa_bot: SimpleNamespace, caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.DEBUG)
     bot = OpenQABot(mocked_openqa_bot)
     responses.add(responses.PUT, f"{settings.qem_dashboard_url}bar")
@@ -232,7 +232,7 @@ def test_passed_post_osd_failed(mocked_openqa_bot: Namespace, caplog: pytest.Log
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_post_qem_success(mocked_openqa_bot: Namespace, mocker: MockerFixture) -> None:
+def test_post_qem_success(mocked_openqa_bot: SimpleNamespace, mocker: MockerFixture) -> None:
     bot = OpenQABot(mocked_openqa_bot)
     bot.openqa = mocker.Mock(spec=OpenQAInterface)
     test_api = "api/jobs/incident/1"
@@ -252,7 +252,7 @@ def test_post_qem_success(mocked_openqa_bot: Namespace, mocker: MockerFixture) -
 
 @responses.activate
 @pytest.mark.usefixtures("mock_runtime", "mock_openqa_passed")
-def test_post_qem_dry(mocked_openqa_bot: Namespace, mocker: MockerFixture) -> None:
+def test_post_qem_dry(mocked_openqa_bot: SimpleNamespace, mocker: MockerFixture) -> None:
     bot = OpenQABot(mocked_openqa_bot)
     bot.dry = True
     bot.openqa = mocker.Mock(spec=OpenQAInterface)

--- a/tests/test_repodiff.py
+++ b/tests/test_repodiff.py
@@ -4,8 +4,8 @@
 
 import json
 import logging
-from argparse import Namespace
 from collections import defaultdict
+from types import SimpleNamespace
 
 import pytest
 from lxml import etree  # ty: ignore[unresolved-import]
@@ -50,7 +50,7 @@ def test_repodiff_no_args(caplog: pytest.LogCaptureFixture) -> None:
 
 def test_repodiff(capsys: pytest.CaptureFixture[str]) -> None:
     RepoDiff(
-        Namespace(
+        SimpleNamespace(
             dry=True,
             fake_data=True,
             repo_a=f"{settings.obs_download_url}/OBS:/PROJECT:/PUBLISH_product",
@@ -63,7 +63,7 @@ def test_repodiff(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_repodiff_compression(capsys: pytest.CaptureFixture[str]) -> None:
     RepoDiff(
-        Namespace(
+        SimpleNamespace(
             dry=True,
             fake_data=True,
             repo_a=f"{settings.obs_download_url}/OBS:/PROJECT:/PUBLISH_product_zst",
@@ -152,7 +152,7 @@ def test_request_and_dump_no_dump(diff: RepoDiff, mocker: MockerFixture) -> None
 
 def test_repodiff_exit(mocker: MockerFixture) -> None:
     diff = RepoDiff(
-        Namespace(
+        SimpleNamespace(
             dry=True,
             fake_data=True,
             repo_a="NONEXISTENT",

--- a/tests/test_smeltsync.py
+++ b/tests/test_smeltsync.py
@@ -4,7 +4,7 @@
 
 import logging
 import re
-from argparse import Namespace
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -17,8 +17,8 @@ from openqabot.smeltsync import SMELTSync
 
 
 @pytest.fixture
-def args() -> Namespace:
-    return Namespace(dry=False, token="123", retry=False)
+def args() -> SimpleNamespace:
+    return SimpleNamespace(dry=False, token="123", retry=False)
 
 
 @pytest.fixture
@@ -92,7 +92,7 @@ def fake_dashboard_replyback() -> None:
     indirect=True,
 )
 @pytest.mark.usefixtures("fake_qem", "fake_smelt_api", "fake_dashboard_replyback")
-def test_sync_qam_inreview(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_sync_qam_inreview(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     caplog.set_level(logging.DEBUG)
     assert SMELTSync(args)() == 0
     assert "Fetching details for SMELT incident smelt:100" in caplog.messages
@@ -111,7 +111,7 @@ def test_sync_qam_inreview(caplog: pytest.LogCaptureFixture, args: Namespace) ->
 @responses.activate
 @pytest.mark.parametrize("fake_smelt_api", [["qam-openqa", "new", "review", None, None]], indirect=True)
 @pytest.mark.usefixtures("fake_qem", "fake_smelt_api", "fake_dashboard_replyback")
-def test_no_embargoed_and_priority_value(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_no_embargoed_and_priority_value(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     caplog.set_level(logging.DEBUG, logger="bot.syncres")
     assert SMELTSync(args)() == 0
     assert len(responses.calls) == 2
@@ -128,7 +128,7 @@ def test_no_embargoed_and_priority_value(caplog: pytest.LogCaptureFixture, args:
     indirect=True,
 )
 @pytest.mark.usefixtures("fake_qem", "fake_smelt_api", "fake_dashboard_replyback")
-def test_sync_approved(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_sync_approved(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     caplog.set_level(logging.DEBUG)
     assert SMELTSync(args)() == 0
     assert "Fetching details for SMELT incident smelt:100" in caplog.messages
@@ -150,7 +150,7 @@ def test_sync_approved(caplog: pytest.LogCaptureFixture, args: Namespace) -> Non
     indirect=True,
 )
 @pytest.mark.usefixtures("fake_qem", "fake_smelt_api")
-def test_sync_dry_run(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_sync_dry_run(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     caplog.set_level(logging.INFO, logger="bot.smeltsync")
     args.dry = True
     assert SMELTSync(args)() == 0

--- a/tests/test_subsyncres.py
+++ b/tests/test_subsyncres.py
@@ -3,8 +3,8 @@
 """Test SubResultsSync."""
 
 import logging
-from argparse import Namespace
 from collections.abc import Generator
+from types import SimpleNamespace
 
 import pytest
 import responses
@@ -39,18 +39,18 @@ def mock_dashboard_settings() -> None:
 
 
 @pytest.fixture
-def args() -> Namespace:
-    return Namespace(dry=False, token="ToKeN")
+def args() -> SimpleNamespace:
+    return SimpleNamespace(dry=False, token="ToKeN")
 
 
-def prepare_syncer(caplog: pytest.LogCaptureFixture, args: Namespace) -> SubResultsSync:
+def prepare_syncer(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> SubResultsSync:
     caplog.set_level(logging.INFO)
     return SubResultsSync(args)
 
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_s", "mock_dashboard_settings")
-def test_clone_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_clone_dry(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     data = {
         "jobs": [
             {
@@ -79,7 +79,7 @@ def test_clone_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_s", "mock_dashboard_settings")
-def test_nogroup_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_nogroup_dry(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     data = {
         "jobs": [
             {
@@ -107,7 +107,7 @@ def test_nogroup_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_s", "mock_dashboard_settings")
-def test_devel_fast_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_devel_fast_dry(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     data = {
         "jobs": [
             {
@@ -140,7 +140,7 @@ def test_devel_fast_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> No
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_s", "mock_dashboard_settings")
-def test_devel_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_devel_dry(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     data = {
         "jobs": [
             {
@@ -171,7 +171,7 @@ def test_devel_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
 
 @responses.activate
 @pytest.mark.usefixtures("get_a_s", "mock_dashboard_settings")
-def test_passed_dry(caplog: pytest.LogCaptureFixture, args: Namespace) -> None:
+def test_passed_dry(caplog: pytest.LogCaptureFixture, args: SimpleNamespace) -> None:
     data = {
         "jobs": [
             {

--- a/tests/test_syncres.py
+++ b/tests/test_syncres.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Test SyncRes."""
 
-from argparse import Namespace
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
@@ -18,12 +18,12 @@ def test_clone_dry() -> None:
         patch("openqabot.openqa.OpenQAInterface.__bool__", return_value=True),
         patch("openqabot.syncres.post_job") as post_job_mock,
     ):
-        SyncRes(Namespace(dry=False)).post_result(result)
+        SyncRes(SimpleNamespace(dry=False)).post_result(result)
         post_job_mock.assert_called()
 
 
 def testnormalize_data_safe_handles_error_gracefully() -> None:
-    syncres = SyncRes(Namespace(dry=False))
+    syncres = SyncRes(SimpleNamespace(dry=False))
     with patch("openqabot.syncres.SyncRes.normalize_data", side_effect=KeyError):
         assert syncres.normalize_data_safe(cast("Data", None), cast("dict", None)) is None
 
@@ -31,7 +31,7 @@ def testnormalize_data_safe_handles_error_gracefully() -> None:
 def test_post_result_aggregate() -> None:
     result = {"job_id": 1, "status": "passed", "update_settings": 123}
     with patch("openqabot.openqa.OpenQAInterface.__bool__", return_value=True):
-        syncres = SyncRes(Namespace(dry=False))
+        syncres = SyncRes(SimpleNamespace(dry=False))
         with patch("openqabot.syncres.post_job") as mock_post:
             syncres.post_result(result)
             mock_post.assert_called()


### PR DESCRIPTION
Motivation:
The lifecycle of a maintenance submission involves scheduling tests, syncing
results, and approving the submission in OBS. These steps represent a single
logical workflow but were previously split across three separate CLI commands,
which led to fragmented cron job definitions and redundant container startup
overhead in production.

Design Choices:
- Added a new `handle-submissions` top-level command.
- Sequentially executes `OpenQABot`, `SubResultsSync`, and `Approver`.
- Consolidated the CLI arguments needed for all three operations.
- Deduplicated the underlying initialization logic into helper functions
  to share implementation with the atomic commands.
- Transitioned internal typing from `argparse.Namespace` to
  `types.SimpleNamespace` to match Typer's context object.

Benefits:
Provides a unified pipeline that accurately models the submission workflow,
simplifying CI configuration while significantly reducing production execution
time by avoiding multiple container startups.

After:
* #500