### PR TITLE
feat(increment-approve): support cloned jobs

### DIFF
--- a/openqabot/incrementapprover.py
+++ b/openqabot/incrementapprover.py
@@ -21,7 +21,7 @@ import osc.core
 
 from openqabot import config
 from openqabot.config import OBSOLETE_PARAMS
-from openqabot.openqa import ENRICH_KEYS, OpenQAInterface
+from openqabot.openqa import CLONE_AWARE_STATS_PARAMS, ENRICH_KEYS, OpenQAInterface
 from openqabot.pc_helper import apply_public_cloud_settings
 
 from .commenter import Commenter
@@ -134,6 +134,7 @@ class IncrementApprover:
                 "arch": p["ARCH"],
                 "build": p["BUILD"],
                 "product": p.get("PRODUCT"),
+                **CLONE_AWARE_STATS_PARAMS,
             })
 
         with ThreadPoolExecutor(max_workers=config.settings.max_workers) as executor:

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -33,6 +33,9 @@ log = logging.getLogger("bot.openqa")
 
 MAX_JOBS_PER_API_REQUEST = 200
 ENRICH_KEYS = ("group_id", "group", "build", "distri", "version", "flavor", "arch", "name")
+# Opt-in per call site: openQA attributes jobs cloned via openqa-clone-job to the groups of the
+# scheduled product, so clones are reported instead of the originals they superseded.
+CLONE_AWARE_STATS_PARAMS = {"infer_groups_from_scheduled_product": "1"}
 
 
 class OpenQAInterface:

--- a/openqabot/openqa.py
+++ b/openqabot/openqa.py
@@ -151,7 +151,9 @@ class OpenQAInterface:
         if config.settings.allow_development_groups:
             return False
 
-        group_name = job.get("group", "")
+        # enrich_job_info fills ENRICH_KEYS with None for jobs outside any job group, so an
+        # explicit None must read as "no group" rather than blow up the membership test
+        group_name = job.get("group") or ""
         group_id = job.get("group_id")
 
         if "Devel" in group_name or "Test" in group_name:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,6 +21,7 @@ from openqabot.config import BUILD_REGEX, settings
 from openqabot.incrementapprover import IncrementApprover
 from openqabot.loader.incrementconfig import IncrementConfig
 from openqabot.loader.qem import SubReq
+from openqabot.openqa import CLONE_AWARE_STATS_PARAMS
 from openqabot.types.submission import Submission
 from openqabot.utils import get_obs_filter_params, merge_dicts
 
@@ -336,7 +337,13 @@ def fake_openqa_responses_with_param_matching(
     additional_builds_json: dict, fake_openqa_url_job_stat: str
 ) -> list[responses.BaseResponse]:
     list_of_params = []
-    base_params = {"distri": "sle", "version": "16.0", "build": "PI-139.1", "product": "SLES"}
+    base_params = {
+        "distri": "sle",
+        "version": "16.0",
+        "build": "PI-139.1",
+        "product": "SLES",
+        **CLONE_AWARE_STATS_PARAMS,
+    }
     json_by_arch = {"aarch64": {}, "x86_64": {}, "s390x": {}, "ppc64le": {}}
     for flavor in ("Online-Increments", "Foo-Increments"):
         for arch, json in json_by_arch.items():

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -546,6 +546,36 @@ def test_approval_if_failing_jobs_are_in_development_group(
 
 @responses.activate
 @pytest.mark.usefixtures("fake_product_repo", "mock_osc")
+@pytest.mark.parametrize(
+    ("job", "expected_evaluated_jobs"),
+    [
+        pytest.param({"id": 456, "result": "passed"}, 1, id="job_without_group_metadata_is_evaluated"),
+        pytest.param(_devel_job(456, result="passed"), 0, id="job_in_development_group_stays_filtered"),
+    ],
+)
+def test_group_filtering_of_jobs_without_group_metadata(
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+    fake_openqa_url_job_stat: str,
+    job: dict[str, Any],
+    expected_evaluated_jobs: int,
+) -> None:
+    # enrich_job_info fills ENRICH_KEYS with None for jobs outside any job group, as
+    # produced by openqa-clone-job, so the devel filter must not choke on a null group
+    responses.add(responses.GET, fake_openqa_url_job_stat, json={"done": {"passed": {"job_ids": [456]}}})
+    mock_osc_approve = mocker.patch("osc.core.change_review_state")
+    increment_approver = prepare_approver(caplog)
+    increment_approver.client.get_jobs_by_ids = mocker.Mock(return_value=[job])
+    increment_approver()
+
+    mock_osc_approve.assert_called()
+    assert (
+        f"All {expected_evaluated_jobs} openQA jobs have passed/softfailed" in mock_osc_approve.call_args[1]["message"]
+    )
+
+
+@responses.activate
+@pytest.mark.usefixtures("fake_product_repo", "mock_osc")
 def test_approval_with_mixed_jobs_development_ignored(
     mocker: MockerFixture, caplog: pytest.LogCaptureFixture, fake_openqa_url_job_stat: str
 ) -> None:

--- a/tests/test_incrementapprover_scenarios.py
+++ b/tests/test_incrementapprover_scenarios.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import osc.core
 import pytest
@@ -542,6 +543,21 @@ def test_approval_if_failing_jobs_are_in_development_group(
     assert "development groups ignored" in caplog.text
     assert "No jobs left for evaluation (all were filtered)" not in caplog.text
     assert "Scheduling jobs for" not in caplog.text
+
+
+@responses.activate
+@pytest.mark.usefixtures("fake_ok_jobs", "fake_product_repo", "mock_osc")
+def test_job_stats_queries_request_server_side_clone_resolution(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    run_approver(mocker, caplog)
+    queries = [
+        parse_qs(urlparse(url).query)
+        for url in (call.request.url or "" for call in responses.calls)
+        if "isos/job_stats" in url
+    ]
+    assert queries, "approver issued no isos/job_stats request"
+    assert all(q.get("infer_groups_from_scheduled_product") == ["1"] for q in queries)
 
 
 @responses.activate


### PR DESCRIPTION
Motivation:
Allow the product increment approver of qem-bot to consider additional jobs
cloned via openqa-clone-job (e.g. to handle failures).

Design Choices:
Pass "infer_groups_from_scheduled_product" to the openQA "isos/job_stats"
endpoint so the server resolves cloned jobs into the statistics. Keep it in the
shared constant CLONE_AWARE_STATS_PARAMS, opted into per call site, so the
giteatrigger presence check stays unaffected and tests assert the same value
the bot sends. This widens approval input beyond the originally scheduled job
IDs; clone provenance is still bounded by check_unique_jobid_request_pair and
by development-group filtering on each job's own group.

Benefits:
Cloned and rescheduled product increment tests are automatically considered for
approval without requiring manual intervention.

Related issue: https://progress.opensuse.org/issues/192442