### PR TITLE
test: show image selection is arbitrary when regex  matches multiple images

### DIFF
--- a/tests/test_pc_helper.py
+++ b/tests/test_pc_helper.py
@@ -188,6 +188,30 @@ def test_get_recent_pint_image() -> None:
     assert ret == img3
 
 
+def test_get_recent_pint_image_broad_regex_order_dependent() -> None:
+    """Broad regex matching multiple architectures is order-dependent.
+
+    When publishedon is equal, max() keeps the first element among ties,
+    so the result depends entirely on the PINT API response order.
+    """
+    img_x86 = {
+        "name": "sle-micro-6-1-byos-v20260618-x86-64",
+        "state": "active",
+        "publishedon": "20260618",
+    }
+    img_arm = {
+        "name": "sle-micro-6-1-byos-v20260618-arm64",
+        "state": "active",
+        "publishedon": "20260618",
+    }
+    regex = r"sle-micro-6-1-byos-v[0-9]{8}-"
+
+    # x86-64 first in response -> x86-64 selected
+    assert get_recent_pint_image([img_x86, img_arm], regex) == img_x86
+    # arm64 first in response -> arm64 selected
+    assert get_recent_pint_image([img_arm, img_x86], regex) == img_arm
+
+
 @responses.activate
 def test_get_latest_tools_image() -> None:
     responses.add(


### PR DESCRIPTION
[[ NOT TO BE MERGED ]]

qem-bot receives PINT metadata and query parameters as input. It does not control what the user writes in the metadata configuration. It does not control the content or ordering of the PINT server JSON response either.

qem-bot runs a PINT query built from the metadata, filters the response by name regex, region, and state, then selects the most recently published image. When multiple images share the same publish date, only one can be returned.

The current code uses max() over the filtered results. When publish dates are equal, max() retains whichever element it encounters first. The element it encounters first is whichever the PINT server happened to serialize first in its JSON array.

This test demonstrates that swapping the order of two images in the input list changes which image is returned. The selected image is not the best or the expected  match, it is simply the first match.