### PR TITLE
fix: escape ampersands in OBS comment URLs

### DIFF
--- a/openqabot/types/pullrequest.py
+++ b/openqabot/types/pullrequest.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Gitea Pullrequest type definition."""
 
+import html
 from dataclasses import dataclass, field
 from logging import getLogger
 from typing import Any, Protocol, Self
@@ -52,7 +53,7 @@ class OBSCommentable:
         image_url: str | None = None,  # ruff: ignore[unused-method-argument]  - Interface compatibility
     ) -> str:
         """Format a link with an optional image badge."""
-        return f"[{label}]({url})"
+        return f"[{label}]({html.escape(url)})"
 
 
 @dataclass

--- a/openqabot/types/submission.py
+++ b/openqabot/types/submission.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import html
 import re
 from collections import defaultdict
 from logging import getLogger
@@ -105,9 +106,11 @@ class Submission:
 
     def format_link(self, label: str, url: str, image_url: str | None = None) -> str:
         """Format a link with an optional image badge."""
-        if self.is_gitea and image_url:
-            return f"[![{label}]({image_url})]({url})"
-        return f"[{label}]({url})"
+        if self.is_gitea:
+            if image_url:
+                return f"[![{label}]({image_url})]({url})"
+            return f"[{label}]({url})"
+        return f"[{label}]({html.escape(url)})"
 
     def _initialize_channels(self, raw_channels: list[str]) -> None:
         """Initialize channels and skipped products from raw channel data."""

--- a/tests/test_commenter.py
+++ b/tests/test_commenter.py
@@ -373,17 +373,17 @@ def test_summarize_message(
 
     result_obs = c.summarize_message(OBSCommentable(124), set(builds), [])
     assert (
-        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*&label=Build+1.1)"
+        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&amp;distri=sle&amp;version=15&amp;not_group_glob=*Devel*%2C*Test*&amp;label=Build+1.1)"
         in result_obs
     )
     assert (
-        "[Build 1.2 Results](https://openqa.opensuse.org/tests/overview?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2)"
+        "[Build 1.2 Results](https://openqa.opensuse.org/tests/overview?build=1.2&amp;not_group_glob=*Devel*%2C*Test*&amp;label=Build+1.2)"
         in result_obs
     )
     # OBS links are separated by double newlines for line breaks
     assert (
-        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&distri=sle&version=15&not_group_glob=*Devel*%2C*Test*&label=Build+1.1)\n\n"
-        "[Build 1.2 Results](https://openqa.opensuse.org/tests/overview?build=1.2&not_group_glob=*Devel*%2C*Test*&label=Build+1.2)"
+        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&amp;distri=sle&amp;version=15&amp;not_group_glob=*Devel*%2C*Test*&amp;label=Build+1.1)\n\n"
+        "[Build 1.2 Results](https://openqa.opensuse.org/tests/overview?build=1.2&amp;not_group_glob=*Devel*%2C*Test*&amp;label=Build+1.2)"
         in result_obs
     )
 
@@ -412,7 +412,7 @@ def test_summarize_message_allow_devel(
     result_obs = c.summarize_message(OBSCommentable(124), {builds[0]}, [])
     assert "not_group_glob" not in result_obs
     assert (
-        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&distri=opensuse&version=Tumbleweed&label=Build+1.1)"
+        "[Build 1.1 Results](https://openqa.opensuse.org/tests/overview?build=1.1&amp;distri=opensuse&amp;version=Tumbleweed&amp;label=Build+1.1)"
         in result_obs
     )
 

--- a/tests/test_pullrequest.py
+++ b/tests/test_pullrequest.py
@@ -77,6 +77,7 @@ def test_obs_commentable() -> None:
     assert obs.is_gitea is False
     assert obs.format_link("Label", "http://url", "http://img") == "[Label](http://url)"
     assert obs.format_link("Label", "http://url") == "[Label](http://url)"
+    assert obs.format_link("Label", "http://url?a=1&b=2") == "[Label](http://url?a=1&amp;b=2)"
 
 
 def test_create_from_json_invalid_data(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -110,10 +110,12 @@ def test_sub_normal() -> None:
     assert sub.is_gitea is False
     assert sub.format_link("Label", "http://url", "http://img") == "[Label](http://url)"
     assert sub.format_link("Label", "http://url") == "[Label](http://url)"
+    assert sub.format_link("Label", "http://url?a=1&b=2") == "[Label](http://url?a=1&amp;b=2)"
     sub_git = Submission({**test_data, "type": "git"})
     assert sub_git.is_gitea is True
     assert sub_git.format_link("Label", "http://url", "http://img") == "[![Label](http://img)](http://url)"
     assert sub_git.format_link("Label", "http://url") == "[Label](http://url)"
+    assert sub_git.format_link("Label", "http://url?a=1&b=2") == "[Label](http://url?a=1&b=2)"
     assert sub.channels == [
         Repos(product="SLE-Module-Public-Cloud", version="15-SP4", arch="x86_64"),
         Repos(product="SLE-Module-Public-Cloud", version="15-SP4", arch="aarch64"),


### PR DESCRIPTION
Motivation:
OBS parses Markdown comments as HTML. In URLs, query parameters like
'&not_group_glob' are incorrectly decoded as HTML entities ('&not' to '¬'),
resulting in broken openQA links.

Design Choices:
Use standard library 'html.escape' inside format_link for OBSCommentable and
Submission (when not is_gitea) to correctly encode ampersands into '&amp;'.

Manual verification:

```
osc comment create project home:okurz:test_comments -c "This is the broken version: [Build Results (broken)](https://openqa.opensuse.org/tes  ts/overview?build=PI-119.24&distri=sle-micro&version=6.0&not_group_glob=*Devel*%2C*Test*&label=Build+PI-119.24)" # E: Line exceeds max leng…
osc comment create project home:okurz:test_comments -c "This is the fixed version: [Build Results (fixed)](https://openqa.opensuse.org/tests  /overview?build=PI-119.24&distri=sle-micro&version=6.0&amp;not_group_glob=*Devel*%2C*Test*&amp;label=Build+PI-119.24)" # E: Line exceeds ma…
```

visible on https://build.opensuse.org/project/show/home:okurz:test_comments

Benefits:
This prevents the Markdown engine of OBS from incorrectly decoding raw
ampersands as named HTML entities, ensuring that openQA links remain correct
and fully functional.

Related issue: https://progress.opensuse.org/issues/205905